### PR TITLE
Docs/create pull request adr

### DIFF
--- a/docs/adrs/3_ATRIBUICAO_DE_NOME_DE_PULL_REQUEST.md
+++ b/docs/adrs/3_ATRIBUICAO_DE_NOME_DE_PULL_REQUEST.md
@@ -21,6 +21,7 @@ Padronizar os nomes de pull requests e consequentemente os nomes de branchs é f
 * feat: Novas funcionalidades
 * fix: Correção de bugs
 * test: Adicionar ou corrigir testes
+* refact: Refatorações no código que não adicionem uma nova funcionalidade e que também não corrijam bugs
 A descrição do pull request deve ser sucinta e as palavras devem ser separadas por underscores "_".
 
 ## Resultado da decisão

--- a/docs/adrs/3_ATRIBUICAO_DE_NOME_DE_PULL_REQUEST.md
+++ b/docs/adrs/3_ATRIBUICAO_DE_NOME_DE_PULL_REQUEST.md
@@ -1,0 +1,37 @@
+---
+status: discução
+date: 01-02-2024
+deciders: Igor, Gustavo,
+---
+
+# Atribuição de nome de pull request
+
+## Contexto
+
+Padronizar os nomes de pull requests e consequentemente os nomes de branchs é fundamental, pois a padronização facilita o entedimento, a clareza e a revisão dos pull requests, dessa forma, a equipe terá um entendimento claro e acertivo para com os nomes de pull request e também poderá acessá-los com maior facilidade.
+
+## Motivadores de decisão
+
+* Evitar ambiguidade e divergências no padrão de pull request
+
+## Opções consideradas
+
+1. Compor os nomes de pull request da seguinte forma: tipo/descrição. O tipo sendo qual a categoria que o pull request se encaixa, sendo eles:
+* docs: Mudanças na documentação
+* feat: Novas funcionalidades
+* fix: Correção de bugs
+* test: Adicionar ou corrigir testes
+A descrição do pull request deve ser sucinta e as palavras devem ser separadas por underscores "_".
+
+## Resultado da decisão
+
+
+### Consequências
+
+*
+*
+
+## More Information
+
+*
+*


### PR DESCRIPTION
## Motivação
Foi necessário criar a adr que descreve o padrão de atribuição de nome de pull request, a fim de deixar documentado os padrões definidos pela equipe.

## Alterações Realizadas
- Criando a documentação da adr que descreve a atribuição de nome de pull request

## Fluxo de Teste
Não há

## Migrations Utilizadas
Não foi utilizada nenhuma migration

## Teste de aceitação
- [ ] Tem teste de aceitação. 
