### PR TITLE
Fix/grades exhibition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.63.100]
+- Corrigido a questão das notas sumirem quando eram salvas
+
 ## [Versão 3.63.99]
 - Corrigido a visibilidade de aulas datas em lançamentos de notas
 

--- a/app/controllers/EnrollmentController.php
+++ b/app/controllers/EnrollmentController.php
@@ -401,6 +401,7 @@ class EnrollmentController extends Controller
                 if ($grade["value"] != "" || ($_POST["isConcept"] == "1" && $grade["concept"] != "")) {
 
                     $gradeObject = Grade::model()->find("enrollment_fk = :enrollment and grade_unity_modality_fk = :modality and discipline_fk = :discipline_fk", [":enrollment" => $student["enrollmentId"], ":modality" => $grade["modalityId"], ":discipline_fk" => $_POST["discipline"]]);
+
                     if ($gradeObject == null) {
                         $gradeObject = new Grade();
                         $gradeObject->enrollment_fk = $student["enrollmentId"];
@@ -414,7 +415,7 @@ class EnrollmentController extends Controller
                     }
                     $gradeObject->save();
                 } else {
-                    Grade::model()->deleteAll("enrollment_fk = :enrollment and grade_unity_modality_fk = :modality", [":enrollment" => $student["enrollmentId"], ":modality" => $grade["modalityId"]]);
+                    Grade::model()->deleteAll("enrollment_fk = :enrollment and grade_unity_modality_fk = :modality and discipline_fk = :discipline", [":enrollment" => $student["enrollmentId"], ":modality" => $grade["modalityId"], ":discipline" => $_POST["discipline"]]);
                 }
             }
             // $gradeResult = GradeResults::model()->find("enrollment_fk = :enrollment_fk and discipline_fk = :discipline_fk", ["enrollment_fk" => $student["enrollmentId"], "discipline_fk" => $_POST["discipline"]]);

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.63.99');
+define("TAG_VERSION", '3.63.100');
 
 
 define("YII_VERSION", Yii::getVersion());


### PR DESCRIPTION
## Motivação
- Por conta da falta de verificação de disciplina em salvar notas, ocorria um problema no qual as notas dos alunos, previamente cadastradas estavam sendo excluídas do banco de dados.

## Alterações Realizadas
- Corrigido a questão das notas sumirem quando eram salvas.
- Adicionando a verificação de diciplina em salvar notas. 

## Fluxo de Teste
- Ir na tela de notas.
- Selecionar uma turma e uma disciplina.
- Salvar notas dos alunos.
- Modificar a disciplina.
- Salvar notas dos alunos.
- Retornar para a primeira disciplina
- Verificar se as notas permanecem.

## Migrations Utilizadas
- Não foi criada nenhuma migration.

## Teste de aceitação
- [ ] Tem teste de aceitação. 
