### PR TITLE
Fix: added food Enabled

### DIFF
--- a/app/migrations/2024-03-19_food_enabled/default.sql
+++ b/app/migrations/2024-03-19_food_enabled/default.sql
@@ -1,0 +1,1 @@
+ALTER TABLE food_menu ADD adjusted BOOL DEFAULT 0 NULL;

--- a/app/modules/sagres/models/SagresConsultModel.php
+++ b/app/modules/sagres/models/SagresConsultModel.php
@@ -698,7 +698,24 @@ class SagresConsultModel
         $strlen = 4;
         $maxLen = 1000;
 
-        $query = "SELECT 
+        $isFoodEnabled = (object) \InstanceConfig::model()->findByAttributes(array('parameter_key' => 'FEAT_FOOD'));
+        
+        if($isFoodEnabled->value) {
+
+            $query = "SELECT 
+                        fm.start_date as data, 
+                        fm.description AS descricaoMerenda, 
+                        fm.adjusted AS ajustado,
+                        fmm.turn AS turno
+                    FROM food_menu fm 
+                        JOIN food_menu_meal fmm on fmm.food_menuId = fm.id
+                    WHERE YEAR(fm.start_date) = :year and month(fm.start_date) <= :month";
+            $params = [
+                ':year' => $year,
+                ':month' => $month
+            ];
+        } else {
+            $query = "SELECT 
                     lm.date AS data,
                     lm.turn AS turno,
                     lm2.restrictions  AS descricaoMerenda,
@@ -707,13 +724,14 @@ class SagresConsultModel
                     JOIN lunch_menu_meal lmm ON lm.id = lmm.menu_fk
                     JOIN lunch_meal lm2 on lmm.meal_fk = lm2.id
                 WHERE lm.school_fk =  :schoolId AND YEAR(lm.date) = :year AND MONTH(lm.date) <= :month";
-
-        $params = [
-            ':schoolId' => $schoolId,
-            ':year' => $year,
-            ':month' => $month
-        ];
-
+        
+            $params = [
+                ':schoolId' => $schoolId,
+                ':year' => $year,
+                ':month' => $month
+            ];  
+        }
+       
         $menus = Yii::app()->db->createCommand($query)->bindValues($params)->queryAll();
 
         foreach ($menus as $menu) {


### PR DESCRIPTION
## Motivação
Recentemente, foi implementado uma reformulação no tratamento dos dados relacionados à merenda escolar.

## Alterações Realizadas
Foi adicionado uma condição para determinar se o novo modelo da merenda está habilitado. Se estiver, utilizaremos o novo modelo para pegar os dados, caso contrário, será feito o uso do modelo anterior.

## Fluxo de Teste

1. Clicar em Administração
2. Configurações do Município
3. Mudar o valor do campo "Novo módulo de merenda" para 1 - Habilitar
4. Clicar no menu Integrações -> Sagres
5. Escolha o mês atual
6. Clique em Exportar Unidade

O arquivo gerado deve conter os dados das novas tabelas (food, food_menu, etc.) se o campo "Novo módulo de merenda" estiver setado como 1. Caso contrário, deve conter os dados das tabelas antigas.


## Migrations Utilizadas
2024-03-19_food_enabled

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
