### PR TITLE
Fix/enrollment form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Atualizações
 
+## [Versão 3.25.63]
+- Agora o formulário de matrícula ao atualizar retorna para o formulário com os dados salvos
+
 ## [Versão 3.25.62]
 - Na tela de plano de aula os GIFs de loading foram atualizados
 - A cor do botão no card de justificativa quando o mouse passa em cima foi atualizado

--- a/app/controllers/EnrollmentController.php
+++ b/app/controllers/EnrollmentController.php
@@ -185,7 +185,7 @@ class EnrollmentController extends Controller
                 if ($model->save()) {
                     Log::model()->saveAction("enrollment", $model->id, "U", $model->studentFk->name . "|" . $model->classroomFk->name);
                     Yii::app()->user->setFlash('success', Yii::t('default', 'Matrícula alterada com sucesso!'));
-                    $this->redirect(array('student/'));
+                    // $this->redirect(array('student/'));
                 }
             }
         }

--- a/app/controllers/EnrollmentController.php
+++ b/app/controllers/EnrollmentController.php
@@ -151,9 +151,9 @@ class EnrollmentController extends Controller
     {
         $model = $this->loadModel($id);
 
-
+        $modelStudentIdentification = StudentIdentification::model()->find('inep_id="' . $model->student_inep_id . '"');
         if ($model->student_fk == NULL && $model->classroom_fk == NULL) {
-            $model->student_fk = StudentIdentification::model()->find('inep_id="' . $model->student_inep_id . '"')->id;
+            $model->student_fk = $modelStudentIdentification->id;
             $model->classroom_fk = Classroom::model()->find('inep_id="' . $model->classroom_inep_id . '"')->id;
         }
 
@@ -192,6 +192,7 @@ class EnrollmentController extends Controller
 
         $this->render('update', array(
             'model' => $model,
+            'modelStudentIdentification' => $modelStudentIdentification,
             'classrooms' => $classrooms
         ));
     }

--- a/app/modules/curricularcomponents/views/default/create.php
+++ b/app/modules/curricularcomponents/views/default/create.php
@@ -12,8 +12,8 @@ $this->menu=array(
 	array('label'=>'Manage EdcensoDiscipline', 'url'=>array('admin')),
 );
 
-$this->setPageTitle('TAG - ' . Yii::t('default', 'Add New Student'));
-$title = Yii::t('default', 'Add New Student');
+$this->setPageTitle('TAG - ' . Yii::t('default', 'Adicionar Componente Curricular'));
+$title = Yii::t('default', 'Adicionar Componente Curricular');
 
 ?>
 

--- a/app/modules/curricularcomponents/views/default/index.php
+++ b/app/modules/curricularcomponents/views/default/index.php
@@ -48,7 +48,7 @@ $title = Yii::t('default', 'Disciplines');
                     'enablePagination' => false,
                     'enableSorting' => false,
                     'ajaxUpdate' => false,
-                    'itemsCssClass' => 'js-tag-table tag-table table table-condensed table-striped table-hover table-primary table-vertical-center checkboxs',
+                    'itemsCssClass' => 'js-tag-table tag-table-primary tag-table table table-condensed table-striped table-hover table-primary table-vertical-center checkboxs',
                     'columns'=>array(
                         'id',
                         'name',

--- a/config.php
+++ b/config.php
@@ -2,7 +2,7 @@
 // defined('YII_DEBUG') or define('YII_DEBUG', true);
 defined('YII_DEBUG') or define('YII_DEBUG', false);
 
-define("TAG_VERSION", '3.25.62');
+define("TAG_VERSION", '3.25.63');
 
 
 define("YII_VERSION", Yii::getVersion());

--- a/themes/default/views/enrollment/_form.php
+++ b/themes/default/views/enrollment/_form.php
@@ -29,6 +29,16 @@ $form = $this->beginWidget('CActiveForm', array(
     <div class="widget widget-tabs border-bottom-none">
 
         <?php echo $form->errorSummary($model); ?>
+        <?php if (Yii::app()->user->hasFlash('error')) : ?>
+            <div class="alert alert-error">
+                <?php echo Yii::app()->user->getFlash('error') ?>
+            </div>
+        <?php endif ?>
+        <?php if (Yii::app()->user->hasFlash('success')) : ?>
+            <div class="alert alert-success">
+                <?php echo Yii::app()->user->getFlash('success') ?>
+            </div>
+        <?php endif ?>
         <div class="alert alert-error enrollment-error no-show"></div>
         <h1 style="margin-left: 20px;"><?php echo $modelStudentIdentification->name ?></h1>
         <div class="t-tabs">

--- a/themes/default/views/enrollment/_form.php
+++ b/themes/default/views/enrollment/_form.php
@@ -12,25 +12,25 @@ $form = $this->beginWidget('CActiveForm', array(
 ?>
 
 
-<div class="row-fluid">
+<div class="row" style="margin-left: 20px;">
     <div class="span12">
         <h1><?php echo $title; ?>
             <span> | <?php echo Yii::t('default', 'Fields with * are required.') ?></h1>
-        <div class="buttons">
-            <button class="btn btn-icon btn-primary last glyphicons circle_ok save-enrollment"
-                    type="button">
-                <i></i> <?= $model->isNewRecord ? Yii::t('default', 'Enroll') : Yii::t('default', 'Save') ?>
-            </button>
+        <div class="tag-buttons-container buttons hide-responsive">
+            <button class="t-button-primary last  save-enrollment"type="button">
+                <?= $model->isNewRecord ? Yii::t('default', 'Enroll') : Yii::t('default', 'Save') ?>
+            </button>   
         </div>
     </div>
 </div>
 
-<div class="innerLR">
+<div class="tag-inner">
 
     <div class="widget widget-tabs border-bottom-none">
 
         <?php echo $form->errorSummary($model); ?>
         <div class="alert alert-error enrollment-error no-show"></div>
+        <h1 style="margin-left: 20px;"><?php echo $modelStudentIdentification->name ?></h1>
         <div class="t-tabs">
             <ul class="t-tabs__list">
                 <li class="t-tabs__item active"><a href="#enrollment" class="t-tabs__link" data-toggle="tab">

--- a/themes/default/views/enrollment/update.php
+++ b/themes/default/views/enrollment/update.php
@@ -21,6 +21,7 @@
             <?php            
              echo $this->renderPartial('_form', array(
                 'model' => $model,
+                'modelStudentIdentification' => $modelStudentIdentification,
                 'transoption'=> $transoption,
                 'classrooms' => $classrooms,
                 'title' => $title)); 


### PR DESCRIPTION
### TAG Change Documentation
This pull request aims to document the following changes to the TAG:

- Return to Enrollment Form on Update
  - Currently, when updating the registration form in the TAG, the user is redirected to the students page, which can be confusing and inconvenient. This change proposes an improvement in the flow, causing the registration form to return to the same page with the data saved after the update.

- Correction of the title in the curricular component form