### PR TITLE
feat:  adding curricular components module | :warning: v3.23.53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Atualizações
 
-## [Versão 3.21.50]
+## [Versão 3.23.51]
+- Novo módulo de gestão para componentes curriculares
+
+## [Versão 3.22.51]
+- adicionando campos de observação e data de transferência no formulário de transferência
+
+## [Versão 3.21.51]
 - O cabeçalho de ata de conselho de classe teve seus erros de sintaxe corrigidos
 
 ## [Versão 3.21.51]
@@ -9,8 +15,6 @@
 ## [Versão 3.21.50]
 - Corrigido a animação de carregamento fora de estrutura fixa e colocando a animação com símbolo do tag na tela de Estrutura de Unidades e Avaliações
 
-## [Versão 3.22.50]
-- adicionando campos de observação e data de transferência no formulário de transferência
 ## [Versão 3.21.49]
 - Corrigido a pré seleção no select de cargo no formulário de usuário
 

--- a/app/config/main.php
+++ b/app/config/main.php
@@ -45,6 +45,7 @@ return array(
         'sagres',
         'professional',
         'sedsp',
+        'curricularcomponents'
     ),
     // application components
     'components' => array(

--- a/app/messages/pt_br/default.php
+++ b/app/messages/pt_br/default.php
@@ -384,7 +384,7 @@ return array(
     'Modality' => 'Modalidade',
     'Edcenso Stage Vs Modality Fk' => 'Etapas de Ensino',
     'Edcenso Professional Education Course Fk' => 'Código Curso Educação Profissional',
-    'Disciplines' => 'Componentes curricularea/eixos',
+    'Disciplines' => 'Componentes curriculares/eixos',
     'Discipline' => 'Componente curricular/eixo',
     'Discipline Chemistry' => 'Química',
     'Discipline Physics' => 'Física',

--- a/app/migrations/2023-05-24_component_curricular_module/component_curricular.sql
+++ b/app/migrations/2023-05-24_component_curricular_module/component_curricular.sql
@@ -1,0 +1,42 @@
+
+-- Cria tabela com disciplinas de referencia do censo
+CREATE TABLE `edcenso_base_disciplines` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(200) COLLATE utf8_unicode_ci NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `id` (`id`)
+) ENGINE=InnoDB; 
+
+-- Copia somente as disciplinas básicas do censo que vão até o id 99
+INSERT INTO edcenso_base_disciplines
+SELECT * from edcenso_discipline
+WHERE id <= 99;
+
+-- Adiciona coluna na tabela original de disciplinas
+ALTER TABLE edcenso_discipline ADD edcenso_base_discipline_fk int NOT NULL;
+
+-- Atualiza registros com um valor padrão, caso não seja da base, adiciona como "outro(99)" 
+UPDATE edcenso_discipline 
+set edcenso_base_discipline_fk = IF(id <= 99, id, 99); 
+
+-- Define chave estrageira entre as duas disciplinas
+ALTER TABLE edcenso_discipline ADD CONSTRAINT edcenso_discipline_FK FOREIGN KEY (edcenso_base_discipline_fk) REFERENCES `demo.tag.ong.br`.edcenso_base_disciplines(id);
+
+-- Alterando id para auto_increment, isso evita que o usuário tente alterar o ID's
+SET foreign_key_checks = 0;
+
+ALTER TABLE edcenso_discipline MODIFY COLUMN id int(11) auto_increment NOT NULL;
+
+SET foreign_key_checks = 1;
+
+-- Alterando auto_incremet para evitar conflit de chave
+
+SELECT @max := MAX(ID)+ 1 FROM edcenso_discipline;
+
+set @alter_statement = concat('ALTER TABLE edcenso_discipline AUTO_INCREMENT = ', @max);
+
+PREPARE stmt FROM @alter_statement;
+
+EXECUTE stmt;
+
+DEALLOCATE PREPARE stmt;

--- a/app/models/Classroom.php
+++ b/app/models/Classroom.php
@@ -298,7 +298,7 @@ class Classroom extends AltActiveRecord
     {
         $disciplines = EdcensoDiscipline::model()
         ->with(array(
-            'curricularMatrices.teachingMatrixes.teachingDataFk' => array(
+            'curricularMatrixes.teachingMatrixes.teachingDataFk' => array(
                 'condition' => 'teachingDataFk.classroom_id_fk=:classroom_id',
                 'params' => array(':classroom_id' => $this->id),
             )

--- a/app/models/Classroom.php
+++ b/app/models/Classroom.php
@@ -305,7 +305,6 @@ class Classroom extends AltActiveRecord
         ))
         ->findAll();
         
-        var_dump($disciplines);
         return $disciplines;
     }
 

--- a/app/models/EdcensoBaseDisciplines.php
+++ b/app/models/EdcensoBaseDisciplines.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * This is the model class for table "edcenso_base_disciplines".
+ *
+ * The followings are the available columns in table 'edcenso_base_disciplines':
+ * @property integer $id
+ * @property string $name
+ *
+ * The followings are the available model relations:
+ * @property EdcensoDiscipline[] $edcensoDisciplines
+ */
+class EdcensoBaseDisciplines extends CActiveRecord
+{
+	/**
+	 * @return string the associated database table name
+	 */
+	public function tableName()
+	{
+		return 'edcenso_base_disciplines';
+	}
+
+	/**
+	 * @return array validation rules for model attributes.
+	 */
+	public function rules()
+	{
+		// NOTE: you should only define rules for those attributes that
+		// will receive user inputs.
+		return array(
+			array('id, name', 'required'),
+			array('id', 'numerical', 'integerOnly'=>true),
+			array('name', 'length', 'max'=>200),
+			// The following rule is used by search().
+			// @todo Please remove those attributes that should not be searched.
+			array('id, name', 'safe', 'on'=>'search'),
+		);
+	}
+
+	/**
+	 * @return array relational rules.
+	 */
+	public function relations()
+	{
+		// NOTE: you may need to adjust the relation name and the related
+		// class name for the relations automatically generated below.
+		return array(
+			'edcensoDisciplines' => array(self::HAS_MANY, 'EdcensoDiscipline', 'edcenso_base_discipline_fk'),
+		);
+	}
+
+	/**
+	 * @return array customized attribute labels (name=>label)
+	 */
+	public function attributeLabels()
+	{
+		return array(
+			'id' => 'ID',
+			'name' => 'Name',
+		);
+	}
+
+	/**
+	 * Retrieves a list of models based on the current search/filter conditions.
+	 *
+	 * Typical usecase:
+	 * - Initialize the model fields with values from filter form.
+	 * - Execute this method to get CActiveDataProvider instance which will filter
+	 * models according to data in model fields.
+	 * - Pass data provider to CGridView, CListView or any similar widget.
+	 *
+	 * @return CActiveDataProvider the data provider that can return the models
+	 * based on the search/filter conditions.
+	 */
+	public function search()
+	{
+		// @todo Please modify the following code to remove attributes that should not be searched.
+
+		$criteria=new CDbCriteria;
+
+		$criteria->compare('id',$this->id);
+		$criteria->compare('name',$this->name,true);
+
+		return new CActiveDataProvider($this, array(
+			'criteria'=>$criteria,
+		));
+	}
+
+	/**
+	 * Returns the static model of the specified AR class.
+	 * Please note that you should have this exact method in all your CActiveRecord descendants!
+	 * @param string $className active record class name.
+	 * @return EdcensoBaseDisciplines the static model class
+	 */
+	public static function model($className=__CLASS__)
+	{
+		return parent::model($className);
+	}
+}

--- a/app/models/EdcensoDiscipline.php
+++ b/app/models/EdcensoDiscipline.php
@@ -18,130 +18,105 @@
  * @property GradeResults[] $gradeResults
  * @property InstructorDisciplines[] $instructorDisciplines
  * @property InstructorTeachingData[] $instructorTeachingDatas
- * @property InstructorTeachingData[] $instructorTeachingDatas1
- * @property InstructorTeachingData[] $instructorTeachingDatas2
- * @property InstructorTeachingData[] $instructorTeachingDatas3
- * @property InstructorTeachingData[] $instructorTeachingDatas4
- * @property InstructorTeachingData[] $instructorTeachingDatas5
- * @property InstructorTeachingData[] $instructorTeachingDatas6
- * @property InstructorTeachingData[] $instructorTeachingDatas7
- * @property InstructorTeachingData[] $instructorTeachingDatas8
- * @property InstructorTeachingData[] $instructorTeachingDatas9
- * @property InstructorTeachingData[] $instructorTeachingDatas10
- * @property InstructorTeachingData[] $instructorTeachingDatas11
- * @property InstructorTeachingData[] $instructorTeachingDatas12
  * @property Schedule[] $schedules
  * @property WorkByDiscipline[] $workByDisciplines
  */
 class EdcensoDiscipline extends CActiveRecord
 {
-    /**
-     * @return string the associated database table name
-     */
-    public function tableName()
-    {
-        return 'edcenso_discipline';
-    }
+	/**
+	 * @return string the associated database table name
+	 */
+	public function tableName()
+	{
+		return 'edcenso_discipline';
+	}
 
-    /**
-     * @return array validation rules for model attributes.
-     */
-    public function rules()
-    {
-        // NOTE: you should only define rules for those attributes that
-        // will receive user inputs.
-        return array(
-            array('id, name, edcenso_base_discipline_fk', 'required'),
-            array('id, edcenso_base_discipline_fk', 'numerical', 'integerOnly'=>true),
-            array('name', 'length', 'max'=>200),
-            // The following rule is used by search().
-            // @todo Please remove those attributes that should not be searched.
-            array('id, name, edcenso_base_discipline_fk', 'safe', 'on'=>'search'),
-        );
-    }
+	/**
+	 * @return array validation rules for model attributes.
+	 */
+	public function rules()
+	{
+		// NOTE: you should only define rules for those attributes that
+		// will receive user inputs.
+		return array(
+			array('name, edcenso_base_discipline_fk', 'required'),
+			array('edcenso_base_discipline_fk', 'numerical', 'integerOnly'=>true),
+			array('name', 'length', 'max'=>200),
+			// The following rule is used by search().
+			// @todo Please remove those attributes that should not be searched.
+			array('id, name, edcenso_base_discipline_fk', 'safe', 'on'=>'search'),
+		);
+	}
 
-    /**
-     * @return array relational rules.
-     */
-    public function relations()
-    {
-        // NOTE: you may need to adjust the relation name and the related
-        // class name for the relations automatically generated below.
-        return array(
-            'classes' => array(self::HAS_MANY, 'Class', 'discipline_fk'),
-            'classBoards' => array(self::HAS_MANY, 'ClassBoard', 'discipline_fk'),
-            'courseClassAbilities' => array(self::HAS_MANY, 'CourseClassAbilities', 'edcenso_discipline_fk'),
-            'coursePlans' => array(self::HAS_MANY, 'CoursePlan', 'discipline_fk'),
-            'curricularMatrixes' => array(self::HAS_MANY, 'CurricularMatrix', 'discipline_fk'),
-            'edcensoBaseDisciplineFk' => array(self::BELONGS_TO, 'EdcensoBaseDisciplines', 'edcenso_base_discipline_fk'),
-            'frequencyAndMeanByDisciplines' => array(self::HAS_MANY, 'FrequencyAndMeanByDiscipline', 'discipline_fk'),
-            'gradeResults' => array(self::HAS_MANY, 'GradeResults', 'discipline_fk'),
-            'instructorDisciplines' => array(self::HAS_MANY, 'InstructorDisciplines', 'discipline_fk'),
-            'instructorTeachingDatas' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_1_fk'),
-            'instructorTeachingDatas1' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_10_fk'),
-            'instructorTeachingDatas2' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_11_fk'),
-            'instructorTeachingDatas3' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_12_fk'),
-            'instructorTeachingDatas4' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_13_fk'),
-            'instructorTeachingDatas5' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_2_fk'),
-            'instructorTeachingDatas6' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_3_fk'),
-            'instructorTeachingDatas7' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_4_fk'),
-            'instructorTeachingDatas8' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_5_fk'),
-            'instructorTeachingDatas9' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_6_fk'),
-            'instructorTeachingDatas10' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_7_fk'),
-            'instructorTeachingDatas11' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_8_fk'),
-            'instructorTeachingDatas12' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_9_fk'),
-            'schedules' => array(self::HAS_MANY, 'Schedule', 'discipline_fk'),
-            'workByDisciplines' => array(self::HAS_MANY, 'WorkByDiscipline', 'discipline_fk'),
-        );
-    }
+	/**
+	 * @return array relational rules.
+	 */
+	public function relations()
+	{
+		// NOTE: you may need to adjust the relation name and the related
+		// class name for the relations automatically generated below.
+		return array(
+			'classBoards' => array(self::HAS_MANY, 'ClassBoard', 'discipline_fk'),
+			'courseClassAbilities' => array(self::HAS_MANY, 'CourseClassAbilities', 'edcenso_discipline_fk'),
+			'coursePlans' => array(self::HAS_MANY, 'CoursePlan', 'discipline_fk'),
+			'curricularMatrixes' => array(self::HAS_MANY, 'CurricularMatrix', 'discipline_fk'),
+			'edcensoBaseDisciplineFk' => array(self::BELONGS_TO, 'EdcensoBaseDisciplines', 'edcenso_base_discipline_fk'),
+			'frequencyAndMeanByDisciplines' => array(self::HAS_MANY, 'FrequencyAndMeanByDiscipline', 'discipline_fk'),
+			'gradeResults' => array(self::HAS_MANY, 'GradeResults', 'discipline_fk'),
+			'instructorDisciplines' => array(self::HAS_MANY, 'InstructorDisciplines', 'discipline_fk'),
+			'instructorTeachingDatas' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_1_fk'),
+			'schedules' => array(self::HAS_MANY, 'Schedule', 'discipline_fk'),
+			'workByDisciplines' => array(self::HAS_MANY, 'WorkByDiscipline', 'discipline_fk'),
+		);
+	}
 
-    /**
-     * @return array customized attribute labels (name=>label)
-     */
-    public function attributeLabels()
-    {
-        return array(
-            'id' => 'ID',
-            'name' => 'Name',
-            'edcenso_base_discipline_fk' => 'Edcenso Base Discipline Fk',
-        );
-    }
+	/**
+	 * @return array customized attribute labels (name=>label)
+	 */
+	public function attributeLabels()
+	{
+		return array(
+			'id' => 'ID',
+			'name' => Yii::t('default', 'Discipline'),
+			'edcenso_base_discipline_fk' => 'Componente no EducaCenso',
+		);
+	}
 
-    /**
-     * Retrieves a list of models based on the current search/filter conditions.
-     *
-     * Typical usecase:
-     * - Initialize the model fields with values from filter form.
-     * - Execute this method to get CActiveDataProvider instance which will filter
-     * models according to data in model fields.
-     * - Pass data provider to CGridView, CListView or any similar widget.
-     *
-     * @return CActiveDataProvider the data provider that can return the models
-     * based on the search/filter conditions.
-     */
-    public function search()
-    {
-        // @todo Please modify the following code to remove attributes that should not be searched.
+	/**
+	 * Retrieves a list of models based on the current search/filter conditions.
+	 *
+	 * Typical usecase:
+	 * - Initialize the model fields with values from filter form.
+	 * - Execute this method to get CActiveDataProvider instance which will filter
+	 * models according to data in model fields.
+	 * - Pass data provider to CGridView, CListView or any similar widget.
+	 *
+	 * @return CActiveDataProvider the data provider that can return the models
+	 * based on the search/filter conditions.
+	 */
+	public function search()
+	{
+		// @todo Please modify the following code to remove attributes that should not be searched.
 
-        $criteria=new CDbCriteria;
+		$criteria=new CDbCriteria;
 
-        $criteria->compare('id',$this->id);
-        $criteria->compare('name',$this->name,true);
-        $criteria->compare('edcenso_base_discipline_fk',$this->edcenso_base_discipline_fk);
+		$criteria->compare('id',$this->id);
+		$criteria->compare('name',$this->name,true);
+		$criteria->compare('edcenso_base_discipline_fk',$this->edcenso_base_discipline_fk);
 
-        return new CActiveDataProvider($this, array(
-            'criteria'=>$criteria,
-        ));
-    }
+		return new CActiveDataProvider($this, array(
+			'criteria'=>$criteria,
+		));
+	}
 
-    /**
-     * Returns the static model of the specified AR class.
-     * Please note that you should have this exact method in all your CActiveRecord descendants!
-     * @param string $className active record class name.
-     * @return EdcensoDiscipline the static model class
-     */
-    public static function model($className=__CLASS__)
-    {
-        return parent::model($className);
-    }
+	/**
+	 * Returns the static model of the specified AR class.
+	 * Please note that you should have this exact method in all your CActiveRecord descendants!
+	 * @param string $className active record class name.
+	 * @return EdcensoDiscipline the static model class
+	 */
+	public static function model($className=__CLASS__)
+	{
+		return parent::model($className);
+	}
 }

--- a/app/models/EdcensoDiscipline.php
+++ b/app/models/EdcensoDiscipline.php
@@ -6,8 +6,17 @@
  * The followings are the available columns in table 'edcenso_discipline':
  * @property integer $id
  * @property string $name
+ * @property integer $edcenso_base_discipline_fk
  *
  * The followings are the available model relations:
+ * @property ClassBoard[] $classBoards
+ * @property CourseClassAbilities[] $courseClassAbilities
+ * @property CoursePlan[] $coursePlans
+ * @property CurricularMatrix[] $curricularMatrixes
+ * @property EdcensoBaseDisciplines $edcensoBaseDisciplineFk
+ * @property FrequencyAndMeanByDiscipline[] $frequencyAndMeanByDisciplines
+ * @property GradeResults[] $gradeResults
+ * @property InstructorDisciplines[] $instructorDisciplines
  * @property InstructorTeachingData[] $instructorTeachingDatas
  * @property InstructorTeachingData[] $instructorTeachingDatas1
  * @property InstructorTeachingData[] $instructorTeachingDatas2
@@ -20,95 +29,119 @@
  * @property InstructorTeachingData[] $instructorTeachingDatas9
  * @property InstructorTeachingData[] $instructorTeachingDatas10
  * @property InstructorTeachingData[] $instructorTeachingDatas11
+ * @property InstructorTeachingData[] $instructorTeachingDatas12
+ * @property Schedule[] $schedules
+ * @property WorkByDiscipline[] $workByDisciplines
  */
 class EdcensoDiscipline extends CActiveRecord
 {
-	/**
-	 * Returns the static model of the specified AR class.
-	 * @param string $className active record class name.
-	 * @return EdcensoDiscipline the static model class
-	 */
-	public static function model($className=__CLASS__)
-	{
-		return parent::model($className);
-	}
+    /**
+     * @return string the associated database table name
+     */
+    public function tableName()
+    {
+        return 'edcenso_discipline';
+    }
 
-	/**
-	 * @return string the associated database table name
-	 */
-	public function tableName()
-	{
-		return 'edcenso_discipline';
-	}
+    /**
+     * @return array validation rules for model attributes.
+     */
+    public function rules()
+    {
+        // NOTE: you should only define rules for those attributes that
+        // will receive user inputs.
+        return array(
+            array('id, name, edcenso_base_discipline_fk', 'required'),
+            array('id, edcenso_base_discipline_fk', 'numerical', 'integerOnly'=>true),
+            array('name', 'length', 'max'=>200),
+            // The following rule is used by search().
+            // @todo Please remove those attributes that should not be searched.
+            array('id, name, edcenso_base_discipline_fk', 'safe', 'on'=>'search'),
+        );
+    }
 
-	/**
-	 * @return array validation rules for model attributes.
-	 */
-	public function rules()
-	{
-		// NOTE: you should only define rules for those attributes that
-		// will receive user inputs.
-		return array(
-			array('id, name', 'required'),
-			array('id', 'numerical', 'integerOnly'=>true),
-			array('name', 'length', 'max'=>200),
-			// The following rule is used by search().
-			// Please remove those attributes that should not be searched.
-			array('id, name', 'safe', 'on'=>'search'),
-		);
-	}
+    /**
+     * @return array relational rules.
+     */
+    public function relations()
+    {
+        // NOTE: you may need to adjust the relation name and the related
+        // class name for the relations automatically generated below.
+        return array(
+            'classes' => array(self::HAS_MANY, 'Class', 'discipline_fk'),
+            'classBoards' => array(self::HAS_MANY, 'ClassBoard', 'discipline_fk'),
+            'courseClassAbilities' => array(self::HAS_MANY, 'CourseClassAbilities', 'edcenso_discipline_fk'),
+            'coursePlans' => array(self::HAS_MANY, 'CoursePlan', 'discipline_fk'),
+            'curricularMatrixes' => array(self::HAS_MANY, 'CurricularMatrix', 'discipline_fk'),
+            'edcensoBaseDisciplineFk' => array(self::BELONGS_TO, 'EdcensoBaseDisciplines', 'edcenso_base_discipline_fk'),
+            'frequencyAndMeanByDisciplines' => array(self::HAS_MANY, 'FrequencyAndMeanByDiscipline', 'discipline_fk'),
+            'gradeResults' => array(self::HAS_MANY, 'GradeResults', 'discipline_fk'),
+            'instructorDisciplines' => array(self::HAS_MANY, 'InstructorDisciplines', 'discipline_fk'),
+            'instructorTeachingDatas' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_1_fk'),
+            'instructorTeachingDatas1' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_10_fk'),
+            'instructorTeachingDatas2' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_11_fk'),
+            'instructorTeachingDatas3' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_12_fk'),
+            'instructorTeachingDatas4' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_13_fk'),
+            'instructorTeachingDatas5' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_2_fk'),
+            'instructorTeachingDatas6' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_3_fk'),
+            'instructorTeachingDatas7' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_4_fk'),
+            'instructorTeachingDatas8' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_5_fk'),
+            'instructorTeachingDatas9' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_6_fk'),
+            'instructorTeachingDatas10' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_7_fk'),
+            'instructorTeachingDatas11' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_8_fk'),
+            'instructorTeachingDatas12' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_9_fk'),
+            'schedules' => array(self::HAS_MANY, 'Schedule', 'discipline_fk'),
+            'workByDisciplines' => array(self::HAS_MANY, 'WorkByDiscipline', 'discipline_fk'),
+        );
+    }
 
-	/**
-	 * @return array relational rules.
-	 */
-	public function relations()
-	{
-		// NOTE: you may need to adjust the relation name and the related
-		// class name for the relations automatically generated below.
-		return array(
-			'curricularMatrices' => array(self::HAS_MANY, 'CurricularMatrix', 'discipline_fk'),
-			'instructorTeachingDatas' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_10_fk'),
-			'instructorTeachingDatas1' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_11_fk'),
-			'instructorTeachingDatas2' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_12_fk'),
-			'instructorTeachingDatas3' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_13_fk'),
-			'instructorTeachingDatas4' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_2_fk'),
-			'instructorTeachingDatas5' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_3_fk'),
-			'instructorTeachingDatas6' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_4_fk'),
-			'instructorTeachingDatas7' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_5_fk'),
-			'instructorTeachingDatas8' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_6_fk'),
-			'instructorTeachingDatas9' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_7_fk'),
-			'instructorTeachingDatas10' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_8_fk'),
-			'instructorTeachingDatas11' => array(self::HAS_MANY, 'InstructorTeachingData', 'discipline_9_fk'),
-		);
-	}
+    /**
+     * @return array customized attribute labels (name=>label)
+     */
+    public function attributeLabels()
+    {
+        return array(
+            'id' => 'ID',
+            'name' => 'Name',
+            'edcenso_base_discipline_fk' => 'Edcenso Base Discipline Fk',
+        );
+    }
 
-	/**
-	 * @return array customized attribute labels (name=>label)
-	 */
-	public function attributeLabels()
-	{
-		return array(
-			'id' => Yii::t('default', 'ID'),
-			'name' => Yii::t('default', 'Name'),
-		);
-	}
+    /**
+     * Retrieves a list of models based on the current search/filter conditions.
+     *
+     * Typical usecase:
+     * - Initialize the model fields with values from filter form.
+     * - Execute this method to get CActiveDataProvider instance which will filter
+     * models according to data in model fields.
+     * - Pass data provider to CGridView, CListView or any similar widget.
+     *
+     * @return CActiveDataProvider the data provider that can return the models
+     * based on the search/filter conditions.
+     */
+    public function search()
+    {
+        // @todo Please modify the following code to remove attributes that should not be searched.
 
-	/**
-	 * Retrieves a list of models based on the current search/filter conditions.
-	 * @return CActiveDataProvider the data provider that can return the models based on the search/filter conditions.
-	 */
-	public function search()
-	{
-		// Warning: Please modify the following code to remove attributes that
-		// should not be searched.
+        $criteria=new CDbCriteria;
 
-		$criteria=new CDbCriteria;
+        $criteria->compare('id',$this->id);
+        $criteria->compare('name',$this->name,true);
+        $criteria->compare('edcenso_base_discipline_fk',$this->edcenso_base_discipline_fk);
 
-		$criteria->compare('id',$this->id);
-		$criteria->compare('name',$this->name,true);
+        return new CActiveDataProvider($this, array(
+            'criteria'=>$criteria,
+        ));
+    }
 
-		return new CActiveDataProvider($this, array(
-			'criteria'=>$criteria,
-		));
-	}
+    /**
+     * Returns the static model of the specified AR class.
+     * Please note that you should have this exact method in all your CActiveRecord descendants!
+     * @param string $className active record class name.
+     * @return EdcensoDiscipline the static model class
+     */
+    public static function model($className=__CLASS__)
+    {
+        return parent::model($className);
+    }
 }

--- a/app/models/InstructorIdentification.php
+++ b/app/models/InstructorIdentification.php
@@ -214,7 +214,6 @@ class InstructorIdentification extends AltActiveRecord
             'select' => 'DISTINCT ed.*',
         ));
 
