### PR TITLE
Fix/synchronize sedsp student data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Versão 3.68.105]
 - Excluido * a mais da tela de aulas ministradas.
+- Adicionado sincronização direta dos dados do aluno, com importação automática de turmas, se necessário.
 
 ## [Versão 3.68.104]
 - Adicionado a opção Ensino Fundamental dentro da escolaridade na tela de alunos.

--- a/app/modules/sedsp/controllers/DefaultController.php
+++ b/app/modules/sedsp/controllers/DefaultController.php
@@ -324,6 +324,11 @@ class DefaultController extends Controller implements AuthenticateSEDTokenInterf
 			$statusSave = $exibirFicha->exec($inAluno);
             $id = (int) $_GET["id"];
 
+            if($statusSave === -1) {
+                Yii::app()->user->setFlash('error', "O estudante foi sincronizado com sucesso, no entanto, a matrícula não foi sincronizada.");
+				$this->redirect([self::REDIRECT_PATH, 'id' => $id]);
+            }
+
             if($statusSave === 401) {
                 Yii::app()->user->setFlash('error', "Não foi possível fazer a sincronização da SED para o TAG.");
 				$this->redirect([self::REDIRECT_PATH, 'id' => $id]);

--- a/app/modules/sedsp/usecases/Student/UpdateFichaAlunoInTAGUseCase.php
+++ b/app/modules/sedsp/usecases/Student/UpdateFichaAlunoInTAGUseCase.php
@@ -33,9 +33,13 @@ class UpdateFichaAlunoInTAGUseCase
             $studentId = StudentIdentification::model()->find('gov_id = :govId', [':govId' => $mapperStudentDocuments->gov_id])->id;
 
             $this->updateStudentDocsAndAddress($mapperStudentDocuments, $studentId);
-            $this->createOrUpdateStudentEnrollment($mapper->StudentEnrollment);
+            $statusUpdateEnrollment = $this->createOrUpdateStudentEnrollment($mapper->StudentEnrollment);
 
-            return $studentIdentification;
+            if($statusUpdateEnrollment === false){
+                return -1;
+            } else {
+                return $studentIdentification;
+            }
         } catch (Exception $e) {
             $this->handleException($mapperStudentIdentification, $e);
             return $e->getCode();
@@ -93,10 +97,15 @@ class UpdateFichaAlunoInTAGUseCase
                 $newEnrollment->attributes = $studentEnrollment->attributes;
                 $newEnrollment->sedsp_sync = 0;
 
-                if($newEnrollment->validate() && $newEnrollment->save()) {
-                    $newEnrollment->sedsp_sync = 1;
+                if($newEnrollment->classroom_fk === null){
+                    return false;
+                }else{
+                    if($newEnrollment->validate() && $newEnrollment->save()) {
+                        $newEnrollment->sedsp_sync = 1;
+                    }
+    
+                    return $newEnrollment->save();
                 }
-                return $newEnrollment->save();
             } else {
                 $enrollment->attributes = $studentEnrollment->attributes;
                 $enrollment->sedsp_sync = 0;


### PR DESCRIPTION
## Motivação
Anteriormente, era comum enfrentar dificuldades ao tentar importar um aluno devido a erros relacionados à não localização da turma, o que impossibilitava a sincronização. Como solução, era necessário acessar a opção 'Integração -> SEDSP' para importar as classes antes de tentar realizar a sincronização do aluno.

## Alterações Realizadas
Com as alterações implementadas, não é mais necessário importar as turmas antes de tentar sincronizar os dados do aluno. Agora, é possível ir diretamente para a página do aluno e realizar a sincronização. Caso a turma não seja encontrada, o sistema automaticamente realiza a importação das turmas e, em seguida, sincroniza os dados do aluno.

Essa melhoria resultou em uma redução nos erros durante o processo de importação dos dados dos alunos.
## 🧪 Fluxo de Teste
1. Acesse a seção "Alunos" no menu principal.
2. Selecione um aluno específico na lista.
3. Dentro do perfil do aluno, clique na opção "Importar dados da SED".

Deve ser exibida uma mensagem de sucesso na importação dos dados
**Obs.: A funcionalidade de importação está disponível apenas até às 23:59.**
## Migrations Utilizadas

## Checklist de revisão
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
