### PR TITLE
fix: correction in the city field

### DIFF
--- a/app/controllers/InstructorController.php
+++ b/app/controllers/InstructorController.php
@@ -402,10 +402,12 @@ preenchidos";
         $data = EdcensoCity::model()->findAll('edcenso_uf_fk=:uf_id', [':uf_id' => (int)$edcenso_uf_fk]);
         $data = CHtml::listData($data, 'id', 'name');
 
-        echo CHtml::tag('option', ['value' => ""], 'Selecione uma Cidade', TRUE);
+        $options = array();
         foreach ($data as $value => $name) {
-            echo CHtml::tag('option', ['value' => $value], CHtml::encode($name), TRUE);
+            array_push($options, CHtml::tag('option', ['value' => $value], CHtml::encode($name), TRUE));
         }
+
+        echo json_encode($options);
     }
 
     public function actionGetCityByCep()

--- a/js/instructor/form/functions.js
+++ b/js/instructor/form/functions.js
@@ -31,9 +31,8 @@ $("#InstructorIdentification_edcenso_uf_fk").on("change", function () {
             edcenso_uf_fk: $(this).val(),
         },
         success: function (response) {
-            console.log(JSON.parse(response));  
-            $.each(JSON.parse(response), function (id, name) {
-                $("#InstructorIdentification_edcenso_city_fk").append(name);
+            $.each(JSON.parse(response), function (id, option) {
+                $("#InstructorIdentification_edcenso_city_fk").append(option);
             })
         }
     });

--- a/js/instructor/form/functions.js
+++ b/js/instructor/form/functions.js
@@ -21,3 +21,20 @@ function updateCep(data) {
     }, 500);
 
 }
+
+$("#InstructorIdentification_edcenso_uf_fk").on("change", function () {
+    $("#InstructorIdentification_edcenso_city_fk").empty();
+    $.ajax({
+        type: "POST",
+        url: "?r=instructor/getCity",
+        data: {
+            edcenso_uf_fk: $(this).val(),
+        },
+        success: function (response) {
+            console.log(JSON.parse(response));  
+            $.each(JSON.parse(response), function (id, name) {
+                $("#InstructorIdentification_edcenso_city_fk").append(name);
+            })
+        }
+    });
+});

--- a/js/instructor/form/functions.js
+++ b/js/instructor/form/functions.js
@@ -23,7 +23,7 @@ function updateCep(data) {
 }
 
 $("#InstructorIdentification_edcenso_uf_fk").on("change", function () {
-    $("#InstructorIdentification_edcenso_city_fk").empty();
+    $('#InstructorIdentification_edcenso_city_fk option:not(:contains("Selecione uma cidade"))').remove();
     $.ajax({
         type: "POST",
         url: "?r=instructor/getCity",

--- a/themes/default/views/instructor/_form.php
+++ b/themes/default/views/instructor/_form.php
@@ -235,14 +235,7 @@ $isModel = isset($modelInstructorIdentification->id); // Corrigir se precisar ac
                                 <div class="controls">
                                     <?php echo $form->DropDownList($modelInstructorIdentification, 'edcenso_uf_fk', CHtml::listData(EdcensoUf::model()->findAll(array("order" => "name")), 'id', 'name'), array(
                                         'prompt' => 'Selecione um estado',
-                                        'class' => 'select-search-on control-input',
-                                        // olhar aqui
-                                        'ajax' => array(
-                                            'type' => 'POST',
-                                            'url' => CController::createUrl('Instructor/getcity'),
-                                            'update' => '#InstructorIdentification_edcenso_city_fk',
-                                            'data' => array('edcenso_uf_fk' => 'js:this.value'),
-                                        ),
+                                        'class' => 'select-search-on control-input'
                                     )); ?>
                                     <?php echo $form->error($modelInstructorIdentification, 'edcenso_uf_fk'); ?>
                                 </div>


### PR DESCRIPTION
### Changes made

There was an issue related to the display of cities on the teacher form. Cities are currently not displaying correctly, which can cause confusion and make the teacher registration process difficult.

After reviewing the code, I identified the issue and made the necessary changes so that the cities displayed correctly on the form. Now, when a teacher fills out the form, they will be able to choose their city correctly and complete the registration process without any problems.

> I believe this fix is ​​crucial to improve the usability of the system and ensure that users can use the teacher form without any problems. Please review my pull request and let me know if there are any additional changes I can make.