### PR TITLE
Refactor/removal of calculate average button (version 3.34.74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Atualizações
 
+## [Versão 3.34.74]
+- O botão inoperante de calcular média na página de notas foi removido
 
 ## [Versão 3.28.71]
 - Corrigido o estilo do alerta de quadro de horários em aulas ministradas

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.33.73');
+define("TAG_VERSION", '3.34.74');
 
 
 define("YII_VERSION", Yii::getVersion());

--- a/js/enrollment/grades/_initialization.js
+++ b/js/enrollment/grades/_initialization.js
@@ -162,23 +162,23 @@ $(document).on("keyup", "input.grade", function (e) {
     this.value = val;
 });
 
-$(document).on("click", ".calculate-media", function (e) {
-    e.preventDefault();
-    $(".js-grades-alert").hide();
-    $.ajax({
-        type: "POST",
-        url: "?r=enrollment/calculateFinalMedia",
-        cache: false,
-        data: {
-            classroom: $("#classroom").val(),
-            discipline: $("#discipline").val(),
-        },
-        beforeSend: function () {
-            $(".js-grades-loading").css("display", "inline-block");
-            $(".js-grades-container, .grades-buttons").css("opacity", "0.4").css("pointer-events", "none");
-        },
-        success: function (data) {
-            $("#discipline").trigger("change");
-        },
-    });
-});
+// $(document).on("click", ".calculate-media", function (e) {
+//     e.preventDefault();
+//     $(".js-grades-alert").hide();
+//     $.ajax({
+//         type: "POST",
+//         url: "?r=enrollment/calculateFinalMedia",
+//         cache: false,
+//         data: {
+//             classroom: $("#classroom").val(),
+//             discipline: $("#discipline").val(),
+//         },
+//         beforeSend: function () {
+//             $(".js-grades-loading").css("display", "inline-block");
+//             $(".js-grades-container, .grades-buttons").css("opacity", "0.4").css("pointer-events", "none");
+//         },
+//         success: function (data) {
+//             $("#discipline").trigger("change");
+//         },
+//     });
+// });

--- a/themes/default/views/enrollment/grades.php
+++ b/themes/default/views/enrollment/grades.php
@@ -30,7 +30,7 @@ $this->setPageTitle('TAG - ' . Yii::t('default', 'Grades'));
         <div class="span12">
             <h1><?php echo Yii::t('default', 'Grades'); ?></h1>
             <div class="buttons row grades-buttons">
-                <button class='t-button-primary calculate-media'>Calcular Média</button>
+                <!--<button class='t-button-primary calculate-media'>Calcular Média</button>-->
                 <button id="save"
                    class='t-button-primary  hidden-print no-show'><?php echo Yii::t('default', 'Save') ?>
                 </button>


### PR DESCRIPTION
## Pull Request: Removed dead average calculate button on grades page

### Description of changes:
This pull request aims to document the following changes made to the TAG source code:
- Removed the inoperative calculate average button on the grades page.

### Motivation:
Removing the inoperative calculate average button on the grades page is necessary to improve usability and ensure a smoother experience for TAG users. The calculate average button was present on the page, but it did not have associated functionality, which can lead to confusion and frustration for users.