### PR TITLE
Fix/correction form email

### DIFF
--- a/app/models/StudentIdentification.php
+++ b/app/models/StudentIdentification.php
@@ -137,7 +137,7 @@ class StudentIdentification extends AltActiveRecord {
             array('school_inep_id_fk', 'length', 'max'=>8),
             array('inep_id', 'length', 'max'=>12),
             array('name, filiation_1, filiation_2', 'length', 'max'=>100),
-            array('id_email', 'length', 'max'=>255),
+            array('id_email, email_responsable', 'length', 'max'=>255),
             array('id_email', 'email'),
             array('birthday, filiation_1_birthday, filiation_2_birthday', 'length', 'max'=>10),
             array('responsable_name', 'length', 'max'=>90),

--- a/themes/default/views/student/_form.php
+++ b/themes/default/views/student/_form.php
@@ -392,14 +392,14 @@ $form = $this->beginWidget('CActiveForm', array(
                         <div class="column clearleft is-two-fifths">
                             <div class=" t-field-text js-hide-not-required" id="emailResponsable">
                                 <?php echo $form->labelEx(
-                                    $modelStudentIdentification, 'email_responsable', 
+                                    $modelStudentIdentification, 'email_responsable',
                                     array('class' => 't-field-text__label')
                                 ); ?>
-                                <?php echo $form->textField($modelStudentIdentification, 'email_responsable', 
+                                <?php echo $form->textField($modelStudentIdentification, 'email_responsable',
                                 array(
-                                    'size' => 60, 
-                                    'maxlength' => 255, 
-                                    'class' => 't-field-text__input', 
+                                    'size' => 60,
+                                    'maxlength' => 255,
+                                    'class' => 't-field-text__input',
                                     'placeholder' => 'Digite o Email'
                                 )); ?>
                                 <?php echo $form->error($modelStudentIdentification, 'email_responsable'); ?>

--- a/themes/default/views/student/_form.php
+++ b/themes/default/views/student/_form.php
@@ -391,8 +391,17 @@ $form = $this->beginWidget('CActiveForm', array(
                         <!-- Email responsável -->
                         <div class="column clearleft is-two-fifths">
                             <div class=" t-field-text js-hide-not-required" id="emailResponsable">
-                                <?php echo $form->labelEx($modelStudentIdentification, 'email_responsable', array('class' => 't-field-text__label')); ?>
-                                <?php echo $form->textField($modelStudentIdentification, 'email_responsable', array('size' => 60, 'maxlength' => 255, 'class' => 't-field-text__input', 'placeholder' => 'Digite o Email')); ?>
+                                <?php echo $form->labelEx(
+                                    $modelStudentIdentification, 'email_responsable', 
+                                    array('class' => 't-field-text__label')
+                                ); ?>
+                                <?php echo $form->textField($modelStudentIdentification, 'email_responsable', 
+                                array(
+                                    'size' => 60, 
+                                    'maxlength' => 255, 
+                                    'class' => 't-field-text__input', 
+                                    'placeholder' => 'Digite o Email'
+                                )); ?>
                                 <?php echo $form->error($modelStudentIdentification, 'email_responsable'); ?>
                             </div>
                         </div>

--- a/themes/default/views/student/_form.php
+++ b/themes/default/views/student/_form.php
@@ -391,9 +391,9 @@ $form = $this->beginWidget('CActiveForm', array(
                         <!-- Email responsável -->
                         <div class="column clearleft is-two-fifths">
                             <div class=" t-field-text js-hide-not-required" id="emailResponsable">
-                                <?php echo $form->labelEx($modelStudentIdentification, 'id_email', array('class' => 't-field-text__label')); ?>
-                                <?php echo $form->textField($modelStudentIdentification, 'id_email', array('size' => 60, 'maxlength' => 255, 'class' => 't-field-text__input', 'placeholder' => 'Digite o Email')); ?>
-                                <?php echo $form->error($modelStudentIdentification, 'id_email'); ?>
+                                <?php echo $form->labelEx($modelStudentIdentification, 'email_responsable', array('class' => 't-field-text__label')); ?>
+                                <?php echo $form->textField($modelStudentIdentification, 'email_responsable', array('size' => 60, 'maxlength' => 255, 'class' => 't-field-text__input', 'placeholder' => 'Digite o Email')); ?>
+                                <?php echo $form->error($modelStudentIdentification, 'email_responsable'); ?>
                             </div>
                         </div>
                         <!-- Profissião do responsavel -->


### PR DESCRIPTION
### 📦 Commits

❌[Fix: modified email column](https://github.com/ipti/br.tag/commit/2e3c40512bc51d8cf711cda9b9025d2c07a200ad)
✅[Feat: added email_responsable to roles](https://github.com/ipti/br.tag/commit/45563d97434d540031c58bb735e844d488d24051)

### 🐞 Problema Encontrado
Ao preencher o campo de e-mail na primeira seção, "Dados do Aluno", e avançar para a próxima etapa, "Filiação", o campo correspondente ao e-mail permanecia vazio. Este problema ocorria devido à vinculação dos campos de e-mail nas seções "Dados do Aluno" e "Filiação" à mesma coluna no banco de dados.

### 💡Solução Implementada
Foi adicionada uma nova coluna para armazenar o endereço de e-mail do responsável. Assim,  o aluno tem seu o seu campo de  e-mail, enquanto o responsável tem o seu próprio campo.

### 🔄 Migration
```
ALTER TABLE student_identification
ADD COLUMN email_responsable VARCHAR(255) NULL AFTER id_email;
```

