### PR TITLE
Feat/required scenario student sedsp

### DIFF
--- a/app/controllers/StudentController.php
+++ b/app/controllers/StudentController.php
@@ -351,6 +351,10 @@ class StudentController extends Controller implements AuthenticateSEDTokenInterf
             date_default_timezone_set("America/Recife");
             $modelStudentIdentification->last_change = date('Y-m-d G:i:s');
 
+            if(Yii::app()->features->isEnable("FEAT_SEDSP")){
+                $modelStudentIdentification->scenario = "formSubmit";
+            }
+
 
             if ($modelStudentIdentification->validate() && $modelStudentDocumentsAndAddress->validate()) {
 

--- a/app/models/StudentIdentification.php
+++ b/app/models/StudentIdentification.php
@@ -133,7 +133,7 @@ class StudentIdentification extends AltActiveRecord {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
         return array(
-            array('school_inep_id_fk, birthday, sex, name, color_race, filiation, nationality, edcenso_city_fk, edcenso_uf_fk, edcenso_nation_fk, deficiency, send_year', 'required'),
+            array('school_inep_id_fk, birthday, sex, name, color_race, filiation, nationality, edcenso_nation_fk, deficiency, send_year', 'required'),
             array('sex, color_race, filiation, scholarity, nationality, edcenso_nation_fk, edcenso_uf_fk, edcenso_city_fk, deficiency, deficiency_type_blindness, deficiency_type_low_vision, deficiency_type_monocular_vision, deficiency_type_deafness, deficiency_type_disability_hearing, deficiency_type_deafblindness, deficiency_type_phisical_disability, deficiency_type_intelectual_disability, deficiency_type_multiple_disabilities, deficiency_type_autism, deficiency_type_aspenger_syndrome, deficiency_type_rett_syndrome, deficiency_type_childhood_disintegrative_disorder, deficiency_type_gifted, resource_aid_lector, resource_aid_transcription, resource_interpreter_guide, resource_interpreter_libras, resource_lip_reading, resource_zoomed_test_16, resource_zoomed_test_20, resource_zoomed_test_24, resource_zoomed_test_18, resource_braille_test, resource_proof_language, resource_cd_audio, resource_video_libras, resource_none, send_year, responsable, responsable_scholarity, filiation_1_scholarity, filiation_2_scholarity, bf_participator, no_document_desc', 'numerical', 'integerOnly'=>true),
             array('register_type', 'length', 'max'=>2),
             array('school_inep_id_fk', 'length', 'max'=>8),

--- a/app/models/StudentIdentification.php
+++ b/app/models/StudentIdentification.php
@@ -134,6 +134,7 @@ class StudentIdentification extends AltActiveRecord {
         // will receive user inputs.
         return array(
             array('school_inep_id_fk, birthday, sex, name, color_race, filiation, nationality, edcenso_nation_fk, deficiency, send_year', 'required'),
+            array('edcenso_uf_fk, edcenso_city_fk', 'required','on' => 'formSubmit'),
             array('sex, color_race, filiation, scholarity, nationality, edcenso_nation_fk, edcenso_uf_fk, edcenso_city_fk, deficiency, deficiency_type_blindness, deficiency_type_low_vision, deficiency_type_monocular_vision, deficiency_type_deafness, deficiency_type_disability_hearing, deficiency_type_deafblindness, deficiency_type_phisical_disability, deficiency_type_intelectual_disability, deficiency_type_multiple_disabilities, deficiency_type_autism, deficiency_type_aspenger_syndrome, deficiency_type_rett_syndrome, deficiency_type_childhood_disintegrative_disorder, deficiency_type_gifted, resource_aid_lector, resource_aid_transcription, resource_interpreter_guide, resource_interpreter_libras, resource_lip_reading, resource_zoomed_test_16, resource_zoomed_test_20, resource_zoomed_test_24, resource_zoomed_test_18, resource_braille_test, resource_proof_language, resource_cd_audio, resource_video_libras, resource_none, send_year, responsable, responsable_scholarity, filiation_1_scholarity, filiation_2_scholarity, bf_participator, no_document_desc', 'numerical', 'integerOnly'=>true),
             array('register_type', 'length', 'max'=>2),
             array('school_inep_id_fk', 'length', 'max'=>8),


### PR DESCRIPTION
## Motivação
Ao tentar cadastrar um estudante estrangeiro, ocorria uma mensagem de erro pois os campos de estado e cidade encontravam-se vazios. Ambos os campos eram obrigatórios no sistema, o que impossibilitava cadastrar um estudante estrangeiro.

## Alterações Realizadas
Foi implementado um cenário para cadastrar o estudante. Caso ele tenha vinculo com o Sedsp, os campos continuam como obrigatórios, seguindo os parâmetros e logísticas do sistema. Entretanto, caso seja um aluno sem vinculo ao Sedsp, ambos os campos de estado e cidade não se encontram mais como obrigatórios, possibilitando assim, cadastrar o estudante.

## Fluxo de Teste
-Cadastro de estudante (normal)
-Cadastro de estudante (ativando o sedsp)

## Migrations Utilizadas
Nenhuma

## Teste de aceitação
- [ ] Tem teste de aceitação. 
