### PR TITLE
Fix: year of generation of the file changed to the one selected in th…

### DIFF
--- a/app/modules/sagres/controllers/DefaultController.php
+++ b/app/modules/sagres/controllers/DefaultController.php
@@ -52,9 +52,11 @@ class DefaultController extends Controller
 		$this->render('inconsistencys');
 	}
 
-	public function actionExport($year, $month, $finalClass, $chunkSize = 100)
+	public function actionExport($month, $finalClass, $chunkSize = 100)
 	{
+
 		try {
+			$year = Yii::app()->user->year;
 			$memory_limit = ini_get('memory_limit');
 			set_time_limit(0);
 

--- a/app/modules/sagres/views/default/index.php
+++ b/app/modules/sagres/views/default/index.php
@@ -126,9 +126,8 @@ $cs->registerCssFile($baseUrl . '/css/sagres.css');
 
 		month = parseInt(selectedValue, 10)
 
-		const year = new Date().getFullYear();
 		const exportLink = document.getElementById('exportLink');
-		const newHref = `?r=sagres/default/export&year=${year}&month=${month}&finalClass=${checkboxValue}`;
+		const newHref = `?r=sagres/default/export&month=${month}&finalClass=${checkboxValue}`;
 		exportLink.setAttribute('href', newHref);
 	});
 
@@ -137,9 +136,8 @@ $cs->registerCssFile($baseUrl . '/css/sagres.css');
 
 		month = parseInt(selectedValue, 10)
 
-		const year = new Date().getFullYear();
 		const exportLink = document.getElementById('exportLink');
-		const newHref = `?r=sagres/default/export&year=${year}&month=${month}&finalClass=${checkboxValue}`;
+		const newHref = `?r=sagres/default/export&month=${month}&finalClass=${checkboxValue}`;
 		exportLink.setAttribute('href', newHref);
 
 	});


### PR DESCRIPTION
## Motivação
A obtenção do ano para a geração do arquivo Sagres é baseada no ano atual (2024). No entanto, caso deseje obter o arquivo referente a dezembro de 2023 por exemplo, o ano a ser utilizado nas consultas seria 2024.

![Screenshot 2024-01-25 123110](https://github.com/ipti/br.tag/assets/117388330/07c4f2b7-61f5-471b-b0ba-d4932aedf585)

## Alterações Realizadas

- [Fix: Ano de geração do arquivo alterado para o ano selecionado no sistema](https://github.com/ipti/br.tag/commit/93f6086828ff0b02a81ec4154ac045e34a705d61)

`Path: app\modules\sagres\controllers\DefaultController.php`
na função actionExport, o ano agora é obtido baseado na seleção do **Ano Letivo** do sistema. 

![Screenshot 2024-01-25 124546](https://github.com/ipti/br.tag/assets/117388330/d989e60f-e3e5-4c4b-92d7-9ed4c37d8e83)

Remoção do parâmetro `year` do JavaScript

![Screenshot 2024-01-25 131132](https://github.com/ipti/br.tag/assets/117388330/191bf59f-2edf-421c-b5f9-1de61a69d318)

## Fluxo de Teste

```
1. Escolha um ano anterior a 2024.
2. Seleccione um mês específico.
3. Clique no botão "Exportar Unidade".
4. No arquivo gerado, verifique no cabeçalho de `PrestacaoContas` no documento Educacao.xml se o ano de referência corresponde ao ano escolhido para o ano letivo.

Path do Educacao.xml: app\export\SagresEdu\File_+instância
```

## Migrations Utilizadas
Não há
## Teste de aceitação
- [ ] Tem teste de aceitação. 
