### PR TITLE
Fix/correction date attendance

### DIFF
--- a/app/modules/professional/controllers/DefaultController.php
+++ b/app/modules/professional/controllers/DefaultController.php
@@ -88,7 +88,7 @@ class DefaultController extends Controller
 			if($modelAttendance->validate()) {
 				if($modelAttendance->save()){
 					Yii::app()->user->setFlash('success', Yii::t('default', 'Atendimento adicionado com sucesso!'));
-					$this->redirect(array('index'));	
+					$this->redirect(array('update', 'id' => $id));
 				}
 			}
 		}

--- a/app/modules/professional/controllers/DefaultController.php
+++ b/app/modules/professional/controllers/DefaultController.php
@@ -72,6 +72,7 @@ class DefaultController extends Controller
 	{
 		$criteria = new CDbCriteria();
 		$criteria->condition = "professional_fk = ".$id;
+		$criteria->order = "date desc"; 
 		$modelProfessional = Professional::model()->findByPk($id);
 		$modelAttendance = new Attendance;
 		$modelAttendances = Attendance::model()->findAll($criteria);
@@ -79,6 +80,11 @@ class DefaultController extends Controller
 		if(isset($_POST['Attendance'])) {
 			$modelAttendance->attributes = $_POST['Attendance'];
 			$modelAttendance->professional_fk = $modelProfessional->id_professional;
+
+			$modelAttendance->date = Yii::app()->dateFormatter->format(
+				'yyyy-MM-dd', CDateTimeParser::parse($modelAttendance->date, 'dd/MM/yyyy')
+			);
+		
 			if($modelAttendance->validate()) {
 				if($modelAttendance->save()){
 					Yii::app()->user->setFlash('success', Yii::t('default', 'Atendimento adicionado com sucesso!'));

--- a/app/modules/professional/views/default/_form.php
+++ b/app/modules/professional/views/default/_form.php
@@ -105,8 +105,27 @@
 												<?php echo $form->label($modelAttendance, 'date', array('class' => 'control-label')); ?>
 											</div>
 											<div class="controls">
-												<?php echo $form->dateField($modelAttendance, 'date', array('size' => 60, 'maxlength' => 100)); ?>
-												<?php echo $form->error($modelAttendance, 'date'); ?>
+												<?php 
+													$this->widget('zii.widgets.jui.CJuiDatePicker', array(
+														'model' => $modelAttendance,
+														'attribute' => 'date',
+														'options' => array(
+															'dateFormat' => 'dd/mm/yy',
+															'changeYear' => true,
+															'changeMonth' => true,
+															'yearRange' => '2000:' . date('Y'),
+															'showOn' => 'focus',
+															'maxDate' => 0
+														),
+														'htmlOptions' => array(
+															'readonly' => 'readonly',
+															'style' => 'cursor: pointer;',
+															'placeholder' => 'Clique aqui para escolher a data'
+														),
+													));
+												
+													echo $form->error($modelAttendance, 'date');
+												?>
 											</div>
 										</div>
 										<div class="control-group">
@@ -114,7 +133,7 @@
 												<?php echo $form->label($modelAttendance, 'local', array('class' => 'control-label')); ?>
 											</div>
 											<div class="controls">
-												<?php echo $form->textField($modelAttendance, 'local', array('size' => 60, 'maxlength' => 100)); ?>
+												<?php echo $form->textField($modelAttendance, 'local', array('size' => 60, 'maxlength' => 100, 'placeholder' => 'Informe o local do atendimento')); ?>
 												<?php echo $form->error($modelAttendance, 'local'); ?>
 											</div>
 										</div>

--- a/app/modules/professional/views/default/_form.php
+++ b/app/modules/professional/views/default/_form.php
@@ -101,6 +101,8 @@
 											<h3>Atendimento</h3>
 										</div>
 										<div class="control-group">
+											<div><?php echo "<strong>* Se a data não for escolhida, mas o local do atendimento for informado, a data registrada será a atual.</strong>" ?></div>
+											
 											<div class="controls">
 												<?php echo $form->label($modelAttendance, 'date', array('class' => 'control-label')); ?>
 											</div>
@@ -122,6 +124,10 @@
 															'style' => 'cursor: pointer;',
 															'placeholder' => 'Clique aqui para escolher a data'
 														),
+													));
+
+													echo CHtml::link('	Limpar', '#', array(
+														'onclick' => '$("#' . CHtml::activeId($modelAttendance, 'date') . '").datepicker("setDate", null); return false;',
 													));
 												
 													echo $form->error($modelAttendance, 'date');


### PR DESCRIPTION
## 🚀 Motivação
 
Ao cadastrar um atendimento realizado por um profissional, estava sendo permitido inserir datas no formato:

- 03/29/2024 (no futuro)
- 03/29/232132
- 03/29/0044
- mm/dd/yyyy (formato atual da data)

Isso criava confusão, uma vez que o formato correto para o português é dd/mm/yyyy. 
Essa flexibilidade aumentava consideravelmente o risco de cadastro de datas incorretas.

## 🔄 Alterações Realizadas

1. **[Fix: added validations and limitations for selecting the date of attendance](https://github.com/ipti/br.tag/commit/05cc1ec6255835fc7506c6ed6b5c0af7130dbab7)**
   - Foram adicionadas validações e limitações para a escolha da data do atendimento, incluindo a capacidade de escolher apenas uma data e a restrição de inserção de datas futuras ou fora do padrão.

![Screenshot 2024-01-30 200700](https://github.com/ipti/br.tag/assets/117388330/4d7ae041-a007-49b4-9b6e-3cdea1fb0a9e)

2. **[Feat: add CDateTimeParser to match the database data type (yyyy-MM-dd)](https://github.com/ipti/br.tag/commit/1d602f66957a38b06cf95bc3c3c2f534ac62fb85)**
   - Foi introduzido um DateTimeParser para converter a data do atendimento do formato `dd/MM/yyyy` para o formato utilizado no banco de dados: `yyyy-MM-dd`.


3. **[Fix: when entering an attendance, the page is no longer redirected to the index.](https://github.com/ipti/br.tag/commit/791e6eafb61f087a2200910a3b492d1a30cc2b59)**
   - Anteriormente, ao cadastrar um atendimento, a página redirecionava automaticamente para a lista de profissionais. Contudo, esse comportamento tornava-se inconveniente quando a pessoa precisava cadastrar múltiplos atendimentos para um mesmo profissional. A modificação realizada agora mantém o usuário na mesma página, simplificando o processo de adição de atendimentos.

4. **[Feat: added action to clear the entered date](https://github.com/ipti/br.tag/commit/171a775225a7449bbebe0138b98b69d0652c3eef)**
   - É realizado a remoção da data informada do atendimento.


## 🧪 Fluxo de Teste

Clique em: **Integrações -> Sagres  -> Profissionais -> Clique em algum profissional -> Adicionar Atendimento**

`🧪 Test 1`   O campo de data não deve permitir inserção de dados.
`🧪 Test 2`   Não deve ser possível escolher uma data no futuro.
`🧪 Test 3`   Ao escolher uma data, ela deve permanecer no formato:  `dd/mm/aaaa`
`🧪 Test 4`   Se a data não for selecionada, mas o local do atendimento for informado, ao clicar em `Salvar`, a data registrada deve ser a atual.
`🧪 Test 5`   Verificar se a data do atendimento na tabela **attendance** está no formato `aaaa-mm-dd` (padrão Date)

## Migrations Utilizadas
Não há

## Teste de Aceitação
- [ ] Testes de aceitação foram devidamente conduzidos