### PR TITLE
Fix: correction of student color selection

### DIFF
--- a/app/modules/sedsp/mappers/StudentMapper.php
+++ b/app/modules/sedsp/mappers/StudentMapper.php
@@ -28,7 +28,12 @@ class StudentMapper
         $inDadosPessoais->setInNomeMae($studentIdentificationTag->filiation_1);
         $inDadosPessoais->setInNomePai($studentIdentificationTag->filiation_2);
         $inDadosPessoais->setInDataNascimento($studentIdentificationTag->birthday);
-        $inDadosPessoais->setInCorRaca($studentIdentificationTag->color_race);
+        
+        // Converte o valor '0' (Não declarada) para '6' no campo de cor/raça da sedsp
+        $inDadosPessoais->setInCorRaca(
+            $studentIdentificationTag->color_race === '0' ? '6' : $studentIdentificationTag->color_race
+        );
+        
         $inDadosPessoais->setInSexo($studentIdentificationTag->sex);
         $inDadosPessoais->setInBolsaFamilia($studentIdentificationTag->bf_participator);
         $inDadosPessoais->setInEmail($studentIdentificationTag->id_email);


### PR DESCRIPTION
### 📦 Commits
❌ [Fix: correction of student color selection](https://github.com/ipti/br.tag/commit/eea9b51461c468a02bd403eef36a0e8bb993d35d)

### 🐞 Problema Encontrado
Na seção de "**Dados do Aluno**" ao selecionar a opção "**Não declarada**" ocorria um erro de mapeamento com a sed.

### 💡Solução Implementada
Foi realizado o mapeamento da opção de cor "**Não declarada**" para ficar em conformidade com os requisitos da sedsp

```
// Converte o valor '0' (Não declarada) para '6' no campo de cor/raça da sedsp
$inDadosPessoais->setInCorRaca(
      $studentIdentificationTag->color_race === '0' ? '6' : $studentIdentificationTag->color_race
);
```