### PR TITLE
Hotfix/added handling for sum of saved grades greater than ten

### DIFF
--- a/app/controllers/EnrollmentController.php
+++ b/app/controllers/EnrollmentController.php
@@ -598,7 +598,10 @@ class EnrollmentController extends Controller
                             }
                             $sumsCount++;
 
-                            $gradeResult["grade_" . ($gradeIndex + 1)] = $grade["unityGrade"] != "" ? number_format($grade["unityGrade"], 1) : null;
+                            $resultGradeResult = $grade["unityGrade"] != "" ? number_format($grade["unityGrade"], 1) : null;
+
+                            $gradeResult["grade_" . ($gradeIndex + 1)] = $resultGradeResult  <= 10.0 ? $resultGradeResult : 10.0;
+                            
                             $gradeIndex++;
                             break;
                         case "UR":
@@ -609,7 +612,10 @@ class EnrollmentController extends Controller
                             }
                             $sumsCount++;
 
-                            $gradeResult["grade_" . ($gradeIndex + 1)] = $grade["unityGrade"] != "" ? number_format($grade["unityGrade"], 1) : null;
+                            $resultGradeResult = $grade["unityGrade"] != "" ? number_format($grade["unityGrade"], 1) : null;
+
+                            $gradeResult["grade_" . ($gradeIndex + 1)] = $resultGradeResult  <= 10.0 ? $resultGradeResult : 10.0;
+
                             $gradeResult["rec_bim_" . ($gradeIndex + 1)] = $grade["unityRecoverGrade"] != "" ? number_format($grade["unityRecoverGrade"], 1) : null;
                             $gradeIndex++;
                             break;


### PR DESCRIPTION
## Problem with grades greater than ten in GradeResults :ambulance:

### Description
A problem was seen regarding the logic of grades when saving in GradeResults, what was happening was that when having a sum greater than 10 it was still saving in the fixed columns of grade_1, grade_2.

### Solution
The problem was fixed by adding an extra variable to store the result of the count, and when assigning the model to check if it is greater than 10, if it is going to be saved as 10. For example, two notes 8.5 and 10 added together will be saved as 10 instead of 18.5.