### PR TITLE
fix: default values in classroom and school sedsp

### DIFF
--- a/app/migrations/3.12.28_bug_fix_from_sedsp/Script.sql
+++ b/app/migrations/3.12.28_bug_fix_from_sedsp/Script.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `demo.tag.ong.br`.school_identification MODIFY COLUMN number_ato varchar(30) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL;

--- a/app/modules/sedsp/mappers/ClassroomMapper.php
+++ b/app/modules/sedsp/mappers/ClassroomMapper.php
@@ -20,6 +20,7 @@ class ClassroomMapper
         $classroom_tag->inep_id = $outClasse->outNumClasse;
         $classroom_tag->name = $outClasse->outCodSerieAno."º ANO ".$outClasse->outTurma;
         $classroom_tag->edcenso_stage_vs_modality_fk = 1;
+        $classroom_tag->assistance_type = 0;
         $classroom_tag->modality = 1;
         $classroom_tag->school_inep_fk = Yii::app()->user->school;
         $classroom_tag->initial_hour = $tempo_inicio[0];


### PR DESCRIPTION
### Changes in SEDSP

#### Description of changes:
- Added a script to change the default value of column `number_ato` from `school_identification` to `NULL`.
- Added a default value for `assistance_type` of `classroom`.

#### Details:
- A new SQL script has been added in `\app\migrations\3.12.28_bug_fix_from_sedsp\Script.sql` to change the default value of column `number_ato` from `school_identification` to `NULL`.
- Also, a default value has been added for `assistance_type` of `classroom`.
> To ensure that the changes are applied correctly, run the SQL script located in the above mentioned path after updating the SEDSP.