### PR TITLE
fix: resolving assets cache problem on new versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Atualizações
 
+## [Versão 3.24.58]
+- Adicionamento versão para arquivos css, resolvendo problema
+com cache do style
+
 ## [Versão 3.24.57]
 - Alterado o estilo da tela de aulas ministradas
 - Criação de variações da classe table

--- a/app/modules/curricularcomponents/views/default/_form.php
+++ b/app/modules/curricularcomponents/views/default/_form.php
@@ -12,7 +12,7 @@ $form = $this->beginWidget('CActiveForm', array(
 ));
 $themeUrl = Yii::app()->theme->baseUrl;
 $cs = Yii::app()->getClientScript();
-$cs->registerCssFile($themeUrl . '/css/template2.css');
+
 $cs->registerScriptFile($baseScriptUrl . '/common/js/professional.js?v=1.1', CClientScript::POS_END);
 
 if(!$model->isNewRecord){

--- a/app/modules/professional/views/default/_form.php
+++ b/app/modules/professional/views/default/_form.php
@@ -10,7 +10,7 @@
 	$baseScriptUrl = Yii::app()->controller->module->baseScriptUrl;
 	$themeUrl = Yii::app()->theme->baseUrl;
     $cs = Yii::app()->getClientScript();
-    $cs->registerCssFile($themeUrl . '/css/template2.css');
+    
 	$cs->registerScriptFile($baseScriptUrl . '/common/js/professional.js?v=1.1', CClientScript::POS_END);
 
 	$form = $this->beginWidget(

--- a/app/modules/professional/views/default/index.php
+++ b/app/modules/professional/views/default/index.php
@@ -17,7 +17,7 @@ $this->breadcrumbs=array(
     );
     $themeUrl = Yii::app()->theme->baseUrl;
     $cs = Yii::app()->getClientScript();
-    $cs->registerCssFile($themeUrl . '/css/template2.css');
+    
     ?>
 
 

--- a/app/modules/sagres/models/SagresConsultModel.php
+++ b/app/modules/sagres/models/SagresConsultModel.php
@@ -525,7 +525,7 @@ class SagresConsultModel
                 ->setData(new DateTime($cardapio['data']))
                 ->setTurno($this->convertTurn($cardapio['turno']))
                 ->setDescricaoMerenda($cardapio['descricaoMerenda'])
-                ->setAjustado($cardapio['ajustado']);
+                ->setAjustado(isset($cardapio['ajustado']) ? $cardapio['ajustado'] :  0);
 
             $cardapioList[] = $cardapioType;
         }

--- a/app/modules/sagres/views/default/_form.php
+++ b/app/modules/sagres/views/default/_form.php
@@ -15,7 +15,7 @@ $cs->registerScriptFile($baseUrl, CClientScript::POS_END);
     <?php
     $themeUrl = Yii::app()->theme->baseUrl;
     $cs = Yii::app()->getClientScript();
-    $cs->registerCssFile($themeUrl . '/css/template2.css');
+    
 
     $form = $this->beginWidget(
         'CActiveForm',

--- a/app/modules/sagres/views/default/inconsistencys.php
+++ b/app/modules/sagres/views/default/inconsistencys.php
@@ -9,7 +9,7 @@
     );
     $themeUrl = Yii::app()->theme->baseUrl;
     $cs = Yii::app()->getClientScript();
-    $cs->registerCssFile($themeUrl . '/css/template2.css');
+    
     ?>
 
     <div class="widget clearmargin">

--- a/app/modules/sedsp/views/default/index.php
+++ b/app/modules/sedsp/views/default/index.php
@@ -9,8 +9,7 @@ $this->breadcrumbs = array(
 $baseScriptUrl = Yii::app()->controller->module->baseScriptUrl;
 $themeUrl = Yii::app()->theme->baseUrl;
 $cs = Yii::app()->getClientScript();
-$cs->registerCssFile($themeUrl . '/css/template2.css');
-$cs->registerCssFile(Yii::app()->request->baseUrl . '/sass/css/main.css');
+
 $cs->registerCssFile($baseUrl . '/css/sedsp.css');
 $cs->registerScriptFile($baseScriptUrl . '/common/js/functions.js?v=1.1', CClientScript::POS_END);
 ?>

--- a/app/modules/sedsp/views/default/manageRA.php
+++ b/app/modules/sedsp/views/default/manageRA.php
@@ -9,8 +9,7 @@ $this->breadcrumbs = array(
 $baseScriptUrl = Yii::app()->controller->module->baseScriptUrl;
 $themeUrl = Yii::app()->theme->baseUrl;
 $cs = Yii::app()->getClientScript();
-$cs->registerCssFile($themeUrl . '/css/template2.css');
-$cs->registerCssFile(Yii::app()->request->baseUrl . '/sass/css/main.css');
+
 $cs->registerScriptFile($baseScriptUrl . '/common/js/functions.js?v=1.1', CClientScript::POS_END);
 ?>
 

--- a/config.php
+++ b/config.php
@@ -1,8 +1,8 @@
 <?php
-defined('YII_DEBUG') or define('YII_DEBUG', true);
-// defined('YII_DEBUG') or define('YII_DEBUG', false);
+// defined('YII_DEBUG') or define('YII_DEBUG', true);
+defined('YII_DEBUG') or define('YII_DEBUG', false);
 
-define("TAG_VERSION", '3.24.57');
+define("TAG_VERSION", '3.24.58');
 
 
 define("YII_VERSION", Yii::getVersion());

--- a/themes/default/views/admin/_form.php
+++ b/themes/default/views/admin/_form.php
@@ -12,7 +12,7 @@ $themeUrl = Yii::app()->theme->baseUrl;
 $cs = Yii::app()->getClientScript();
 $cs->registerScriptFile($baseUrl . '/js/admin/form/validations.js', CClientScript::POS_END);
 $cs->registerScriptFile($baseUrl . '/js/admin/form/_initialization.js', CClientScript::POS_END);
-$cs->registerCssFile($themeUrl . '/css/template2.css');
+
 $cs->registerCssFile($baseUrl . 'sass/css/main.css');
 
 $form = $this->beginWidget('CActiveForm', array(

--- a/themes/default/views/admin/activeDisableUser.php
+++ b/themes/default/views/admin/activeDisableUser.php
@@ -7,7 +7,7 @@ $cs->registerScriptFile($baseUrl . '/js/admin/index/dialogs.js', CClientScript::
 $cs->registerScriptFile($baseUrl . '/js/admin/index/global.js', CClientScript::POS_END);
 $cs->registerScriptFile($baseUrl . '/js/admin/activeDisableUser/_initialization.js', CClientScript::POS_END);
 $themeUrl = Yii::app()->theme->baseUrl;
-$cs->registerCssFile($themeUrl . '/css/template2.css');
+
 ?>
 
 <div id="mainPage" class="main">

--- a/themes/default/views/calendar/default/index.php
+++ b/themes/default/views/calendar/default/index.php
@@ -12,7 +12,7 @@ $themeUrl = Yii::app()->theme->baseUrl;
 $cs = Yii::app()->getClientScript();
 $cs->registerCssFile($baseScriptUrl . '/common/css/layout.css?v=1.1');
 $cs->registerScriptFile($baseScriptUrl . '/common/js/index.js', CClientScript::POS_END);
-$cs->registerCssFile($themeUrl . '/css/template2.css');
+
 $this->setPageTitle('TAG - ' . Yii::t('calendarModule.index', 'Calendar'));
 ?>
 

--- a/themes/default/views/censo/validate.php
+++ b/themes/default/views/censo/validate.php
@@ -11,7 +11,7 @@
     );
     $themeUrl = Yii::app()->theme->baseUrl;
     $cs = Yii::app()->getClientScript();
-    $cs->registerCssFile($themeUrl . '/css/template2.css');
+    
     ?>
     <style type="text/css">
         .widget-timeline .widget-body:before {

--- a/themes/default/views/classes/classContents.php
+++ b/themes/default/views/classes/classContents.php
@@ -10,7 +10,7 @@ $themeUrl = Yii::app()->theme->baseUrl;
 $cs = Yii::app()->getClientScript();
 $cs->registerScriptFile($baseUrl . '/js/classes/class-contents/_initialization.js?v=1.0', CClientScript::POS_END);
 $cs->registerScriptFile($baseUrl . '/js/classes/class-contents/functions.js?v=1.0', CClientScript::POS_END);
-$cs->registerCssFile($themeUrl . '/css/template2.css');
+
 $this->setPageTitle('TAG - ' . Yii::t('default', 'Classes Contents'));
 
 $form = $this->beginWidget('CActiveForm', array(

--- a/themes/default/views/classes/frequency.php
+++ b/themes/default/views/classes/frequency.php
@@ -8,7 +8,7 @@ $baseUrl = Yii::app()->baseUrl;
 $themeUrl = Yii::app()->theme->baseUrl;
 $cs = Yii::app()->getClientScript();
 $cs->registerScriptFile($baseUrl . '/js/classes/frequency/_initialization.js?v=1.0', CClientScript::POS_END);
-$cs->registerCssFile($themeUrl . '/css/template2.css');
+
 $this->setPageTitle('TAG - ' . Yii::t('default', 'Classes'));
 
 $school = SchoolIdentification::model()->findByPk(Yii::app()->user->school);

--- a/themes/default/views/classroom/_form.php
+++ b/themes/default/views/classroom/_form.php
@@ -14,7 +14,7 @@ $cs->registerScriptFile($baseUrl . '/js/classroom/form/dialogs.js', CClientScrip
 $cs->registerScriptFile($baseUrl . '/js/classroom/form/functions.js?v=1.0', CClientScript::POS_END);
 $cs->registerScriptFile($baseUrl . '/js/classroom/form/validations.js?v=1.0', CClientScript::POS_END);
 $cs->registerScriptFile($baseUrl . '/js/classroom/form/pagination.js', CClientScript::POS_END);
-$cs->registerCssFile($themeUrl . '/css/template2.css');
+
 $cs->registerCssFile($baseUrl . 'sass/css/main.css');
 
 $form = $this->beginWidget('CActiveForm', array(

--- a/themes/default/views/classroom/index.php
+++ b/themes/default/views/classroom/index.php
@@ -6,10 +6,6 @@
     $this->menu = array(
         array('label' => Yii::t('default', 'Create a new Classroom'), 'url' => array('create'), 'description' => Yii::t('default', 'This action create a new Classroom')),
     );
-    $themeUrl = Yii::app()->theme->baseUrl;
-    $cs = Yii::app()->getClientScript();
-    $cs->registerCssFile($themeUrl . '/css/template2.css');
-    $cs->registerCssFile(Yii::app()->request->baseUrl . '/sass/css/main.css');
     
     ?>
 

--- a/themes/default/views/courseplan/form.php
+++ b/themes/default/views/courseplan/form.php
@@ -16,7 +16,7 @@ $cs->registerScriptFile($baseUrl . '/js/courseplan/form/pagination.js', CClientS
 // $cs->registerScriptFile($themeUrl . '/js/jquery/jquery.dataTables.min.js', CClientScript::POS_END);
 // $cs->registerCssFile($themeUrl . '/css/jquery.dataTables.min.css');
 // $cs->registerCssFile($themeUrl . '/css/dataTables.fontAwesome.css');
-$cs->registerCssFile($themeUrl . '/css/template2.css');
+
 
 
 $this->setPageTitle('TAG - ' . Yii::t('default', 'Course Plan'));

--- a/themes/default/views/courseplan/index.php
+++ b/themes/default/views/courseplan/index.php
@@ -5,7 +5,7 @@
 $this->setPageTitle('TAG - ' . Yii::t('default', 'Course Plan'));
 $themeUrl = Yii::app()->theme->baseUrl;
 $cs = Yii::app()->getClientScript();
-$cs->registerCssFile($themeUrl . '/css/template2.css');
+
 ?>
 
 <div id="mainPage" class="main">

--- a/themes/default/views/curricularmatrix/curricularmatrix/index.php
+++ b/themes/default/views/curricularmatrix/curricularmatrix/index.php
@@ -13,7 +13,7 @@ $cs->registerCssFile($baseScriptUrl . '/common/css/layout.css?v=1.2');
 $cs->registerScriptFile($baseScriptUrl . '/common/js/curricularmatrix.js', CClientScript::POS_END);
 $cs->registerScript("vars", "var addMatrix = '" . $this->createUrl("addMatrix") . "';", CClientScript::POS_HEAD);
 $this->setPageTitle('TAG - ' . Yii::t('curricularMatrixModule.index', 'Curricular Matrix'));
-// $cs->registerCssFile($themeUrl . '/css/template2.css');
+// 
 ?>
 
 

--- a/themes/default/views/enrollment/grades.php
+++ b/themes/default/views/enrollment/grades.php
@@ -15,7 +15,7 @@ $script = "var getGradesUrl = '" . Yii::app()->createUrl('enrollment/getGrades')
 $cs->registerScript('variables', $script, CClientScript::POS_END);
 $cs->registerCssFile($baseUrl . '/css/grades.css');
 $this->setPageTitle('TAG - ' . Yii::t('default', 'Grades'));
-$cs->registerCssFile($themeUrl . '/css/template2.css');
+
 ?>
 
 <div class="main">

--- a/themes/default/views/instructor/_form.php
+++ b/themes/default/views/instructor/_form.php
@@ -11,7 +11,7 @@ $cs->registerScriptFile($baseUrl . '/js/instructor/form/_initialization.js', CCl
 $cs->registerScriptFile($baseUrl . '/js/instructor/form/functions.js', CClientScript::POS_END);
 $cs->registerScriptFile($baseUrl . '/js/instructor/form/validations.js', CClientScript::POS_END);
 $cs->registerScriptFile($baseUrl . '/js/instructor/form/pagination.js', CClientScript::POS_END);
-$cs->registerCssFile($themeUrl . '/css/template2.css');
+
 $cs->registerScript("VARS", "
     var GET_INSTITUTIONS = '" . $this->createUrl('instructor/getInstitutions') . "';
 ", CClientScript::POS_BEGIN);

--- a/themes/default/views/instructor/frequency.php
+++ b/themes/default/views/instructor/frequency.php
@@ -7,7 +7,7 @@
 	$themeUrl = Yii::app()->theme->baseUrl;
 	$cs = Yii::app()->getClientScript();
 	$cs->registerScriptFile($baseUrl . '/js/instructor/frequency.js', CClientScript::POS_END);
-	$cs->registerCssFile($themeUrl . '/css/template2.css');
+	
 	$this->setPageTitle('TAG - ' . Yii::t('default', 'Instructor frequency'));
     ?>
 <div class="main">

--- a/themes/default/views/instructor/index.php
+++ b/themes/default/views/instructor/index.php
@@ -7,7 +7,7 @@
     );
     $themeUrl = Yii::app()->theme->baseUrl;
     $cs = Yii::app()->getClientScript();
-    $cs->registerCssFile($themeUrl . '/css/template2.css');
+    
     ?>
 
 

--- a/themes/default/views/instructor/updateEmails.php
+++ b/themes/default/views/instructor/updateEmails.php
@@ -9,7 +9,7 @@
 	$themeUrl = Yii::app()->theme->baseUrl;
 	$cs = Yii::app()->getClientScript();
 	$cs->registerScriptFile($baseUrl . '/js/instructor/form/updateEmails.js', CClientScript::POS_END);
-	$cs->registerCssFile($themeUrl . '/css/template2.css');
+	
 	$this->setPageTitle('TAG - ' . Yii::t('default', 'Update Instructor e-mails'));
 
 	$form = $this->beginWidget('CActiveForm', [

--- a/themes/default/views/layouts/fullmenu.php
+++ b/themes/default/views/layouts/fullmenu.php
@@ -33,6 +33,33 @@ if (Yii::app()->user->isGuest) {
     $this->redirect(yii::app()->createUrl('site/login'));
 }
 
+$assetManager = Yii::app()->getAssetManager();
+$assetUrl = Yii::app()->theme->baseUrl;
+
+$cs = Yii::app()->getClientScript();
+
+// Base Layout 
+$cs->registerCssFile($assetUrl . "/css/bootstrap.min.css");
+$cs->registerCssFile($assetUrl . "/css/responsive.min.css");
+$cs->registerCssFile($assetUrl . "/css/print.css", "print");
+
+// 3rd party libraries
+$cs->registerCssFile($assetUrl . "/css/select2.css");
+$cs->registerCssFile($assetUrl . "/css/datatables.min.css");
+$cs->registerCssFile($assetUrl . "/css/bootstrap-datepicker.min.css");
+$cs->registerCssFile($assetUrl . '/js/jquery/fullcalendar/fullcalendar.css');
+$cs->registerCssFile($assetUrl . '/js/jquery/fullcalendar/fullcalendar.print.css', 'print');
+$cs->registerCssFile($assetUrl . '/css/jquery-ui-1.9.2.custom.min.css');
+$cs->registerCssFile($assetUrl . "/css/glyphicons.min.css");
+$cs->registerCssFile($assetUrl . '/css/font-awesome.min.css');
+
+// Custom styles
+$cs->registerCssFile($assetUrl . "/css/template.css?v=". TAG_VERSION);
+$cs->registerCssFile($assetUrl . '/css/template2.css?v='. TAG_VERSION);
+$cs->registerCssFile($assetUrl . "/css/admin.css?v=". TAG_VERSION);
+$cs->registerCssFile($assetUrl . "/css/home.css?v=". TAG_VERSION);
+$cs->registerCssFile(Yii::app()->baseUrl. "/sass/css/main.css?v=". TAG_VERSION);
+
 ?>
 <!DOCTYPE html>
 <!--[if lt IE 7]>
@@ -62,22 +89,6 @@ if (Yii::app()->user->isGuest) {
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
     <meta http-equiv="X-UA-Compatible" content="IE=9; IE=8; IE=7; IE=EDGE" />
 
-    <link href="<?php echo Yii::app()->theme->baseUrl; ?>/css/bootstrap.min.css" rel="stylesheet" type="text/css" />
-    <link href="<?php echo Yii::app()->theme->baseUrl; ?>/css/bootstrap-datepicker.min.css" rel="stylesheet" type="text/css" />
-    <link href="<?php echo Yii::app()->theme->baseUrl; ?>/css/responsive.min.css" rel="stylesheet" type="text/css" />
-    <link href="<?php echo Yii::app()->theme->baseUrl; ?>/css/template.css?v=1.2" rel="stylesheet" type="text/css" />
-    <link href="<?php echo Yii::app()->theme->baseUrl; ?>/css/template2.css" rel="stylesheet" type="text/css" />
-    <link href="<?php echo Yii::app()->baseUrl; ?>/sass/css/main.css" rel="stylesheet" type="text/css" />
-    <link href="<?php echo Yii::app()->theme->baseUrl; ?>/css/glyphicons.min.css" rel="stylesheet" type="text/css" />
-    <link href="<?php echo Yii::app()->theme->baseUrl; ?>/css/select2.css" rel="stylesheet" />
-    <link href="<?php echo Yii::app()->theme->baseUrl; ?>/css/print.css" media="print" rel="stylesheet" type="text/css" />
-    <link href="<?php echo Yii::app()->theme->baseUrl; ?>/css/admin.css" rel="stylesheet" type="text/css" />
-    <link rel='stylesheet' type='text/css' href='<?php echo Yii::app()->theme->baseUrl; ?>/js/jquery/fullcalendar/fullcalendar.css' />
-    <link rel='stylesheet' type='text/css' href='<?php echo Yii::app()->theme->baseUrl; ?>/js/jquery/fullcalendar/fullcalendar.print.css' media='print' />
-    <link rel='stylesheet' type='text/css' href='<?php echo Yii::app()->theme->baseUrl; ?>/css/jquery-ui-1.9.2.custom.min.css' />
-    <link rel='stylesheet' type='text/css' href='<?php echo Yii::app()->theme->baseUrl; ?>/css/font-awesome.min.css' />
-    <link rel="stylesheet" type="text/css" href="<?php echo Yii::app()->theme->baseUrl; ?>/css/home.css?v=1.0" />
-    <link rel="stylesheet" type="text/css" href="<?php echo Yii::app()->theme->baseUrl; ?>/css/datatables.min.css" />
 </head>
 
 <body>

--- a/themes/default/views/lunch/lunch/index.php
+++ b/themes/default/views/lunch/lunch/index.php
@@ -10,7 +10,7 @@ $themeUrl = Yii::app()->theme->baseUrl;
 $cs = Yii::app()->getClientScript();
 $cs->registerCssFile($baseScriptUrl . '/common/css/layout.css?v=1.0');
 $cs->registerScriptFile($baseScriptUrl . '/common/js/stock.js', CClientScript::POS_END);
-$cs->registerCssFile($themeUrl . '/css/template2.css');
+
 $cs->registerCssFile($baseUrl . '/css/lunch.css');
 ?>
 <div class="main">

--- a/themes/default/views/quiz/default/group/_form.php
+++ b/themes/default/views/quiz/default/group/_form.php
@@ -6,7 +6,6 @@ $cs = Yii::app()->getClientScript();
 $cs->registerCssFile($baseScriptUrl . '/common/css/layout.css?v=1.0');
 $cs->registerScriptFile($baseScriptUrl . '/common/js/quiz.js', CClientScript::POS_END);
 $this->setPageTitle('TAG - ' . Yii::t('default', 'Group'));
-$cs->registerCssFile($baseUrl . 'sass/css/main.css');
 
 
 $form = $this->beginWidget('CActiveForm', array(

--- a/themes/default/views/quiz/default/question/_form.php
+++ b/themes/default/views/quiz/default/question/_form.php
@@ -6,7 +6,6 @@ $cs = Yii::app()->getClientScript();
 $cs->registerCssFile($baseScriptUrl . '/common/css/layout.css?v=1.0');
 $cs->registerScriptFile($baseScriptUrl . '/common/js/quiz.js', CClientScript::POS_END);
 $this->setPageTitle('TAG - ' . Yii::t('default', 'Question'));
-$cs->registerCssFile($baseUrl . 'sass/css/main.css');
 
 
 $form = $this->beginWidget('CActiveForm', array(

--- a/themes/default/views/quiz/default/questiongroup/_form.php
+++ b/themes/default/views/quiz/default/questiongroup/_form.php
@@ -6,7 +6,6 @@ $cs = Yii::app()->getClientScript();
 $cs->registerCssFile($baseScriptUrl . '/common/css/layout.css?v=1.0');
 $cs->registerScriptFile($baseScriptUrl . '/common/js/quiz.js', CClientScript::POS_END);
 $this->setPageTitle('TAG - ' . Yii::t('Group', 'default'));
-$cs->registerCssFile($baseUrl . 'sass/css/main.css');
 
 Yii::app()->clientScript->registerMetaTag('unsafe-url', 'referrer');
 Yii::app()->clientScript->registerMetaTag('origin', 'referrer');

--- a/themes/default/views/quiz/default/quiz/_form.php
+++ b/themes/default/views/quiz/default/quiz/_form.php
@@ -10,8 +10,7 @@ $baseScriptUrl = Yii::app()->controller->module->baseScriptUrl;
 $cs = Yii::app()->getClientScript();
 $cs->registerCssFile($baseScriptUrl . '/common/css/layout.css?v=1.0');
 $cs->registerScriptFile($baseScriptUrl . '/common/js/quiz.js', CClientScript::POS_END);
-$cs->registerCssFile($themeUrl . '/css/template2.css');
-$cs->registerCssFile($baseUrl . 'sass/css/main.css');
+
 
 $this->setPageTitle('TAG - ' . Yii::t('default', 'Quiz'));
 

--- a/themes/default/views/school/_form.php
+++ b/themes/default/views/school/_form.php
@@ -11,9 +11,6 @@ $cs->registerScriptFile($baseUrl . '/js/school/form/_initialization.js', CClient
 $cs->registerScriptFile($baseUrl . '/js/school/form/functions.js', CClientScript::POS_END);
 $cs->registerScriptFile($baseUrl . '/js/school/form/validations.js', CClientScript::POS_END);
 $cs->registerScriptFile($baseUrl . '/js/school/form/pagination.js', CClientScript::POS_END);
-$cs->registerCssFile($themeUrl . '/css/template2.css');
-$cs->registerCssFile($baseUrl . 'sass/css/main.css');
-
 
 $form = $this->beginWidget('CActiveForm', array(
     'id' => 'school',

--- a/themes/default/views/school/index.php
+++ b/themes/default/views/school/index.php
@@ -7,7 +7,7 @@
     );
     $themeUrl = Yii::app()->theme->baseUrl;
     $cs = Yii::app()->getClientScript();
-    $cs->registerCssFile($themeUrl . '/css/template2.css');
+    
    
     ?>
 

--- a/themes/default/views/site/error.php
+++ b/themes/default/views/site/error.php
@@ -14,7 +14,7 @@
 	$themeUrl = Yii::app()->theme->baseUrl;
 	$cs = Yii::app()->getClientScript();
 	$cs->registerScriptFile($baseUrl . '/js/reports/BFReport/_initialization.js', CClientScript::POS_END);
-	$cs->registerCssFile($themeUrl . '/css/template2.css'); 
+	 
 
 ?>
 

--- a/themes/default/views/site/index.php
+++ b/themes/default/views/site/index.php
@@ -8,7 +8,7 @@
 	$cs->registerScriptFile(Yii::app()->theme->baseUrl . '/js/amcharts/pie.js', CClientScript::POS_END);
 	$cs->registerScriptFile(Yii::app()->theme->baseUrl . '/js/amcharts/lang/pt.js', CClientScript::POS_END);
 	$cs->registerScriptFile(Yii::app()->theme->baseUrl . '/js/amcharts/themes/light.js', CClientScript::POS_END);
-	$cs->registerCssFile($themeUrl . '/css/template2.css');
+	
 	/* @var $this SiteController */
 
 	$cs->registerScript("vars",

--- a/themes/default/views/site/login.php
+++ b/themes/default/views/site/login.php
@@ -9,7 +9,7 @@ $cs = Yii::app()->getClientScript();
 $cs->registerCssFile($baseUrl . '/css/bootstrap.min.css');
 $cs->registerCssFile($baseUrl . '/css/responsive.min.css');
 $cs->registerCssFile($baseUrl . '/css/template.css?v=1.0');
-$cs->registerCssFile($themeUrl . '/css/template2.css'); 
+ 
 $form = $this->beginWidget('CActiveForm', array(
     'id' => 'login-form',
     'enableClientValidation' => true,

--- a/themes/default/views/student/_form.php
+++ b/themes/default/views/student/_form.php
@@ -19,9 +19,7 @@ $cs->registerScriptFile($baseUrl . '/js/student/form/pagination.js', CClientScri
 $cs->registerScriptFile($baseUrl . '/js/enrollment/form/_initialization.js', CClientScript::POS_END);
 $cs->registerScriptFile($baseUrl . '/js/enrollment/form/validations.js', CClientScript::POS_END);
 $cs->registerScriptFile($baseUrl . '/js/enrollment/form/functions.js', CClientScript::POS_END);
-$cs->registerCssFile($themeUrl . '/css/template2.css');
-$cs->registerCssFile($baseUrl . 'sass/css/main.css');
-/* */
+
 $form = $this->beginWidget('CActiveForm', array(
     'id' => 'student',
     'enableAjaxValidation' => false,

--- a/themes/default/views/student/index.php
+++ b/themes/default/views/student/index.php
@@ -7,7 +7,7 @@
     );
     $themeUrl = Yii::app()->theme->baseUrl;
     $cs = Yii::app()->getClientScript();
-    $cs->registerCssFile($themeUrl . '/css/template2.css');
+    
     ?>
 
     <div class="row-fluid">

--- a/themes/default/views/timesheet/timesheet/index.php
+++ b/themes/default/views/timesheet/timesheet/index.php
@@ -22,7 +22,7 @@ $cs->registerScript(
         "var changeInstructorUrl = '" . $this->createUrl("changeInstructor") . "'; ",
     CClientScript::POS_HEAD
 );
-$cs->registerCssFile($themeUrl . '/css/template2.css');
+
 $this->setPageTitle('TAG - ' . Yii::t('timesheetModule.timesheet', 'Timesheet'));
 ?>
 

--- a/themes/default/views/wizard/configuration/classrooms.php
+++ b/themes/default/views/wizard/configuration/classrooms.php
@@ -18,7 +18,7 @@ $lastYear = (Yii::app()->user->year - 1);
 $school = Yii::app()->user->school;
 $themeUrl = Yii::app()->theme->baseUrl;
 $cs = Yii::app()->getClientScript();
-$cs->registerCssFile($themeUrl . '/css/template2.css');
+
 ?>
 <div class="main">
     <div class="row-fluid">

--- a/themes/default/views/wizard/configuration/index.php
+++ b/themes/default/views/wizard/configuration/index.php
@@ -8,7 +8,6 @@ $this->setPageTitle('TAG - ' .  Yii::t('default', 'Configurarion'));
 $baseUrl = Yii::app()->baseUrl;
 $baseUrl = Yii::app()->theme->baseUrl;
 $cs = Yii::app()->getClientScript();
-$cs->registerCssFile($baseUrl . 'sass/css/main.css');
 
 $form = $this->beginWidget('CActiveForm', array(
     'id' => 'school-configuration-form',

--- a/themes/default/views/wizard/configuration/school.php
+++ b/themes/default/views/wizard/configuration/school.php
@@ -18,7 +18,7 @@ $form = $this->beginWidget('CActiveForm', array(
 ));
 $themeUrl = Yii::app()->theme->baseUrl;
 $cs = Yii::app()->getClientScript();
-$cs->registerCssFile($themeUrl . '/css/template2.css');
+
 ?>
 <div class="main">
     <div class="row-fluid">

--- a/themes/default/views/wizard/configuration/students.php
+++ b/themes/default/views/wizard/configuration/students.php
@@ -6,10 +6,10 @@
 $baseUrl = Yii::app()->baseUrl;
 $themeUrl = Yii::app()->theme->baseUrl;
 $cs = Yii::app()->getClientScript();
+
 $cs->registerScriptFile($baseUrl . '/js/enrollment/form/_initialization.js', CClientScript::POS_END);
 $cs->registerScriptFile($baseUrl . '/js/enrollment/form/validations.js', CClientScript::POS_END);
 
-$cs->registerCssFile($themeUrl . '/css/template2.css');
 $form = $this->beginWidget('CActiveForm', array(
     'id' => 'school-configuration-form',
     'enableAjaxValidation' => false


### PR DESCRIPTION
# Motivação

Os navegadores tem mantido em cache arquivos de css do projeto mesmo quando eles são atualizados com correções de design. A alteração atual corrige o processo de registro e controle de versões dos arquivos css.

# Fatores de análise
- Uma forma de forçar o arquivo ser baixado novamente é aplicando o código de versão no fim da url como "?v=1.1";
- O método de importação foi alterado para aproveitar o sistema de controle do assetManager;
- É possível verificar essa alteração alternando em localhost da branch  master para essa branch;