-        var_dump($disciplines);
         return $disciplines;
     }
 

--- a/app/models/InstructorIdentification.php
+++ b/app/models/InstructorIdentification.php
@@ -205,7 +205,7 @@ class InstructorIdentification extends AltActiveRecord
     {
         $disciplines = EdcensoDiscipline::model()
         ->with(array(
-                'curricularMatrices.teachingMatrixes.teachingDataFk' => array(
+                'curricularMatrixes.teachingMatrixes.teachingDataFk' => array(
                 'condition' => 'teachingDataFk.instructor_fk=:instructor_fk',
                 'params' => array(':instructor_fk' => $this->id),
             )

--- a/app/modules/curricularcomponents/CurricularcomponentsModule.php
+++ b/app/modules/curricularcomponents/CurricularcomponentsModule.php
@@ -1,0 +1,30 @@
+<?php
+
+class CurricularcomponentsModule extends CWebModule
+{
+	public function init()
+	{
+		// this method is called when the module is being created
+		// you may place code here to customize the module or the application
+
+		// import the module-level models and components
+		$this->setImport(array(
+			'curricularcomponents.models.*',
+			'curricularcomponents.components.*',
+		));
+	}
+
+	public function beforeControllerAction($controller, $action)
+	{
+		$controller->layout = 'webroot.themes.default.views.layouts.fullmenu';
+		
+		if(parent::beforeControllerAction($controller, $action))
+		{
+			// this method is called before any module controller action is performed
+			// you may place customized code here
+			return true;
+		}
+		else
+			return false;
+	}
+}

--- a/app/modules/curricularcomponents/controllers/DefaultController.php
+++ b/app/modules/curricularcomponents/controllers/DefaultController.php
@@ -1,0 +1,173 @@
+<?php
+
+class DefaultController extends Controller
+{
+	/**
+	 * @var string the default layout for the views. Defaults to '//layouts/column2', meaning
+	 * using two-column layout. See 'protected/views/layouts/column2.php'.
+	 */
+	// public $layout='webroot.themes.default.views.layouts.fullmenu';
+
+	/**
+	 * @return array action filters
+	 */
+	public function filters()
+	{
+		return array(
+			'accessControl', // perform access control for CRUD operations
+			'postOnly + delete', // we only allow deletion via POST request
+		);
+	}
+
+	/**
+	 * Specifies the access control rules.
+	 * This method is used by the 'accessControl' filter.
+	 * @return array access control rules
+	 */
+	public function accessRules()
+	{
+		return array(
+			array('allow',  // allow all users to perform 'index' and 'view' actions
+				'actions'=>array('index','view'),
+				'users'=>array('*'),
+			),
+			array('allow', // allow authenticated user to perform 'create' and 'update' actions
+				'actions'=>array('create','update'),
+				'users'=>array('@'),
+			),
+			array('allow', // allow admin user to perform 'admin' and 'delete' actions
+				'actions'=>array('admin','delete'),
+				'users'=>array('admin'),
+			),
+			array('deny',  // deny all users
+				'users'=>array('*'),
+			),
+		);
+	}
+
+	/**
+	 * Displays a particular model.
+	 * @param integer $id the ID of the model to be displayed
+	 */
+	public function actionView($id)
+	{
+		$this->render('view',array(
+			'model'=>$this->loadModel($id),
+		));
+	}
+
+	/**
+	 * Creates a new model.
+	 * If creation is successful, the browser will be redirected to the 'view' page.
+	 */
+	public function actionCreate()
+	{
+		$model=new EdcensoDiscipline;
+
+		// Uncomment the following line if AJAX validation is needed
+		// $this->performAjaxValidation($model);
+
+		if(isset($_POST['EdcensoDiscipline']))
+		{
+			$model->attributes=$_POST['EdcensoDiscipline'];
+			if($model->save())
+				$this->redirect(array('view','id'=>$model->id));
+		}
+
+		$this->render('create',array(
+			'model'=>$model,
+		));
+	}
+
+	/**
+	 * Updates a particular model.
+	 * If update is successful, the browser will be redirected to the 'view' page.
+	 * @param integer $id the ID of the model to be updated
+	 */
+	public function actionUpdate($id)
+	{
+		$model=$this->loadModel($id);
+
+		// Uncomment the following line if AJAX validation is needed
+		// $this->performAjaxValidation($model);
+
+		if(isset($_POST['EdcensoDiscipline']))
+		{
+			$model->attributes=$_POST['EdcensoDiscipline'];
+			if($model->save())
+				$this->redirect(array('view','id'=>$model->id));
+		}
+
+		$this->render('update',array(
+			'model'=>$model,
+		));
+	}
+
+	/**
+	 * Deletes a particular model.
+	 * If deletion is successful, the browser will be redirected to the 'admin' page.
+	 * @param integer $id the ID of the model to be deleted
+	 */
+	public function actionDelete($id)
+	{
+		$this->loadModel($id)->delete();
+
+		// if AJAX request (triggered by deletion via admin grid view), we should not redirect the browser
+		if(!isset($_GET['ajax']))
+			$this->redirect(isset($_POST['returnUrl']) ? $_POST['returnUrl'] : array('admin'));
+	}
+
+	/**
+	 * Lists all models.
+	 */
+	public function actionIndex()
+	{
+		$dataProvider=new CActiveDataProvider('EdcensoDiscipline');
+		$this->render('index',array(
+			'dataProvider'=> $dataProvider,
+		));
+	}
+
+	/**
+	 * Manages all models.
+	 */
+	public function actionAdmin()
+	{
+		$model=new EdcensoDiscipline('search');
+		$model->unsetAttributes();  // clear any default values
+		if(isset($_GET['EdcensoDiscipline']))
+			$model->attributes=$_GET['EdcensoDiscipline'];
+
+		$this->render('admin',array(
+			'model'=>$model,
+		));
+	}
+
+	/**
+	 * Returns the data model based on the primary key given in the GET variable.
+	 * If the data model is not found, an HTTP exception will be raised.
+	 * @param integer $id the ID of the model to be loaded
+	 * @return EdcensoDiscipline the loaded model
+	 * @throws CHttpException
+	 */
+	public function loadModel($id)
+	{
+		$model=EdcensoDiscipline::model()->findByPk($id);
+		if($model===null)
+			throw new CHttpException(404,'The requested page does not exist.');
+		return $model;
+	}
+
+	/**
+	 * Performs the AJAX validation.
+	 * @param EdcensoDiscipline $model the model to be validated
+	 */
+	protected function performAjaxValidation($model)
+	{
+		if(isset($_POST['ajax']) && $_POST['ajax']==='edcenso-discipline-form')
+		{
+			echo CActiveForm::validate($model);
+			Yii::app()->end();
+		}
+	}
+}

--- a/app/modules/curricularcomponents/controllers/DefaultController.php
+++ b/app/modules/curricularcomponents/controllers/DefaultController.php
@@ -104,7 +104,13 @@ class DefaultController extends Controller
      */
     public function actionDelete($id)
     {
-        $this->loadModel($id)->delete();
+        $curricular_component = $this->loadModel($id);
+
+        if($curricular_component->edcenso_base_discipline_fk < 99) {
+            throw new CHttpException(400, 'Não é possível remover um componente base do EducaCenso');
+        }
+
+        $curricular_component->delete();
 
         // if AJAX request (triggered by deletion via admin grid view), we should not redirect the browser
         if(!isset($_GET['ajax'])) {

--- a/app/modules/curricularcomponents/controllers/DefaultController.php
+++ b/app/modules/curricularcomponents/controllers/DefaultController.php
@@ -2,172 +2,168 @@
 
 class DefaultController extends Controller
 {
-	/**
-	 * @var string the default layout for the views. Defaults to '//layouts/column2', meaning
-	 * using two-column layout. See 'protected/views/layouts/column2.php'.
-	 */
-	// public $layout='webroot.themes.default.views.layouts.fullmenu';
+    /**
+     * @var string the default layout for the views. Defaults to '//layouts/column2', meaning
+     * using two-column layout. See 'protected/views/layouts/column2.php'.
+     */
+    // public $layout='webroot.themes.default.views.layouts.fullmenu';
 
-	/**
-	 * @return array action filters
-	 */
-	public function filters()
-	{
-		return array(
-			'accessControl', // perform access control for CRUD operations
-			'postOnly + delete', // we only allow deletion via POST request
-		);
-	}
+    /**
+     * @return array action filters
+     */
+    public function filters()
+    {
+        return array(
+            'accessControl', // perform access control for CRUD operations
+            'postOnly + delete', // we only allow deletion via POST request
+        );
+    }
 
-	/**
-	 * Specifies the access control rules.
-	 * This method is used by the 'accessControl' filter.
-	 * @return array access control rules
-	 */
-	public function accessRules()
-	{
-		return array(
-			array('allow',  // allow all users to perform 'index' and 'view' actions
-				'actions'=>array('index','view'),
-				'users'=>array('*'),
-			),
-			array('allow', // allow authenticated user to perform 'create' and 'update' actions
-				'actions'=>array('create','update'),
-				'users'=>array('@'),
-			),
-			array('allow', // allow admin user to perform 'admin' and 'delete' actions
-				'actions'=>array('admin','delete'),
-				'users'=>array('admin'),
-			),
-			array('deny',  // deny all users
-				'users'=>array('*'),
-			),
-		);
-	}
+    /**
+     * Specifies the access control rules.
+     * This method is used by the 'accessControl' filter.
+     * @return array access control rules
+     */
+    public function accessRules()
+    {
+        return array(
+            array('allow',  // allow all users to perform 'index' and 'view' actions
+                'actions'=>array('index','view'),
+                'users'=>array('*'),
+            ),
+            array('allow', // allow authenticated user to perform 'create' and 'update' actions
+                'actions'=>array('create','update'),
+                'users'=>array('@'),
+            ),
+            array('allow', // allow admin user to perform 'admin' and 'delete' actions
+                'actions'=>array('admin','delete'),
+                'users'=>array('admin'),
+            ),
+            array('deny',  // deny all users
+                'users'=>array('*'),
+            ),
+        );
+    }
 
-	/**
-	 * Displays a particular model.
-	 * @param integer $id the ID of the model to be displayed
-	 */
-	public function actionView($id)
-	{
-		$this->render('view',array(
-			'model'=>$this->loadModel($id),
-		));
-	}
 
-	/**
-	 * Creates a new model.
-	 * If creation is successful, the browser will be redirected to the 'view' page.
-	 */
-	public function actionCreate()
-	{
-		$model=new EdcensoDiscipline;
+    /**
+     * Creates a new model.
+     * If creation is successful, the browser will be redirected to the 'view' page.
+     */
+    public function actionCreate()
+    {
+        $model=new EdcensoDiscipline();
 
-		// Uncomment the following line if AJAX validation is needed
-		// $this->performAjaxValidation($model);
+        // Uncomment the following line if AJAX validation is needed
+        // $this->performAjaxValidation($model);
 
-		if(isset($_POST['EdcensoDiscipline']))
-		{
-			$model->attributes=$_POST['EdcensoDiscipline'];
-			if($model->save())
-				$this->redirect(array('view','id'=>$model->id));
-		}
+        $edcenso_base_disciplines =  EdcensoBaseDisciplines::model()->findAll();
 
-		$this->render('create',array(
-			'model'=>$model,
-		));
-	}
+        if(isset($_POST['EdcensoDiscipline'])) {
+            $model->attributes=$_POST['EdcensoDiscipline'];
+            if($model->save()) {
+                $this->redirect(array('index'));
+            }
+        }
 
-	/**
-	 * Updates a particular model.
-	 * If update is successful, the browser will be redirected to the 'view' page.
-	 * @param integer $id the ID of the model to be updated
-	 */
-	public function actionUpdate($id)
-	{
-		$model=$this->loadModel($id);
+        $this->render('create', array(
+            'model'=>$model,
+            'edcenso_base_disciplines' => $edcenso_base_disciplines,
+        ));
+    }
 
-		// Uncomment the following line if AJAX validation is needed
-		// $this->performAjaxValidation($model);
+    /**
+     * Updates a particular model.
+     * If update is successful, the browser will be redirected to the 'view' page.
+     * @param integer $id the ID of the model to be updated
+     */
+    public function actionUpdate($id)
+    {
+        $model=$this->loadModel($id);
+        $edcenso_base_disciplines =  EdcensoBaseDisciplines::model()->findAll();
+        // Uncomment the following line if AJAX validation is needed
+        // $this->performAjaxValidation($model);
 
-		if(isset($_POST['EdcensoDiscipline']))
-		{
-			$model->attributes=$_POST['EdcensoDiscipline'];
-			if($model->save())
-				$this->redirect(array('view','id'=>$model->id));
-		}
+        if(isset($_POST['EdcensoDiscipline'])) {
+            $model->attributes=$_POST['EdcensoDiscipline'];
+            if($model->save()) {
+                $this->redirect(array('index'));
+            }
+        }
 
-		$this->render('update',array(
-			'model'=>$model,
-		));
-	}
+        $this->render('update', array(
+            'model'=>$model,
+            'edcenso_base_disciplines' => $edcenso_base_disciplines,
+        ));
+    }
 
-	/**
-	 * Deletes a particular model.
-	 * If deletion is successful, the browser will be redirected to the 'admin' page.
-	 * @param integer $id the ID of the model to be deleted
-	 */
-	public function actionDelete($id)
-	{
-		$this->loadModel($id)->delete();
+    /**
+     * Deletes a particular model.
+     * If deletion is successful, the browser will be redirected to the 'admin' page.
+     * @param integer $id the ID of the model to be deleted
+     */
+    public function actionDelete($id)
+    {
+        $this->loadModel($id)->delete();
 
-		// if AJAX request (triggered by deletion via admin grid view), we should not redirect the browser
-		if(!isset($_GET['ajax']))
-			$this->redirect(isset($_POST['returnUrl']) ? $_POST['returnUrl'] : array('admin'));
-	}
+        // if AJAX request (triggered by deletion via admin grid view), we should not redirect the browser
+        if(!isset($_GET['ajax'])) {
+            $this->redirect(isset($_POST['returnUrl']) ? $_POST['returnUrl'] : array('admin'));
+        }
+    }
 
-	/**
-	 * Lists all models.
-	 */
-	public function actionIndex()
-	{
-		$dataProvider=new CActiveDataProvider('EdcensoDiscipline');
-		$this->render('index',array(
-			'dataProvider'=> $dataProvider,
-		));
-	}
+    /**
+     * Lists all models.
+     */
+    public function actionIndex()
+    {
+        $dataProvider = new CActiveDataProvider('EdcensoDiscipline', array('pagination' => false));
+        $this->render('index', array(
+            'dataProvider'=> $dataProvider,
+        ));
+    }
 
-	/**
-	 * Manages all models.
-	 */
-	public function actionAdmin()
-	{
-		$model=new EdcensoDiscipline('search');
-		$model->unsetAttributes();  // clear any default values
-		if(isset($_GET['EdcensoDiscipline']))
-			$model->attributes=$_GET['EdcensoDiscipline'];
+    /**
+     * Manages all models.
+     */
+    public function actionAdmin()
+    {
+        $model = new EdcensoDiscipline('search');
+        $model->unsetAttributes();  // clear any default values
+        if(isset($_GET['EdcensoDiscipline'])) {
+            $model->attributes=$_GET['EdcensoDiscipline'];
+        }
 
-		$this->render('admin',array(
-			'model'=>$model,
-		));
-	}
+        $this->render('admin', array(
+            'model'=>$model,
+        ));
+    }
 
-	/**
-	 * Returns the data model based on the primary key given in the GET variable.
-	 * If the data model is not found, an HTTP exception will be raised.
-	 * @param integer $id the ID of the model to be loaded
-	 * @return EdcensoDiscipline the loaded model
-	 * @throws CHttpException
-	 */
-	public function loadModel($id)
-	{
-		$model=EdcensoDiscipline::model()->findByPk($id);
-		if($model===null)
-			throw new CHttpException(404,'The requested page does not exist.');
-		return $model;
-	}
+    /**
+     * Returns the data model based on the primary key given in the GET variable.
+     * If the data model is not found, an HTTP exception will be raised.
+     * @param integer $id the ID of the model to be loaded
+     * @return EdcensoDiscipline the loaded model
+     * @throws CHttpException
+     */
+    public function loadModel($id)
+    {
+        $model = EdcensoDiscipline::model()->findByPk($id);
+        if($model===null) {
+            throw new CHttpException(404, 'The requested page does not exist.');
+        }
+        return $model;
+    }
 
-	/**
-	 * Performs the AJAX validation.
-	 * @param EdcensoDiscipline $model the model to be validated
-	 */
-	protected function performAjaxValidation($model)
-	{
-		if(isset($_POST['ajax']) && $_POST['ajax']==='edcenso-discipline-form')
-		{
-			echo CActiveForm::validate($model);
-			Yii::app()->end();
-		}
-	}
+    /**
+     * Performs the AJAX validation.
+     * @param EdcensoDiscipline $model the model to be validated
+     */
+    protected function performAjaxValidation($model)
+    {
+        if(isset($_POST['ajax']) && $_POST['ajax']==='edcenso-discipline-form') {
+            echo CActiveForm::validate($model);
+            Yii::app()->end();
+        }
+    }
 }

--- a/app/modules/curricularcomponents/controllers/DefaultController.php
+++ b/app/modules/curricularcomponents/controllers/DefaultController.php
@@ -107,15 +107,14 @@ class DefaultController extends Controller
         $curricular_component = $this->loadModel($id);
 
         if($curricular_component->edcenso_base_discipline_fk < 99) {
-            throw new CHttpException(400, 'Não é possível remover um componente base do EducaCenso');
+            Yii::app()->user->setFlash('error', Yii::t('default', 'Não é possível remover um componente base do EducaCenso'));
+            $this->redirect(array('index'));
         }
 
         $curricular_component->delete();
 
-        // if AJAX request (triggered by deletion via admin grid view), we should not redirect the browser
-        if(!isset($_GET['ajax'])) {
-            $this->redirect(isset($_POST['returnUrl']) ? $_POST['returnUrl'] : array('admin'));
-        }
+        Yii::app()->user->setFlash('success', Yii::t('default', 'Componente curricular excluído com sucesso!'));
+        $this->redirect(array('index'));
     }
 
     /**

--- a/app/modules/curricularcomponents/controllers/DefaultController.php
+++ b/app/modules/curricularcomponents/controllers/DefaultController.php
@@ -63,6 +63,8 @@ class DefaultController extends Controller
             $model->attributes=$_POST['EdcensoDiscipline'];
             if($model->save()) {
                 $this->redirect(array('index'));
+            } else {
+                Yii::app()->user->setFlash('error', Yii::t('default', 'Não foi possível criar esse componente curricular'));
             }
         }
 
@@ -88,7 +90,9 @@ class DefaultController extends Controller
             $model->attributes=$_POST['EdcensoDiscipline'];
             if($model->save()) {
                 $this->redirect(array('index'));
-            }
+            } else {
+                Yii::app()->user->setFlash('error', Yii::t('default', 'Não foi possível atualizar esse componente curricular'));
+            }            
         }
 
         $this->render('update', array(
@@ -111,9 +115,12 @@ class DefaultController extends Controller
             $this->redirect(array('index'));
         }
 
-        $curricular_component->delete();
+        if($curricular_component->delete()){
+            Yii::app()->user->setFlash('success', Yii::t('default', 'Componente curricular excluído com sucesso!'));
+        } else {
+            Yii::app()->user->setFlash('error', Yii::t('default', 'Não é possível remover este componente curricular'));
+        }
 
-        Yii::app()->user->setFlash('success', Yii::t('default', 'Componente curricular excluído com sucesso!'));
         $this->redirect(array('index'));
     }
 

--- a/app/modules/curricularcomponents/views/default/_form.php
+++ b/app/modules/curricularcomponents/views/default/_form.php
@@ -15,6 +15,10 @@ $cs = Yii::app()->getClientScript();
 $cs->registerCssFile($themeUrl . '/css/template2.css');
 $cs->registerScriptFile($baseScriptUrl . '/common/js/professional.js?v=1.1', CClientScript::POS_END);
 
+if(!$model->isNewRecord){
+    $cant_change_censo_discipline = $model->edcenso_base_discipline_fk < 99;
+}
+
 ?>
 
 <div class="form">
@@ -52,7 +56,7 @@ $cs->registerScriptFile($baseScriptUrl . '/common/js/professional.js?v=1.1', CCl
 
                     <div class="t-field-text">
                         <?php echo $form->labelEx($model, 'edcenso_base_discipline_fk', array('class' => 'control-label t-field-text__label--required')); ?>
-                        <?php echo $form->dropDownList($model, 'edcenso_base_discipline_fk', CHtml::listData($edcenso_base_disciplines, "id", "name"), array( 'class' => 't-field-text__input')); ?>
+                        <?php echo $form->dropDownList($model, 'edcenso_base_discipline_fk', CHtml::listData($edcenso_base_disciplines, "id", "name"), array( 'class' => 't-field-text__input', 'disabled' => $cant_change_censo_discipline)); ?>
                         <?php echo $form->error($model, 'edcenso_base_discipline_fk'); ?>
                     </div>
                 </div>

--- a/app/modules/curricularcomponents/views/default/_form.php
+++ b/app/modules/curricularcomponents/views/default/_form.php
@@ -1,0 +1,40 @@
+<?php
+/* @var $this DefaultController */
+/* @var $model EdcensoDiscipline */
+/* @var $form CActiveForm */
+?>
+
+<div class="form">
+
+<?php $form=$this->beginWidget('CActiveForm', array(
+	'id'=>'edcenso-discipline-form',
+	// Please note: When you enable ajax validation, make sure the corresponding
+	// controller action is handling ajax validation correctly.
+	// There is a call to performAjaxValidation() commented in generated controller code.
+	// See class documentation of CActiveForm for details on this.
+	'enableAjaxValidation'=>false,
+)); ?>
+
+	<p class="note">Fields with <span class="required">*</span> are required.</p>
+
+	<?php echo $form->errorSummary($model); ?>
+
+	<div class="row">
+		<?php echo $form->labelEx($model,'id'); ?>
+		<?php echo $form->textField($model,'id'); ?>
+		<?php echo $form->error($model,'id'); ?>
+	</div>
+
+	<div class="row">
+		<?php echo $form->labelEx($model,'name'); ?>
+		<?php echo $form->textField($model,'name',array('size'=>60,'maxlength'=>200)); ?>
+		<?php echo $form->error($model,'name'); ?>
+	</div>
+
+	<div class="row buttons">
+		<?php echo CHtml::submitButton($model->isNewRecord ? 'Create' : 'Save'); ?>
+	</div>
+
+<?php $this->endWidget(); ?>
+
+</div><!-- form -->

--- a/app/modules/curricularcomponents/views/default/_form.php
+++ b/app/modules/curricularcomponents/views/default/_form.php
@@ -1,40 +1,66 @@
 <?php
-/* @var $this DefaultController */
-/* @var $model EdcensoDiscipline */
-/* @var $form CActiveForm */
+/**
+* @var DefaultController $this DefaultController
+* @var EdcensoDiscipline $model EdcensoDiscipline
+* @var EdcensoBaseDisciplines[] $edcenso_base_disciplines EdcensoBaseDiscipline[]
+* @var CActiveForm $form CActiveForm
+*/
+
+$form = $this->beginWidget('CActiveForm', array(
+    'id'=>'edcenso-discipline-_form-form',
+    'enableAjaxValidation'=>false,
+));
+$themeUrl = Yii::app()->theme->baseUrl;
+$cs = Yii::app()->getClientScript();
+$cs->registerCssFile($themeUrl . '/css/template2.css');
+$cs->registerScriptFile($baseScriptUrl . '/common/js/professional.js?v=1.1', CClientScript::POS_END);
+
 ?>
 
 <div class="form">
-
-<?php $form=$this->beginWidget('CActiveForm', array(
-	'id'=>'edcenso-discipline-form',
-	// Please note: When you enable ajax validation, make sure the corresponding
-	// controller action is handling ajax validation correctly.
-	// There is a call to performAjaxValidation() commented in generated controller code.
-	// See class documentation of CActiveForm for details on this.
-	'enableAjaxValidation'=>false,
-)); ?>
-
-	<p class="note">Fields with <span class="required">*</span> are required.</p>
-
-	<?php echo $form->errorSummary($model); ?>
-
-	<div class="row">
-		<?php echo $form->labelEx($model,'id'); ?>
-		<?php echo $form->textField($model,'id'); ?>
-		<?php echo $form->error($model,'id'); ?>
+    <div class="row-fluid hidden-print">
+		<div class="span12">
+			<h1>
+				<?php echo $title; ?>
+			</h1>
+			<div class="tag-buttons-container buttons">
+				<button class="t-button-primary pull-right" type="submit">
+					<?= $model->isNewRecord ? Yii::t('default', 'Create') : Yii::t('default', 'Save') ?>
+				</button>
+			</div>
+		</div>
 	</div>
 
-	<div class="row">
-		<?php echo $form->labelEx($model,'name'); ?>
-		<?php echo $form->textField($model,'name',array('size'=>60,'maxlength'=>200)); ?>
-		<?php echo $form->error($model,'name'); ?>
-	</div>
+    <div class="tag-inner">
+		<?php if (Yii::app()->user->hasFlash('success') && (!$modelProfessional->isNewRecord)): ?>
+			<div class="alert alert-success">
+				<?php echo Yii::app()->user->getFlash('success') ?>
+			</div>
+		<?php endif ?>
+		<div class="widget widget-tabs border-bottom-none">
+            <div class="row">
+                <div class="column">
+                    <?php echo $form->errorSummary($model); ?>
 
-	<div class="row buttons">
-		<?php echo CHtml::submitButton($model->isNewRecord ? 'Create' : 'Save'); ?>
-	</div>
+                    <?php echo $form->hiddenField($model, 'id'); ?>
+
+                    <div class="t-field-text">
+                        <?php echo $form->labelEx($model, 'name', array('class' => 'control-label t-field-text__label--required')); ?>
+                        <?php echo $form->textField($model, 'name'); ?>
+                        <?php echo $form->error($model, 'name'); ?>
+                    </div>
+
+                    <div class="t-field-text">
+                        <?php echo $form->labelEx($model, 'edcenso_base_discipline_fk', array('class' => 'control-label t-field-text__label--required')); ?>
+                        <?php echo $form->dropDownList($model, 'edcenso_base_discipline_fk', CHtml::listData($edcenso_base_disciplines, "id", "name"), array( 'class' => 't-field-text__input')); ?>
+                        <?php echo $form->error($model, 'edcenso_base_discipline_fk'); ?>
+                    </div>
+                </div>
+                <div class="column"></div>
+            </div>
+    </div>
+</div>
 
 <?php $this->endWidget(); ?>
 
-</div><!-- form -->
+</div><!-- form --> 

--- a/app/modules/curricularcomponents/views/default/create.php
+++ b/app/modules/curricularcomponents/views/default/create.php
@@ -1,6 +1,6 @@
 <?php
-/* @var $this DefaultController */
-/* @var $model EdcensoDiscipline */
+/** @var DefaultController $this DefaultController */
+/** @var EdcensoDiscipline $model EdcensoDiscipline */
 
 $this->breadcrumbs=array(
 	'Edcenso Disciplines'=>array('index'),
@@ -11,8 +11,14 @@ $this->menu=array(
 	array('label'=>'List EdcensoDiscipline', 'url'=>array('index')),
 	array('label'=>'Manage EdcensoDiscipline', 'url'=>array('admin')),
 );
+
+$this->setPageTitle('TAG - ' . Yii::t('default', 'Add New Student'));
+$title = Yii::t('default', 'Add New Student');
+
 ?>
 
-<h1>Create EdcensoDiscipline</h1>
 
-<?php $this->renderPartial('_form', array('model'=>$model)); ?>
+
+<div id="mainPage" class="main">
+	<?php $this->renderPartial('_form', array('model'=>$model, 'edcenso_base_disciplines' => $edcenso_base_disciplines,  'title' => $title)); ?>
+</div>

--- a/app/modules/curricularcomponents/views/default/create.php
+++ b/app/modules/curricularcomponents/views/default/create.php
@@ -1,0 +1,18 @@
+<?php
+/* @var $this DefaultController */
+/* @var $model EdcensoDiscipline */
+
+$this->breadcrumbs=array(
+	'Edcenso Disciplines'=>array('index'),
+	'Create',
+);
+
+$this->menu=array(
+	array('label'=>'List EdcensoDiscipline', 'url'=>array('index')),
+	array('label'=>'Manage EdcensoDiscipline', 'url'=>array('admin')),
+);
+?>
+
+<h1>Create EdcensoDiscipline</h1>
+
+<?php $this->renderPartial('_form', array('model'=>$model)); ?>

--- a/app/modules/curricularcomponents/views/default/index.php
+++ b/app/modules/curricularcomponents/views/default/index.php
@@ -30,7 +30,7 @@ $title = Yii::t('default', 'Disciplines');
 
 <?php $this->widget('zii.widgets.grid.CGridView', array(
     'id'=>'edcenso-discipline-grid',
-    'dataProvider'=>$dataProvider,
+    'dataProvider' => $dataProvider,
     'enablePagination' => false,
     'enableSorting' => false,
     'itemsCssClass' => 'js-tag-table tag-table table table-condensed table-striped table-hover table-primary table-vertical-center checkboxs',

--- a/app/modules/curricularcomponents/views/default/index.php
+++ b/app/modules/curricularcomponents/views/default/index.php
@@ -1,0 +1,42 @@
+<?php
+/* @var $this EdcensoDisciplineController */
+/* @var $model EdcensoDiscipline */
+
+$this->breadcrumbs=array(
+    'Edcenso Disciplines'=>array('index'),
+    'Manage',
+);
+
+$this->menu=array(
+    array('label'=>'List EdcensoDiscipline', 'url'=>array('index')),
+    array('label'=>'Create EdcensoDiscipline', 'url'=>array('create')),
+);
+
+Yii::app()->clientScript->registerScript('search', "
+$('.search-button').click(function(){
+    $('.search-form').toggle();
+    return false;
+});
+$('.search-form form').submit(function(){
+    $('#edcenso-discipline-grid').yiiGridView('update', {
+        data: $(this).serialize()
+    });
+    return false;
+});
+");
+?>
+
+<h1>Manage Edcenso Disciplines</h1>
+
+
+<?php $this->widget('zii.widgets.grid.CGridView', array(
+    'id'=>'edcenso-discipline-grid',
+    'dataProvider'=>$dataProvider,
+    'columns'=>array(
+        'id',
+        'name',
+        array(
+            'class'=>'CButtonColumn',
+        ),
+    ),
+)); ?>

--- a/app/modules/curricularcomponents/views/default/index.php
+++ b/app/modules/curricularcomponents/views/default/index.php
@@ -1,42 +1,58 @@
 <?php
-/* @var $this EdcensoDisciplineController */
-/* @var $model EdcensoDiscipline */
+/** @var DefaultController $this EdcensoDisciplineController */
+/** @var EdcensoDiscipline $model EdcensoDiscipline */
 
-$this->breadcrumbs=array(
-    'Edcenso Disciplines'=>array('index'),
-    'Manage',
-);
 
-$this->menu=array(
-    array('label'=>'List EdcensoDiscipline', 'url'=>array('index')),
-    array('label'=>'Create EdcensoDiscipline', 'url'=>array('create')),
-);
+$this->setPageTitle('TAG - ' . Yii::t('default', 'Disciplines'));
+$title = Yii::t('default', 'Disciplines');
 
-Yii::app()->clientScript->registerScript('search', "
-$('.search-button').click(function(){
-    $('.search-form').toggle();
-    return false;
-});
-$('.search-form form').submit(function(){
-    $('#edcenso-discipline-grid').yiiGridView('update', {
-        data: $(this).serialize()
-    });
-    return false;
-});
-");
 ?>
 
-<h1>Manage Edcenso Disciplines</h1>
 
+<div id="mainPage" class="main">
+<div class="row-fluid box-instructor">
+        <div class="span12">
+            <h1><?php echo Yii::t('default', 'Disciplines') ?></h1>
+            <div class="t-buttons-container">
+                <a class="t-button-primary" href="<?php echo Yii::app()->createUrl('curricularcomponents/default/create')?>">Adicionar Componente</a>
+            </div>
+        </div>
+        <div class="btn-group pull-right mt-30 responsive-menu dropdown-margin">
+            <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+                Menu
+                <span class="caret"></span>
+            </a>
+            <ul class="dropdown-menu">
+                <li><a href="<?php echo Yii::app()->createUrl('curricularcomponents/default/create')?>"><i></i> Adicionar Componente</a></li>
+            </ul>
+        </div>
+    </div>  
 
 <?php $this->widget('zii.widgets.grid.CGridView', array(
     'id'=>'edcenso-discipline-grid',
     'dataProvider'=>$dataProvider,
+    'enablePagination' => false,
+    'enableSorting' => false,
+    'itemsCssClass' => 'js-tag-table tag-table table table-condensed table-striped table-hover table-primary table-vertical-center checkboxs',
     'columns'=>array(
         'id',
         'name',
         array(
-            'class'=>'CButtonColumn',
+            'header' => 'Ações',
+            'class' => 'CButtonColumn', 
+            'template' => '{update}{delete}',
+            'buttons' => array(
+                'update' => array(
+                    'imageUrl' => Yii::app()->theme->baseUrl.'/img/editar.svg',
+                ),
+                'delete' => array(
+                    'imageUrl' => Yii::app()->theme->baseUrl.'/img/deletar.svg',
+                )
+            ),
+            'updateButtonOptions' => array('style' => 'margin-right: 20px;'),
+            'htmlOptions' => array('width' => '100px', 'style' => 'text-align: center'),
         ),
     ),
 )); ?>
+
+</div>

--- a/app/modules/curricularcomponents/views/default/index.php
+++ b/app/modules/curricularcomponents/views/default/index.php
@@ -10,7 +10,7 @@ $title = Yii::t('default', 'Disciplines');
 
 
 <div id="mainPage" class="main">
-<div class="row-fluid box-instructor">
+    <div class="row-fluid box-instructor">
         <div class="span12">
             <h1><?php echo Yii::t('default', 'Disciplines') ?></h1>
             <div class="t-buttons-container">
@@ -27,32 +27,49 @@ $title = Yii::t('default', 'Disciplines');
             </ul>
         </div>
     </div>  
-
-<?php $this->widget('zii.widgets.grid.CGridView', array(
-    'id'=>'edcenso-discipline-grid',
-    'dataProvider' => $dataProvider,
-    'enablePagination' => false,
-    'enableSorting' => false,
-    'itemsCssClass' => 'js-tag-table tag-table table table-condensed table-striped table-hover table-primary table-vertical-center checkboxs',
-    'columns'=>array(
-        'id',
-        'name',
-        array(
-            'header' => 'Ações',
-            'class' => 'CButtonColumn', 
-            'template' => '{update}{delete}',
-            'buttons' => array(
-                'update' => array(
-                    'imageUrl' => Yii::app()->theme->baseUrl.'/img/editar.svg',
-                ),
-                'delete' => array(
-                    'imageUrl' => Yii::app()->theme->baseUrl.'/img/deletar.svg',
-                )
-            ),
-            'updateButtonOptions' => array('style' => 'margin-right: 20px;'),
-            'htmlOptions' => array('width' => '100px', 'style' => 'text-align: center'),
-        ),
-    ),
-)); ?>
-
+<div class="tag-inner">
+        <?php if (Yii::app()->user->hasFlash('success')): ?>
+            <div class="alert alert-success">
+                <?php echo Yii::app()->user->getFlash('success') ?>
+            </div>
+            <br/>
+        <?php endif ?>
+        <?php if (Yii::app()->user->hasFlash('error')): ?>
+            <div class="alert alert-error">
+                <?php echo Yii::app()->user->getFlash('error') ?>
+            </div>
+            <br/>
+        <?php endif ?>
+        <div class="widget clearmargin">
+            <div class="widget-body">
+                <?php $this->widget('zii.widgets.grid.CGridView', array(
+                    'id'=>'edcenso-discipline-grid',
+                    'dataProvider' => $dataProvider,
+                    'enablePagination' => false,
+                    'enableSorting' => false,
+                    'ajaxUpdate' => false,
+                    'itemsCssClass' => 'js-tag-table tag-table table table-condensed table-striped table-hover table-primary table-vertical-center checkboxs',
+                    'columns'=>array(
+                        'id',
+                        'name',
+                        array(
+                            'header' => 'Ações',
+                            'class' => 'CButtonColumn', 
+                            'template' => '{update}{delete}',
+                            'buttons' => array(
+                                'update' => array(
+                                    'imageUrl' => Yii::app()->theme->baseUrl.'/img/editar.svg',
+                                ),
+                                'delete' => array(
+                                    'imageUrl' => Yii::app()->theme->baseUrl.'/img/deletar.svg',
+                                )
+                            ),
+                            'updateButtonOptions' => array('style' => 'margin-right: 20px;'),
+                            'htmlOptions' => array('width' => '100px', 'style' => 'text-align: center'),
+                        ),
+                    ),
+                )); ?>
+            </div>
+        </div>
+    </div>
 </div>

--- a/app/modules/curricularcomponents/views/default/update.php
+++ b/app/modules/curricularcomponents/views/default/update.php
@@ -1,0 +1,21 @@
+<?php
+/* @var $this DefaultController */
+/* @var $model EdcensoDiscipline */
+
+$this->breadcrumbs=array(
+	'Edcenso Disciplines'=>array('index'),
+	$model->name=>array('view','id'=>$model->id),
+	'Update',
+);
+
+$this->menu=array(
+	array('label'=>'List EdcensoDiscipline', 'url'=>array('index')),
+	array('label'=>'Create EdcensoDiscipline', 'url'=>array('create')),
+	array('label'=>'View EdcensoDiscipline', 'url'=>array('view', 'id'=>$model->id)),
+	array('label'=>'Manage EdcensoDiscipline', 'url'=>array('admin')),
+);
+?>
+
+<h1>Update EdcensoDiscipline <?php echo $model->id; ?></h1>
+
+<?php $this->renderPartial('_form', array('model'=>$model)); ?>

--- a/app/modules/curricularcomponents/views/default/update.php
+++ b/app/modules/curricularcomponents/views/default/update.php
@@ -1,6 +1,6 @@
 <?php
-/* @var $this DefaultController */
-/* @var $model EdcensoDiscipline */
+/** @var DefaultController $this DefaultController */
+/** @var EdcensoDiscipline $model EdcensoDiscipline */
 
 $this->breadcrumbs=array(
 	'Edcenso Disciplines'=>array('index'),
@@ -8,14 +8,14 @@ $this->breadcrumbs=array(
 	'Update',
 );
 
-$this->menu=array(
-	array('label'=>'List EdcensoDiscipline', 'url'=>array('index')),
-	array('label'=>'Create EdcensoDiscipline', 'url'=>array('create')),
-	array('label'=>'View EdcensoDiscipline', 'url'=>array('view', 'id'=>$model->id)),
-	array('label'=>'Manage EdcensoDiscipline', 'url'=>array('admin')),
-);
+$this->setPageTitle('TAG - Atualizar Componente Curricular');
+$title = Yii::t('default', 'Atualizar Componente: '. $model->name);
+
 ?>
 
-<h1>Update EdcensoDiscipline <?php echo $model->id; ?></h1>
-
-<?php $this->renderPartial('_form', array('model'=>$model)); ?>
+<div id="mainPage" class="main">
+	<?php $this->renderPartial('_form', array(
+		'model'=>$model, 
+		'edcenso_base_disciplines' => $edcenso_base_disciplines,  
+		'title' => $title)); ?>
+</div>

--- a/config.php
+++ b/config.php
@@ -1,6 +1,6 @@
 <?php
-defined('YII_DEBUG') or define('YII_DEBUG', true);
-// defined('YII_DEBUG') or define('YII_DEBUG', false);
+// defined('YII_DEBUG') or define('YII_DEBUG', true);
+defined('YII_DEBUG') or define('YII_DEBUG', false);
 
 define("TAG_VERSION", '3.22.51');
 

--- a/config.php
+++ b/config.php
@@ -2,7 +2,7 @@
 // defined('YII_DEBUG') or define('YII_DEBUG', true);
 defined('YII_DEBUG') or define('YII_DEBUG', false);
 
-define("TAG_VERSION", '3.22.51');
+define("TAG_VERSION", '3.23.51');
 
 
 define("YII_VERSION", Yii::getVersion());

--- a/js/datatables/init.js
+++ b/js/datatables/init.js
@@ -217,6 +217,7 @@ function initDatatable() {
             else if(action.includes("curricularmatrix")) $('.dataTables_filter input[type="search"]').attr('placeholder', '  Pesquisar matriz')
             else if(action.includes("courseplan")) $('.dataTables_filter input[type="search"]').attr('placeholder', '  Pesquisar plano de aula')
             else if(action.includes("professional")) $('.dataTables_filter input[type="search"]').attr('placeholder', '  Pesquisar profissional')
+            else if(action.includes("curricularcomponents")) $('.dataTables_filter input[type="search"]').attr('placeholder', ' Pesquisar componente')
             else if(action.includes("stock")) {
                 $('.stock-container .dataTables_filter input[type="search"]').attr('placeholder', '  Pesquisar Itens')
                 $('.transactions-container .dataTables_filter input[type="search"]').attr('placeholder', '  Pesquisar Movimentações')

--- a/themes/default/views/admin/index.php
+++ b/themes/default/views/admin/index.php
@@ -67,6 +67,18 @@ $this->pageTitle = 'TAG - ' . Yii::t('default', 'Administration');
                             </button>
                         </a>
 
+                        <a href="<?php echo Yii::app()->createUrl('curricularcomponents') ?>">
+                            <button type="button" class="admin-box-container">
+                                <div class="pull-left" style="margin-right: 20px;">
+                                    <span class="t-icon-copy t-reports_icons"></span>
+                                </div>
+                                <div class="pull-left">
+                                    <span class="title">Componentes curriculares</span><br>
+                                    <span class="subtitle">Gerencie os componetes curriculares da unidade</span>
+                                </div>
+                            </button>
+                        </a>
+
                         <a href="<?php echo Yii::app()->createUrl('admin/editPassword', array("id" => Yii::app()->user->loginInfos->id)) ?>">
                             <button type="button" class="admin-box-container">
                                 <div class="pull-left" style="margin-right: 20px;">


### PR DESCRIPTION
:warning: MIGRATION INCLUSA -> migrations\2023-05-24_component_curricular_module\component_curricular.sql

# Motivação

Baseado no grande número de solicitações dos municípios relacionadas a alteração do nome e a adição de novos componentes curriculares (disciplinas). Fez-se necessária a criação de um módulo dedicado a gestão desse dados na plataforma.

# Fatores de análise

- Os componentes curriculares no TAG atualmente são baseados no EducaCenso, toda disciplina tem que ter um código correspondente a uma das áreas do conhecimento censo;
- Em casos de componentes que não se enquadram a um componente do censo, ele deve ter o código atrelado a "Outras disciplinas", código 99 do censo;
- Somente administradores podem alterar as informações do componentes;
- Os ids nunca podem ser modificados;
- Somente disciplinas com código 99 do censo podem ser excluídas;

# Evidências

![image](https://github.com/ipti/br.tag/assets/4085653/317d4102-9b7d-4071-a8cd-80dff772efc5)

![image](https://github.com/ipti/br.tag/assets/4085653/ec5cddeb-94a3-4465-998d-cc89a1ceae37)

![image](https://github.com/ipti/br.tag/assets/4085653/31039412-6b89-4f72-b538-6e98038efbff)


# Commits:
- feat: adding new module to disciplines
- feat: updating edcenso_disciplines
- feat: adding curricular_component module
- feat: adding rules for dont remove any base componets
- feat: improve table actions to better UX
- feat: adding migration to create tables edcenso_base_disciplines
