### PR TITLE
Fix/removal of tag logo image on home page

### DIFF
--- a/themes/default/views/site/index.php
+++ b/themes/default/views/site/index.php
@@ -30,7 +30,8 @@
 <div class="main">
 	<div class="row-fluid">
 		<div class="span12">
-			<h1>Bem vindo ao <img class="tag-logo"  alt="tag logo" style="width:65px;" src="<?php echo Yii::app()->theme->baseUrl; ?>/img/tag_navbar.svg" /></h1>
+			<h1>Bem vindo ao Tag
+				<!-- <img class="tag-logo"  alt="tag logo" style="width:65px;" src="<?php echo Yii::app()->theme->baseUrl; ?>/img/tag_navbar.svg" /></h1> -->
 		</div>
 	</div>
 	<div class="tag-inner eggs">


### PR DESCRIPTION
Removed the logo image in the welcome phrase on the home page.
![image](https://github.com/ipti/br.tag/assets/107931809/a98c8531-0e9f-452e-bbdb-120e7129ef0d)
