### PR TITLE
Fix: correction in edcenso_city for sedsp

### DIFF
--- a/app/modules/sedsp/mappers/StudentMapper.php
+++ b/app/modules/sedsp/mappers/StudentMapper.php
@@ -115,7 +115,7 @@ class StudentMapper
             $studentIdentification->edcenso_nation_fk = $outDadosPessoais->getOutCodPaisOrigem();
         }
         $studentIdentification->edcenso_uf_fk = intval(EdcensoUf::model()->find("acronym = :acronym", [":acronym" => $outDadosPessoais->getOutUfMunNascto()])->id);
-        $studentIdentification->edcenso_city_fk = intval(EdcensoCity::model()->find("name = :name", [":name" => $outDadosPessoais->getOutNomeMunNascto()])->id);
+        $studentIdentification->edcenso_city_fk = intval(EdcensoCity::model()->find("name = :name", [":name" => $outEnderecoResidencial->getOutNomeCidade()])->id);
         $studentIdentification->deficiency = 0;
         $studentIdentification->send_year = intval(Yii::app()->user->year);
 

--- a/app/modules/sedsp/usecases/Student/GetExibirFichaAlunoFromSEDUseCase.php
+++ b/app/modules/sedsp/usecases/Student/GetExibirFichaAlunoFromSEDUseCase.php
@@ -44,6 +44,7 @@ class GetExibirFichaAlunoFromSEDUseCase
     {
         $studentDocumentsAndAddress = new StudentDocumentsAndAddress();
         $studentDocumentsAndAddress->attributes = $attributes->getAttributes();
+        $studentDocumentsAndAddress->edcenso_city_fk = $attributes->edcenso_city_fk;
         $studentDocumentsAndAddress->gov_id = $gov_id;
         $studentDocumentsAndAddress->id = $studentIdentification->id;
 


### PR DESCRIPTION
- [x] ❌ [Fix: correction in edcenso_city for sedsp](https://github.com/ipti/br.tag/commit/e4564ff7bc89b6694c8afb1efe39cc9c7e15ce94) 

Corrected $studentIdentification->edcenso_city_fk to receive the code based on the name of the city where the student currently lives.