### PR TITLE
fix: corrections to class council minutes and enrollment report reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Atualizações
 
+## [Vesão 3.18.41]
+- Ajuste na largura para impressão do relatório de matrícula
+- Adição de legendas para o relatório de matrícula
+- Modificação do formulário de gerar ata de conselho de classe
+
 ## [Versão 3.18.38]
 - Modelo de ata de conselho de classe de 6º ao 9º ano adicionado
 - Modelo de ata de conselho de classe de ensino médio adicionado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Ajuste na largura para impressão do relatório de matrícula
 - Adição de legendas para o relatório de matrícula
 - Modificação do formulário de gerar ata de conselho de classe
+- O bug de repetição dos professores no ata de conselho de classe foi corrigido
 
 ## [Versão 3.18.38]
 - Modelo de ata de conselho de classe de 6º ao 9º ano adicionado

--- a/app/controllers/ReportsController.php
+++ b/app/controllers/ReportsController.php
@@ -206,34 +206,39 @@ class ReportsController extends Controller
                 $title = "EDUCAÇÃO INFANTIL";
             }
 
-            if ($current_report == 1) {
-                $this->render('buzios/quarterly/QuarterlyClassCouncil', array(
-                    "classroom" => $classrooms,
-                    "count_days" => $count_days,
-                    "mounth" => $mounth,
-                    "hour" => $hour,
-                    "quarterly" => $quarterly,
-                    "year" => $year,
-                    "title" => $title
-                ));
-            }else if ($current_report == 2) {
-                $this->render('buzios/quarterly/QuarterlyClassCouncilSixNineYear', array(
-                    "classroom" => $classrooms,
-                    "count_days" => $count_days,
-                    "mounth" => $mounth,
-                    "hour" => $hour,
-                    "quarterly" => $quarterly,
-                    "year" => $year
-                ));
-            }else if ($current_report == 3) {
-                $this->render('buzios/quarterly/QuarterlyClassCouncilHighSchool', array(
-                    "classroom" => $classrooms,
-                    "count_days" => $count_days,
-                    "mounth" => $mounth,
-                    "hour" => $hour,
-                    "quarterly" => $quarterly,
-                    "year" => $year
-                ));
+            if($classrooms[0] != null) {
+                if ($current_report == 1) {
+                    $this->render('buzios/quarterly/QuarterlyClassCouncil', array(
+                        "classroom" => $classrooms,
+                        "count_days" => $count_days,
+                        "mounth" => $mounth,
+                        "hour" => $hour,
+                        "quarterly" => $quarterly,
+                        "year" => $year,
+                        "title" => $title
+                    ));
+                }else if ($current_report == 2) {
+                    $this->render('buzios/quarterly/QuarterlyClassCouncilSixNineYear', array(
+                        "classroom" => $classrooms,
+                        "count_days" => $count_days,
+                        "mounth" => $mounth,
+                        "hour" => $hour,
+                        "quarterly" => $quarterly,
+                        "year" => $year
+                    ));
+                }else if ($current_report == 3) {
+                    $this->render('buzios/quarterly/QuarterlyClassCouncilHighSchool', array(
+                        "classroom" => $classrooms,
+                        "count_days" => $count_days,
+                        "mounth" => $mounth,
+                        "hour" => $hour,
+                        "quarterly" => $quarterly,
+                        "year" => $year
+                    ));
+                }
+            }else {
+                Yii::app()->user->setFlash('error', Yii::t('default', 'Certifique-se de que a turma selecionada tem professores e alunos cadastrados'));
+                return $this->redirect(array('index'));
             }
         }
     }

--- a/app/controllers/ReportsController.php
+++ b/app/controllers/ReportsController.php
@@ -191,16 +191,22 @@ class ReportsController extends Controller
 
             $classrooms = Yii::app()->db->createCommand($sql)->bindParam(":year", $year)->bindParam(":school_inep_id", $school_inep_id)->queryAll();
 
