### PR TITLE
Fix: sagres-generation

### DIFF
--- a/app/modules/sagres/controllers/DefaultController.php
+++ b/app/modules/sagres/controllers/DefaultController.php
@@ -75,11 +75,10 @@ class DefaultController extends Controller
 		}
 	}
 
-
 	public function actionDownload(){
 
-		
-		$fileDir = "./app/export/SagresEdu/Educacao.zip";
+		$inst = "Edu" . INSTANCE . "/";
+		$fileDir = "./app/export/SagresEdu/" . $inst . "Educacao.zip";
         if (file_exists($fileDir)) {
             header('Content-Description: File Transfer');
             header('Content-type: application/zip');

--- a/app/modules/sagres/controllers/DefaultController.php
+++ b/app/modules/sagres/controllers/DefaultController.php
@@ -77,7 +77,7 @@ class DefaultController extends Controller
 
 	public function actionDownload(){
 
-		$inst = "Edu" . INSTANCE . "/";
+		$inst = "File_" . INSTANCE . "/";
 		$fileDir = "./app/export/SagresEdu/" . $inst . "Educacao.zip";
         if (file_exists($fileDir)) {
             header('Content-Description: File Transfer');

--- a/app/modules/sagres/models/SagresConsultModel.php
+++ b/app/modules/sagres/models/SagresConsultModel.php
@@ -1133,19 +1133,23 @@ class SagresConsultModel
     public function actionExportSagresXML($xml)
     {       
         $fileName = "Educacao.xml";
-        $fileDir = "./app/export/SagresEdu/" . $fileName;
 
+        $inst = "File_" . INSTANCE . "/";
+        $path = "./app/export/SagresEdu/" . $inst;
+
+        if(!file_exists($path)){
+            mkdir($path);
+        }
+       
+        $fileDir = "./app/export/SagresEdu/". $inst . $fileName;
         Yii::import('ext.FileManager.fileManager');
         $fm = new fileManager();
         $result = $fm->write($fileDir, $xml);
-        
-        if ($result == false) {                    
+        if ($result == false) {
             throw new ErrorException("Ocorreu um erro ao exportar o arquivo XML.");
         }
-        
         $content = file_get_contents($fileDir);
-        
-        $zipName = './app/export/SagresEdu/Educacao.zip';
+        $zipName = './app/export/SagresEdu/' . $inst . 'Educacao.zip';
         $tempArchiveZip = new ZipArchive;
         $tempArchiveZip->open($zipName, ZipArchive::CREATE);
         $tempArchiveZip->addFromString(pathinfo ($fileDir, PATHINFO_BASENAME), $content);


### PR DESCRIPTION
## Motivação
Com o advento da possibilidade de um município poder acessar o arquivo gerado pelo Sagres de outro município, foram implementadas as seguintes medidas.

## Alterações Realizadas
Foi adicionada a criação de pastas para cada município, a fim de armazenar os respectivos dados gerados pelo Sagres.

## Fluxo de Teste

1. Ir para a tela principal do Sagres.
2. Escolher um mês e clicar em "Exportar Unidade".
3. Verificar se na pasta: `app\export\SagresEdu\` foi criada uma pasta: `File_` + o nome da instância, contendo os arquivos: `Educação.xml` e `Educação.zip`.

🚨Como a instância é localhost, o arquivo dever ser algo como: `File_LOCALHOST`.

## Migrations Utilizadas
Não há migrations
## Teste de aceitação
- [ ] Tem teste de aceitação. 
