### PR TITLE
Fix/sagres schema 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.68.111]
+- Foi modificado o ano para o tipo: @XmlNamespace para 2024
+
 ## [Versão 3.68.109]
 - consertado listagem de refeições
 - 

--- a/app/modules/sagres/soap/metadata/sagresEduMetadata/AlunoTType.yml
+++ b/app/modules/sagres/soap/metadata/sagresEduMetadata/AlunoTType.yml
@@ -6,7 +6,7 @@ SagresEdu\AlunoTType:
             serialized_name: cpfAluno
             xml_element:
                 cdata: false
-                namespace: 'http://www.tce.se.gov.br/sagres2023/xml/sagresEdu'
+                namespace: 'http://www.tce.se.gov.br/sagres2024/xml/sagresEdu'
             accessor:
                 getter: getCpfAluno
                 setter: setCpfAluno
@@ -17,7 +17,7 @@ SagresEdu\AlunoTType:
             serialized_name: data_nascimento
             xml_element:
                 cdata: false
-                namespace: 'http://www.tce.se.gov.br/sagres2023/xml/sagresEdu'
+                namespace: 'http://www.tce.se.gov.br/sagres2024/xml/sagresEdu'
             accessor:
                 getter: getDataNascimento
                 setter: setDataNascimento
@@ -28,7 +28,7 @@ SagresEdu\AlunoTType:
             serialized_name: nome
             xml_element:
                 cdata: false
-                namespace: 'http://www.tce.se.gov.br/sagres2023/xml/sagresEdu'
+                namespace: 'http://www.tce.se.gov.br/sagres2024/xml/sagresEdu'
             accessor:
                 getter: getNome
                 setter: setNome
@@ -39,7 +39,7 @@ SagresEdu\AlunoTType:
             serialized_name: pcd
             xml_element:
                 cdata: false
-                namespace: 'http://www.tce.se.gov.br/sagres2023/xml/sagresEdu'
+                namespace: 'http://www.tce.se.gov.br/sagres2024/xml/sagresEdu'
             accessor:
                 getter: getPcd
                 setter: setPcd
@@ -50,7 +50,7 @@ SagresEdu\AlunoTType:
             serialized_name: sexo
             xml_element:
                 cdata: false
-                namespace: 'http://www.tce.se.gov.br/sagres2023/xml/sagresEdu'
+                namespace: 'http://www.tce.se.gov.br/sagres2024/xml/sagresEdu'
             accessor:
                 getter: getSexo
                 setter: setSexo

--- a/app/modules/sagres/soap/src/sagresEdu/EducacaoTType.php
+++ b/app/modules/sagres/soap/src/sagresEdu/EducacaoTType.php
@@ -16,7 +16,7 @@ use JMS\Serializer\Annotation\XmlElement;
  * 
  * XSD Type: educacao_t
  * @XmlRoot("edu:educacao")
- * @XmlNamespace(uri="http://www.tce.se.gov.br/sagres2023/xml/sagresEdu", prefix="edu")
+ * @XmlNamespace(uri="http://www.tce.se.gov.br/sagres2024/xml/sagresEdu", prefix="edu")
  */
 class EducacaoTType
 {

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.68.109');
+define("TAG_VERSION", '3.68.111');
 
 
 define("YII_VERSION", Yii::getVersion());


### PR DESCRIPTION
## Motivação
O esquema do arquivo Educacao.xml está marcando o ano como 2023, o que está causando falha no processo de validação.
## Alterações Realizadas
Foi modificado o ano para o tipo: @XmlNamespace
## Fluxo de Teste
O arquivo sagres deve gerar o xmlns:edu="http://www.tce.se.gov.br/sagres2024/xml/sagresEdu" do arquivo Educacao.xml com o ano de 2024.
## Migrations Utilizadas

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
