### PR TITLE
Fix/scholarity sql column removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.72.116]
+- Correção no relatório de professores por escola
+
 ## [Versão 3.72.115]
 - Adicionado Modal para adicionar novos recursos na tela de plano de aula.
 - Alteração na estrutura do banco de dados referente ao tipo de recurso cadastrado em um plano

--- a/app/repository/ReportsRepository.php
+++ b/app/repository/ReportsRepository.php
@@ -637,12 +637,9 @@ class ReportsRepository
                 ii.name,
                 ii.birthday_date,
                 ii.inep_id,
-                ivd.scholarity,
                 ii.school_inep_id_fk
             FROM instructor_identification ii
-            JOIN instructor_variable_data ivd ON ii.id = ivd.id
-            GROUP BY ii.name
-            ORDER BY ii.name;";
+            GROUP BY ii.name;";
         $instructors = Yii::app()->db->createCommand($sql)->queryAll();
 
         $schools = SchoolIdentification::model()->findAll();

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.72.115');
+define("TAG_VERSION", '3.72.116');
 
 
 define("YII_VERSION", Yii::getVersion());


### PR DESCRIPTION
## Motivação
Ao gerar um **RELATÓRIO DE PROFESSORES POR ESCOLA**, observou-se que nem todos os professores vinculados estavam sendo listados corretamente.

## Alterações Realizadas
A coluna `scholarity` foi removida, pois continha menos registros de professores em comparação com a tabela `instructor_identification`. Isso causava problemas no processo de junção de dados, já que alguns professores listados em `instructor_identification` não possuíam registros correspondentes em `instructor_variable_data`. Como resultado, nem todos os professores da escola estavam sendo corretamente incluídos no relatório.

## Fluxo de Teste
1. Clique em **Relatórios**.
2. Navegue até a seção de **Administrador**.
3. Selecione **Professores por Escola**.
4. Pesquise pela escola: ID INEP: 32065744.
5. Deverá ser exibido aproximadamente **26 professores**.

Se tiver, o teste foi ok!

## Migrations Utilizadas

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
