### PR TITLE
fix: correction in the transfer form

### DIFF
--- a/themes/default/css/template.css
+++ b/themes/default/css/template.css
@@ -8997,7 +8997,7 @@ tbody .details-control:hover {
 
 .pageA4H {
     width: 1122px;
-    height: 810px;
+    height: 1122px;
     margin: 0 auto;
 }
 


### PR DESCRIPTION
### Description
Before the footer was on top of the document because the page has a fixed height, changing the height of the document now the footer is being rendered correctly