### PR TITLE
Fix/hide sagres button

### DIFF
--- a/themes/default/views/layouts/fullmenu.php
+++ b/themes/default/views/layouts/fullmenu.php
@@ -326,6 +326,7 @@ $cs->registerCssFile(Yii::app()->baseUrl. "/sass/css/main.css?v=". TAG_VERSION);
                                             <span class="t-menu-item__text">Educacenso</span>
                                         </a>
                                     </li>
+                                    <?php if (INSTANCE != "BUZIOS") { ?>
                                     <li class="t-menu-item <?= strpos($_SERVER['REQUEST_URI'], "?r=sagres") ? 'active' : '' ?>">
                                         <a class="t-menu-item__link" href="<?php echo yii::app()->createUrl('sagres') ?> ">
                                             <span class="t-icon-sagres t-menu-item__icon"></span>
@@ -333,6 +334,7 @@ $cs->registerCssFile(Yii::app()->baseUrl. "/sass/css/main.css?v=". TAG_VERSION);
                                             <span class="t-menu-item__text">Sagres</span>
                                         </a>
                                     </li>
+                                    <?php } ?>
                                     <?php if (INSTANCE == "UBATUBA" || INSTANCE == "TREINAMENTO" || INSTANCE == "LOCALHOST" || INSTANCE == "DEMO") { ?>
                                         <li class="t-menu-item <?= strpos($_SERVER['REQUEST_URI'], "?r=sedsp") ? 'active' : '' ?>">
                                             <a class="t-menu-item__link" href="<?php echo yii::app()->createUrl('sedsp') ?>">


### PR DESCRIPTION
## Pull Request: Hide Sagres button for the municipality of Búzios/RJ
### Description of changes:
This pull request implements the hiding of the Sagres button in the specific integrations menu for the municipality of Búzios/RJ in the TAG.

### Details of the changes:
- Added a condition in the integrations menu code to check if the current municipality is Búzios/RJ.
- If it is detected that the municipality is Búzios/RJ, the Sagres button will be hidden dynamically, preventing users from the municipality from having access to this functionality.