### PR TITLE
fix(grades): The final average is deleted when all the student's grad…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Atualizações
 
+##  [Versão 3.36.76]
+- A média final é excluída quando todas as notas do aluno são excluídas
 ## [Versão 3.36.75]
 - O botão inoperante de calcular média na página de notas foi removido
 

--- a/app/controllers/AdminController.php
+++ b/app/controllers/AdminController.php
@@ -436,7 +436,7 @@ class AdminController extends Controller
         return str_replace($search, $replace, $value);
     }
   
-    public
+    /* public
     function actionImportMaster()
     {
         set_time_limit(0);
@@ -461,7 +461,7 @@ class AdminController extends Controller
         fclose($fileImport);
         $json = unserialize($jsonSyncTag);
         $this->loadMaster($json);
-    }
+    } */
 
     public
     function loadMaster($loads)
@@ -678,7 +678,7 @@ class AdminController extends Controller
         return $loads;
     }
 
-    public
+    /* public
     function actionExportMaster()
     {
         try {
@@ -740,7 +740,7 @@ class AdminController extends Controller
             fclose($file);
             unlink($fileName);
         }
-    }
+    } */
 
     public function actionManageUsers()
     {

--- a/app/controllers/EnrollmentController.php
+++ b/app/controllers/EnrollmentController.php
@@ -319,13 +319,15 @@ class EnrollmentController extends Controller
             }
         }
     }
-
+//////////
     public function actionSaveGrades()
     {
         // $hasFinalMediaCalculated = false;
         foreach ($_POST["students"] as $student) {
+            $allGradesEmpty = true;
             foreach ($student["grades"] as $grade) {
                 if ($grade["value"] != "" || ($_POST["isConcept"] == "1" && $grade["concept"] != "")) {
+                    $allGradesEmpty = false;
 
                     $gradeObject = Grade::model()->find("enrollment_fk = :enrollment and grade_unity_modality_fk = :modality and discipline_fk = :discipline_fk", [":enrollment" => $student["enrollmentId"], ":modality" => $grade["modalityId"], ":discipline_fk" => $_POST["discipline"]]);
                     if ($gradeObject == null) {
@@ -348,6 +350,9 @@ class EnrollmentController extends Controller
             // if ($gradeResult != null) {
             //     $hasFinalMediaCalculated = true;
             // }
+            if($allGradesEmpty){
+                GradeResults::model()->deleteAll("enrollment_fk = :enrollment_fk and discipline_fk = :discipline_fk", ["enrollment_fk" => $student["enrollmentId"], "discipline_fk" => $_POST["discipline"]]);
+            }
         }
         // if ($hasFinalMediaCalculated) {
         //     $this->calculateFinalMedia();

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.35.75');
+define("TAG_VERSION", '3.36.76');
 
 
 define("YII_VERSION", Yii::getVersion());

--- a/instance.php
+++ b/instance.php
@@ -12,7 +12,7 @@ $domain = array_shift((explode(".",$_SERVER['HTTP_HOST'])));
 $newdb = $domain.'.tag.ong.br';
 
 if($domain == "localhost"){
-    $newdb = 'nossasenhoradagloria.tag.ong.br';
+    $newdb = 'demo.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;


### PR DESCRIPTION
### Descrição do Problema
quando um usuário deletava todas as notas de um aluno em uma matéria na tela de notas a média final permanecia pois as notas só eram excluidas da tabela grades e não da tabela grades_results  que é usada para calcular a média anual. Isso fazia também fazia com que o relatório de notas por aluno permanecesse com as notas que foram excluídas e a média pois ele é gerado a partir de grades_result

![image](https://github.com/ipti/br.tag/assets/115715913/8fd9ad70-dc38-4ac3-b2b3-8aece1342b55)
![image](https://github.com/ipti/br.tag/assets/115715913/54af22b5-c437-4e4b-a75a-dba2beaefd33)

### Solução
Criei uma validação no controller responsável por salvar as notas dos alunos. Essa validação verifica se todas as notas foram excluídas. Caso todas as notas tenham sido excluídas, ele também exclui a média final

![image](https://github.com/ipti/br.tag/assets/115715913/944448ef-faf1-46de-92e7-879cfeb925f9)
![image](https://github.com/ipti/br.tag/assets/115715913/b341af61-da62-4dca-9c0e-7f1eb8d8eef2)