-            if ($model == 1) {
+            $title = '';
+            if($model == 1) {
+                $title = "EDUCAÇÃO INFANTIL";
+            }
+
+            if ($model == 1 || $model == 2) {
                 $this->render('buzios/quarterly/QuarterlyClassCouncil', array(
                     "classroom" => $classrooms,
                     "count_days" => $count_days,
                     "mounth" => $mounth,
                     "hour" => $hour,
                     "quarterly" => $quarterly,
-                    "year" => $year
+                    "year" => $year,
+                    "title" => $title
                 ));
-            }else if ($model == 2) {
+            }else if ($model == 3) {
                 $this->render('buzios/quarterly/QuarterlyClassCouncilSixNineYear', array(
                     "classroom" => $classrooms,
                     "count_days" => $count_days,
@@ -209,7 +215,7 @@ class ReportsController extends Controller
                     "quarterly" => $quarterly,
                     "year" => $year
                 ));
-            }else if ($model == 3) {
+            }else if ($model == 4) {
                 $this->render('buzios/quarterly/QuarterlyClassCouncilHighSchool', array(
                     "classroom" => $classrooms,
                     "count_days" => $count_days,

--- a/app/controllers/ReportsController.php
+++ b/app/controllers/ReportsController.php
@@ -163,7 +163,7 @@ class ReportsController extends Controller
         $hour = $_POST['hour'];
         $quarterly = $_POST['quarterly'];
         $school_inep_id = Yii::app()->user->school;
-        $model = $_POST['quarterly-model'];
+        $infantil = $_POST['infantil-model'];
         $year = $_POST['year'];
         $condition = '';
         if (isset($_POST['classroom2']) && $_POST['classroom2'] != '') {
@@ -171,7 +171,7 @@ class ReportsController extends Controller
             $sql = "SELECT 
                     e.name as school_name, c.name as classroom_name, c.id as classroom_id,
                     s.*, se.status, se.create_date, ii.name as prof_name, ed.name as discipline,
-                    c.turn as turno, esvm.name as class_stage, se.date_cancellation_enrollment as date_cancellation
+                    c.turn as turno, esvm.stage as stage_id ,esvm.name as class_stage, se.date_cancellation_enrollment as date_cancellation
                 FROM
                     student_enrollment as se
                     INNER JOIN classroom as c on se.classroom_fk=c.id
@@ -191,12 +191,22 @@ class ReportsController extends Controller
 
             $classrooms = Yii::app()->db->createCommand($sql)->bindParam(":year", $year)->bindParam(":school_inep_id", $school_inep_id)->queryAll();
 
+            $stage_id = $classrooms[0]['stage_id'];
+            $current_report = 0;
+            if ($stage_id == 1 || $stage_id == 2) {
+                $current_report = 1;
+            }else if ($stage_id == 3) {
+                $current_report = 2;
+            }else if ($stage_id == 4) {
+                $current_report = 3;
+            }
+
             $title = '';
-            if($model == 1) {
+            if($infantil) {
                 $title = "EDUCAÇÃO INFANTIL";
             }
 
-            if ($model == 1 || $model == 2) {
+            if ($current_report == 1) {
                 $this->render('buzios/quarterly/QuarterlyClassCouncil', array(
                     "classroom" => $classrooms,
                     "count_days" => $count_days,
@@ -206,7 +216,7 @@ class ReportsController extends Controller
                     "year" => $year,
                     "title" => $title
                 ));
-            }else if ($model == 3) {
+            }else if ($current_report == 2) {
                 $this->render('buzios/quarterly/QuarterlyClassCouncilSixNineYear', array(
                     "classroom" => $classrooms,
                     "count_days" => $count_days,
@@ -215,7 +225,7 @@ class ReportsController extends Controller
                     "quarterly" => $quarterly,
                     "year" => $year
                 ));
-            }else if ($model == 4) {
+            }else if ($current_report == 3) {
                 $this->render('buzios/quarterly/QuarterlyClassCouncilHighSchool', array(
                     "classroom" => $classrooms,
                     "count_days" => $count_days,

--- a/config.php
+++ b/config.php
@@ -2,7 +2,7 @@
 defined('YII_DEBUG') or define('YII_DEBUG', true);
 // defined('YII_DEBUG') or define('YII_DEBUG', false);
 
-define("TAG_VERSION", '3.18.38');
+define("TAG_VERSION", '3.18.41');
 
 
 define("YII_VERSION", Yii::getVersion());

--- a/themes/default/views/reports/EnrollmentPerClassroomReport.php
+++ b/themes/default/views/reports/EnrollmentPerClassroomReport.php
@@ -6,7 +6,19 @@ Yii::app()->clientScript->registerCoreScript('jquery');
 
 $this->setPageTitle('TAG - ' . Yii::t('default', 'Reports'));
 $stage = EdcensoStageVsModality::model()->findByPk($classroom->edcenso_stage_vs_modality_fk)->name;
-$school = SchoolIdentification::model()->findByPk($classroom->school_inep_fk)
+$school = SchoolIdentification::model()->findByPk($classroom->school_inep_fk);
+
+$subtitle = "
+<div class='subtitle-enrollments'>
+<span>MI - Matrícula Inicial</span>
+<span>MC - Rematrícula</span>
+<span>MR - Matrícula Recorrente</span>
+<span>MT - Matrícula por Transferência</span>
+<span>N - Não informado</span>
+<span>P - Promovido</span>
+<span>R - Transferido</span>
+</div>
+";
 
 ?>
 <br>
@@ -277,6 +289,7 @@ $school = SchoolIdentification::model()->findByPk($classroom->school_inep_fk)
         </tr>
         <?php echo $r20;?>
     </table>
+    <?php echo $subtitle?>
     <br>
     <br>
     <?php if(isset($r40)){ ?>
@@ -306,6 +319,7 @@ $school = SchoolIdentification::model()->findByPk($classroom->school_inep_fk)
             </tr>
             <?php echo $r40;?>
         </table>
+        <?php echo $subtitle?>
     <?php } ?>
 
 <br>
@@ -370,6 +384,7 @@ $school = SchoolIdentification::model()->findByPk($classroom->school_inep_fk)
     table { page-break-after:auto; }
     thead { display:table-header-group }
     tfoot { display:table-footer-group }
+    .subtitle-enrollments span {margin-right: 10px;}
 </style>
 
 

--- a/themes/default/views/reports/EnrollmentPerClassroomReport.php
+++ b/themes/default/views/reports/EnrollmentPerClassroomReport.php
@@ -11,7 +11,7 @@ $school = SchoolIdentification::model()->findByPk($classroom->school_inep_fk)
 ?>
 <br>
 <br>
-<div class="pageA4H">
+<div class="pageA4H" style="width: 1075px;">
     <?php $this->renderPartial('head'); ?>
     <h3>RELATÓRIO DE MATRÍCULA / <?= $classroom->school_year?></h3>
     

--- a/themes/default/views/reports/buzios/quarterly/QuarterlyClassCouncil.php
+++ b/themes/default/views/reports/buzios/quarterly/QuarterlyClassCouncil.php
@@ -223,22 +223,25 @@ if ($turno == 'M') {
                 </tr>
             </thead>
             <tbody>
-                <?php
-                $prof_name = '';
-                $discipline = '';
+            <?php
+                $validate_array = array();
                 foreach ($classroom as $c) {
-                    if($prof_name != $c['prof_name'] || $discipline != $c['discipline'] ) {
-                ?>
-                    <tr>
-                        <td><?= $c['discipline'] ?></td>
-                        <td><?= $c['prof_name'] ?></td>
-                        <td></td>
-                    </tr>
-                <?php
+                    $json = json_encode(array(
+                        "prof_name" => $c['prof_name'],
+                        "discipline" => $c['discipline']
+                    ));
+                    if(!in_array($json, $validate_array)) {
+            ?>
+                        <tr>
+                            <td><?= $c['discipline'] ?></td>
+                            <td><?= $c['prof_name'] ?></td>
+                            <td></td>
+                        </tr>
+            <?php
                     }
-                    $prof_name = $c['prof_name'];
-                    $discipline = $c['discipline'];
-                } ?>
+                    array_push($validate_array, $json);
+                }
+            ?>
             </tbody>
         </table>
         <div class="container-box signatures-container">

--- a/themes/default/views/reports/buzios/quarterly/QuarterlyClassCouncil.php
+++ b/themes/default/views/reports/buzios/quarterly/QuarterlyClassCouncil.php
@@ -23,7 +23,7 @@ if ($turno == 'M') {
     <div class="cabecalho" style="margin: 30px 0;">
         <?php $this->renderPartial('buzios/headers/headBuziosI'); ?>
     </div>
-    <h3><?php echo Yii::t('default', 'Quarterly Class Council Report'); ?> <?php echo strtoupper($classroom[0]['class_stage'])?></h3>
+    <h3><?php echo Yii::t('default', 'Quarterly Class Council Report')." - "; ?> <?php echo $title == '' ? strtoupper($classroom[0]['class_stage']) : $title?></h3>
     <p style="font-size: 19px;">Aos <?php echo $count_days?> dias do mês de <?php echo $mounth?> de 
     <?php echo $year?> às <?php echo $hour?>hs, realizou-se a 
     reunião de Conselho de Classe referente ao <br> <?php echo $quarterly?> Trimestre,
@@ -271,7 +271,7 @@ if ($turno == 'M') {
     <div class="cabecalho" style="margin: 30px 0;">
         <?php $this->renderPartial('buzios/headers/headBuziosI'); ?>
     </div>
-    <h3><?php echo Yii::t('default', 'Quarterly Class Council Report'); ?> <?php echo strtoupper($classroom[0]['class_stage'])?></h3>
+    <h3><?php echo Yii::t('default', 'Quarterly Class Council Report')." - "; ?> <?php echo $title == '' ? strtoupper($classroom[0]['class_stage']) : $title?></h3>
     <div class='no-enrollments'>Não há alunos matriculados na turma.</div>
 </div>
 <?php }?>

--- a/themes/default/views/reports/buzios/quarterly/QuarterlyClassCouncilHighSchool.php
+++ b/themes/default/views/reports/buzios/quarterly/QuarterlyClassCouncilHighSchool.php
@@ -275,19 +275,19 @@ if ($turno == 'M') {
                 </thead>
                 <tbody>
                     <?php
-                    $discipline = '';
-                    foreach ($classroom as $c) {
-                        if($discipline != $c['discipline'] ) {
+                        $validate_array = array();
+                        foreach ($classroom as $c) {
+                            if(!in_array($c['discipline'], $validate_array)) {
                     ?>
-                        <tr>
-                            <td><?= $c['discipline'] ?></td>
-                            <td></td>
-                            <td></td>
-                        </tr>
+                                <tr>
+                                    <td><?= $c['discipline'] ?></td>
+                                    <td></td>
+                                    <td></td>
+                                </tr>
                     <?php
+                            }
+                            array_push($validate_array, $c['discipline']);
                         }
-                        $discipline = $c['discipline'];
-                    } 
                     ?>
                 </tbody>
             </table>
@@ -360,21 +360,24 @@ if ($turno == 'M') {
             </thead>
             <tbody>
                 <?php
-                $prof_name = '';
-                $discipline = '';
-                foreach ($classroom as $c) {
-                    if($prof_name != $c['prof_name'] || $discipline != $c['discipline'] ) {
+                    $validate_array = array();
+                    foreach ($classroom as $c) {
+                        $json = json_encode(array(
+                            "prof_name" => $c['prof_name'],
+                            "discipline" => $c['discipline']
+                        ));
+                        if(!in_array($json, $validate_array)) {
                 ?>
-                    <tr>
-                        <td><?= $c['discipline'] ?></td>
-                        <td><?= $c['prof_name'] ?></td>
-                        <td></td>
-                    </tr>
+                            <tr>
+                                <td><?= $c['discipline'] ?></td>
+                                <td><?= $c['prof_name'] ?></td>
+                                <td></td>
+                            </tr>
                 <?php
+                        }
+                        array_push($validate_array, $json);
                     }
-                    $prof_name = $c['prof_name'];
-                    $discipline = $c['discipline'];
-                } ?>
+                ?>
             </tbody>
         </table>
         <div class="container-box signatures-container">

--- a/themes/default/views/reports/buzios/quarterly/QuarterlyClassCouncilHighSchool.php
+++ b/themes/default/views/reports/buzios/quarterly/QuarterlyClassCouncilHighSchool.php
@@ -411,7 +411,7 @@ if ($turno == 'M') {
     <div class="cabecalho" style="margin: 30px 0;">
         <?php $this->renderPartial('buzios/headers/headBuziosI'); ?>
     </div>
-    <h3><?php echo Yii::t('default', 'Quarterly Class Council Report'); ?> <?php echo strtoupper($classroom[0]['class_stage'])?></h3>
+    <h3><?php echo Yii::t('default', 'Quarterly Class Council Report'); ?> <?php echo '- ENSINO MÉDIO'?></h3>
     <div class='no-enrollments'>Não há alunos matriculados na turma.</div>
 </div>
 <?php }?>

--- a/themes/default/views/reports/buzios/quarterly/QuarterlyClassCouncilSixNineYear.php
+++ b/themes/default/views/reports/buzios/quarterly/QuarterlyClassCouncilSixNineYear.php
@@ -275,19 +275,19 @@ if ($turno == 'M') {
                 </thead>
                 <tbody>
                     <?php
-                    $discipline = '';
-                    foreach ($classroom as $c) {
-                        if($discipline != $c['discipline'] ) {
+                        $validate_array = array();
+                        foreach ($classroom as $c) {
+                            if(!in_array($c['discipline'], $validate_array)) {
                     ?>
-                        <tr>
-                            <td><?= $c['discipline'] ?></td>
-                            <td></td>
-                            <td></td>
-                        </tr>
+                                <tr>
+                                    <td><?= $c['discipline'] ?></td>
+                                    <td></td>
+                                    <td></td>
+                                </tr>
                     <?php
+                            }
+                            array_push($validate_array, $c['discipline']);
                         }
-                        $discipline = $c['discipline'];
-                    } 
                     ?>
                 </tbody>
             </table>
@@ -360,21 +360,24 @@ if ($turno == 'M') {
             </thead>
             <tbody>
                 <?php
-                $prof_name = '';
-                $discipline = '';
-                foreach ($classroom as $c) {
-                    if($prof_name != $c['prof_name'] || $discipline != $c['discipline'] ) {
+                    $validate_array = array();
+                    foreach ($classroom as $c) {
+                        $json = json_encode(array(
+                            "prof_name" => $c['prof_name'],
+                            "discipline" => $c['discipline']
+                        ));
+                        if(!in_array($json, $validate_array)) {
                 ?>
-                    <tr>
-                        <td><?= $c['discipline'] ?></td>
-                        <td><?= $c['prof_name'] ?></td>
-                        <td></td>
-                    </tr>
+                            <tr>
+                                <td><?= $c['discipline'] ?></td>
+                                <td><?= $c['prof_name'] ?></td>
+                                <td></td>
+                            </tr>
                 <?php
+                        }
+                        array_push($validate_array, $json);
                     }
-                    $prof_name = $c['prof_name'];
-                    $discipline = $c['discipline'];
-                } ?>
+                ?>
             </tbody>
         </table>
         <div class="container-box signatures-container">

--- a/themes/default/views/reports/buzios/quarterly/QuarterlyClassCouncilSixNineYear.php
+++ b/themes/default/views/reports/buzios/quarterly/QuarterlyClassCouncilSixNineYear.php
@@ -411,7 +411,7 @@ if ($turno == 'M') {
     <div class="cabecalho" style="margin: 30px 0;">
         <?php $this->renderPartial('buzios/headers/headBuziosI'); ?>
     </div>
-    <h3><?php echo Yii::t('default', 'Quarterly Class Council Report'); ?> <?php echo strtoupper($classroom[0]['class_stage'])?></h3>
+    <h3><?php echo Yii::t('default', 'Quarterly Class Council Report'); ?> <?php echo '- 6º AO 9º ANO DE ESCOLARIDADE'?></h3>
     <div class='no-enrollments'>Não há alunos matriculados na turma.</div>
 </div>
 <?php }?>

--- a/themes/default/views/reports/index.php
+++ b/themes/default/views/reports/index.php
@@ -479,10 +479,11 @@ $this->breadcrumbs = array(
                                 <div style="display:block;width:45%;margin-right:5%;">
                                     <label for="quarterly-model" class="control-label">Modelo</label>
                                     <select name="quarterly-model" id="quarterly-model" style="width:100%" required>
-                                        <option value='' selected>Selecione o trimestre</option>
-                                        <option value="1">1º ao 5º Ano</option>
-                                        <option value="2">6º ao 9º Ano</option>
-                                        <option value="3">Ensino Médio</option>
+                                        <option value='' selected>Selecione o modelo</option>
+                                        <option value="1">Educação Infantil</option>
+                                        <option value="2">1º ao 5º Ano</option>
+                                        <option value="3">6º ao 9º Ano</option>
+                                        <option value="4">Ensino Médio</option>
                                     </select>
                                 </div>
                                 <div style="display:block;width:50%;">

--- a/themes/default/views/reports/index.php
+++ b/themes/default/views/reports/index.php
@@ -435,11 +435,11 @@ $this->breadcrumbs = array(
                             <div class="model-quarterly-container" style="display: flex;">
                                 <div style="display:block;width:65%;margin-right:5%;">
                                     <label for="count_days" class="control-label" style="width: 100%;"> Dia da reunião de conselho de classe</label>
-                                    <input type="number" name="count_days" placeholder="Digite o dia das reuniões" style="width: 100%;" min="1" max="31" required>
+                                    <input type="number" name="count_days" placeholder="Digite o dia das reuniões" style="width: 100%;height:35px;" min="1" max="31" required>
                                 </div>
                                 <div style="display:block;width:30%;">
                                     <label for="hour" class="control-label" style="width: 100%;">Horário das reuniões</label>
-                                    <input type="time" id="hour" name="hour" min="00:00" max="23:59" style="width: 92%;" required>
+                                    <input type="time" id="hour" name="hour" min="00:00" max="23:59" style="width: 92%;height:35px;" required>
                                 </div>
                             </div>
 
@@ -486,7 +486,7 @@ $this->breadcrumbs = array(
                                         <option value="4">Ensino Médio</option>
                                     </select>
                                 </div> -->
-                                <div style="display:block;width:68%;">
+                                <div style="display:block;width:70%;">
                                     <label for="quarterly" class="control-label" style="width: 30%;">Trimestre</label>
                                     <select name="quarterly" id="quarterly" style="width:100%" required>
                                         <option value='' selected>Selecione o trimestre</option>
@@ -496,9 +496,9 @@ $this->breadcrumbs = array(
                                         <option value="4º">4º Trimestre</option>
                                     </select>
                                 </div>
-                                <div style="width: 30%;margin-top: 6%;margin-left:2%;text-align:right;">
+                                <div style="width: 30%;margin-top: 6%;text-align:right;">
+                                <input type="checkbox" name="infantil-model" id="infantil-model" style="margin-right:5px;margin-bottom:2px;">
                                 Educação Infantil?
-                                <input type="checkbox" name="infantil-model" id="infantil-model">  
                                 </div>
                             </div>
                         </div>

--- a/themes/default/views/reports/index.php
+++ b/themes/default/views/reports/index.php
@@ -476,7 +476,7 @@ $this->breadcrumbs = array(
                                 </div>
                             </div>
                             <div class="model-quarterly-container" style="display: flex;">
-                                <div style="display:block;width:45%;margin-right:5%;">
+                                <!-- <div style="display:block;width:45%;margin-right:5%;">
                                     <label for="quarterly-model" class="control-label">Modelo</label>
                                     <select name="quarterly-model" id="quarterly-model" style="width:100%" required>
                                         <option value='' selected>Selecione o modelo</option>
@@ -485,8 +485,8 @@ $this->breadcrumbs = array(
                                         <option value="3">6º ao 9º Ano</option>
                                         <option value="4">Ensino Médio</option>
                                     </select>
-                                </div>
-                                <div style="display:block;width:50%;">
+                                </div> -->
+                                <div style="display:block;width:68%;">
                                     <label for="quarterly" class="control-label" style="width: 30%;">Trimestre</label>
                                     <select name="quarterly" id="quarterly" style="width:100%" required>
                                         <option value='' selected>Selecione o trimestre</option>
@@ -495,6 +495,10 @@ $this->breadcrumbs = array(
                                         <option value="3º">3º Trimestre</option>
                                         <option value="4º">4º Trimestre</option>
                                     </select>
+                                </div>
+                                <div style="width: 30%;margin-top: 6%;margin-left:2%;text-align:right;">
+                                Educação Infantil?
+                                <input type="checkbox" name="infantil-model" id="infantil-model">  
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Documentation of changes in the TAG
### Description of changes:
- The width for printing the enrollment report has been adjusted.
- Captions have been added for the enrollment report.
- The form for generating class council minutes has been modified.
- The teacher subject repeat bug in the class council minutes has been fixed.

### Changes made:
- Adjustment in the printing width of the enrollment report: an adjustment was made in the printing width of the enrollment report so that the data is better distributed and easier to read.
- Added captions for the enrollment report: captions were added to the fields in the enrollment report, which will make reading the data more intuitive.
- Modification of the class council minutes generation form: the form was modified to make the minutes generation process clearer and easier to use.
- Bug fix for repeating teacher subjects in class council minutes: Fixed a bug that caused teacher subjects to be repeated in class council minutes.