### PR TITLE
Fix: correction in inep_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.76.128]
+- Corrigido erro que não mostrava o nome da escola e das turmas nas inconsistências sagres
+
 ## [Versão 3.76.127]
 - Corrigido erro que não saía do painel de cadastros pendentes, referente à matriz curricular e estrutura de notas
 

--- a/app/modules/sagres/models/SagresConsultModel.php
+++ b/app/modules/sagres/models/SagresConsultModel.php
@@ -439,6 +439,7 @@ class SagresConsultModel
         $seriesList = [];
         $strlen = 2;
         $strMaxLength = 50;
+        $school = (object) \SchoolIdentification::model()->findByAttributes(array('inep_id' => $inepId));
 
         $query = "SELECT
                     c.name AS serieDescription,
@@ -459,9 +460,9 @@ class SagresConsultModel
                 if (empty($serieType)) {
                     $inconsistencyModel = new ValidationSagresModel();
                     $inconsistencyModel->enrollment = 'SÉRIE';
-                    $inconsistencyModel->school = '';
-                    $inconsistencyModel->description = 'Não há série para a escola: ';
-                    $inconsistencyModel->action = 'Adicione uma série para a turma: ';
+                    $inconsistencyModel->school = $school->name;
+                    $inconsistencyModel->description = 'Não há série para a escola: ' . $school->name;
+                    $inconsistencyModel->action = 'Adicione uma série para a turma';
                     $inconsistencyModel->identifier = '10';
                     $inconsistencyModel->idClass = $classId;
                     $inconsistencyModel->insert();
@@ -471,7 +472,7 @@ class SagresConsultModel
                 if (strlen($serieType->getDescricao()) <= $strlen) {
                     $inconsistencyModel = new ValidationSagresModel();
                     $inconsistencyModel->enrollment = 'SÉRIE';
-                    $inconsistencyModel->school = '';
+                    $inconsistencyModel->school = $school->name;
                     $inconsistencyModel->description = 'Descrição para a série: ' . $serieType->getDescricao() . ' menor que 3 caracteres';
                     $inconsistencyModel->action = 'Forneça uma descrição mais detalhada, contendo mais de 5 caracteres';
                     $inconsistencyModel->identifier = '10';
@@ -483,7 +484,7 @@ class SagresConsultModel
                 if (strlen($serieType->getDescricao()) > $strMaxLength) {
                     $inconsistencyModel = new ValidationSagresModel();
                     $inconsistencyModel->enrollment = 'SÉRIE';
-                    $inconsistencyModel->school = '';
+                    $inconsistencyModel->school = $school->name;
                     $inconsistencyModel->description = 'Descrição para a série: ' . $serieType->getDescricao() . ' com mais de 50 caracteres';
                     $inconsistencyModel->action = 'Forneça uma descrição menos detalhada, contendo até 50 caracteres';
                     $inconsistencyModel->identifier = '10';
@@ -501,7 +502,7 @@ class SagresConsultModel
                 if (!in_array($serieType->getModalidade(), [1, 2, 3, 4, 5])) {
                     $inconsistencyModel = new ValidationSagresModel();
                     $inconsistencyModel->enrollment = 'SÉRIE';
-                    $inconsistencyModel->school = '';
+                    $inconsistencyModel->school = $school->name;
                     $inconsistencyModel->description = 'Modalidade inválida';
                     $inconsistencyModel->action = 'Selecione uma modalidade válida para a série';
                     $inconsistencyModel->identifier = '10';
@@ -525,6 +526,8 @@ class SagresConsultModel
         $scheduleList = [];
         $strlen = 3;
         $maxLength = 100;
+
+        $school = (object) \SchoolIdentification::model()->findByAttributes(array('inep_id' => $inepId));
 
         $query = "SELECT DISTINCT
                     s.schedule AS schedule,
@@ -553,18 +556,18 @@ class SagresConsultModel
 
         $schedules = Yii::app()->db->createCommand($query)->bindValues($params)->queryAll();
 
+        $class = (object) \Classroom::model()->findByAttributes(array('id' => $classId));
+
         if(empty($schedules)) {
-            if (empty($schedules)) {
-                $inconsistencyModel = new ValidationSagresModel();
-                $inconsistencyModel->enrollment = 'HORÁRIO';
-                $inconsistencyModel->school = '';
-                $inconsistencyModel->description = 'Não há um quadro de horários para a turma: ';
-                $inconsistencyModel->action = 'Adicione um quadro de horários para turma';
-                $inconsistencyModel->identifier = '10';
-                $inconsistencyModel->idClass = $classId;
-                #$inconsistencyModel->idSchool = $inepId;
-                $inconsistencyModel->insert();
-            }
+            $inconsistencyModel = new ValidationSagresModel();
+            $inconsistencyModel->enrollment = '<strong>HORÁRIO<strong>';
+            $inconsistencyModel->school = $school->name;
+            $inconsistencyModel->description = 'Não há um quadro de horários para a turma: <strong>' . $class->name . '<strong>';
+            $inconsistencyModel->action = 'Adicione um quadro de horários para turma';
+            $inconsistencyModel->identifier = '10';
+            $inconsistencyModel->idClass = $classId;
+            $inconsistencyModel->idSchool = $inepId;
+            $inconsistencyModel->insert();
         }
 
 
@@ -595,74 +598,74 @@ class SagresConsultModel
 
                 if (empty($scheduleType)) {
                     $inconsistencyModel = new ValidationSagresModel();
-                    $inconsistencyModel->enrollment = 'HORÁRIO';
-                    $inconsistencyModel->school = '';
+                    $inconsistencyModel->enrollment = '<strong>HORÁRIO<strong>';
+                    $inconsistencyModel->school = $school->name;
                     $inconsistencyModel->description = 'Não há um professor, horários ou componentes curriculares para a turma: ';
                     $inconsistencyModel->action = 'Adicione um professor ou componentes curriculares à turma';
                     $inconsistencyModel->identifier = '10';
                     $inconsistencyModel->idClass = $classId;
-                    #$inconsistencyModel->idSchool = $inepId;
+                    $inconsistencyModel->idSchool = $inepId;
                     $inconsistencyModel->insert();
                 }
                 
                 if (!in_array($scheduleType->getDiaSemana(), [1, 2, 3, 4, 5, 6, 7])) {
                     $inconsistencyModel = new ValidationSagresModel();
-                    $inconsistencyModel->enrollment = 'HORÁRIO';
-                    $inconsistencyModel->school = '';
+                    $inconsistencyModel->enrollment = '<strong>HORÁRIO<strong>';
+                    $inconsistencyModel->school = $school->name;
                     $inconsistencyModel->description = 'Dia da semana inválido: ' . $scheduleType->getDiaSemana();
                     $inconsistencyModel->action = 'Adicione um dia da semana válido para a disciplina';
                     $inconsistencyModel->identifier = '10';
                     $inconsistencyModel->idClass = $classId;
-                    #$inconsistencyModel->idSchool = $inepId;
+                    $inconsistencyModel->idSchool = $inepId;
                     $inconsistencyModel->insert();
                 }
                 
                 if (!is_int($scheduleType->getDuracao())) {
                     $inconsistencyModel = new ValidationSagresModel();
-                    $inconsistencyModel->enrollment = 'HORÁRIO';
-                    $inconsistencyModel->school = '';
+                    $inconsistencyModel->enrollment = '<strong>HORÁRIO<strong>';
+                    $inconsistencyModel->school = $school->name;
                     $inconsistencyModel->description = 'Duração inválida';
                     $inconsistencyModel->action = 'Adicione um dia da semana válido para a disciplina';
                     $inconsistencyModel->identifier = '10';
                     $inconsistencyModel->idClass = $classId;
-                    #$inconsistencyModel->idSchool = $inepId;
+                    $inconsistencyModel->idSchool = $inepId;
                     $inconsistencyModel->insert();
                 }
                 
                 $cpfInstructor = $scheduleType->getCpfProfessor();
                 if (!$this->validaCPF($cpfInstructor[0])) {
                     $inconsistencyModel = new ValidationSagresModel();
-                    $inconsistencyModel->enrollment = 'HORÁRIO';
-                    $inconsistencyModel->school = '';
+                    $inconsistencyModel->enrollment = '<strong>HORÁRIO<strong>';
+                    $inconsistencyModel->school = $school->name;
                     $inconsistencyModel->description = 'CPF do professor é inválido, vinculado a turma: ';
                     $inconsistencyModel->action = 'Informar um CPF válido para o professor';
                     $inconsistencyModel->identifier = '10';
                     $inconsistencyModel->idClass = $classId;
-                    #$inconsistencyModel->idSchool = $inepId;
+                    $inconsistencyModel->idSchool = $inepId;
                     $inconsistencyModel->insert();
                 }
                 
                 if (strlen($scheduleType->getDisciplina()) < $strlen) {
                     $inconsistencyModel = new ValidationSagresModel();
-                    $inconsistencyModel->enrollment = 'HORÁRIO';
-                    $inconsistencyModel->school = '';
+                    $inconsistencyModel->enrollment = '<strong>HORÁRIO<strong>';
+                    $inconsistencyModel->school = $school->name;
                     $inconsistencyModel->description = 'Nome da disciplina muito curta';
                     $inconsistencyModel->action = 'Adicione um nome para a disciplina com pelo menos 5 caracteres';
                     $inconsistencyModel->identifier = '10';
                     $inconsistencyModel->idClass = $classId;
-                    #$inconsistencyModel->idSchool = $inepId;
+                    $inconsistencyModel->idSchool = $inepId;
                     $inconsistencyModel->insert();
                 }
                 
                 if (strlen($scheduleType->getDisciplina()) > $maxLength) {
                     $inconsistencyModel = new ValidationSagresModel();
-                    $inconsistencyModel->enrollment = 'HORÁRIO';
-                    $inconsistencyModel->school = '';
+                    $inconsistencyModel->enrollment = '<strong>HORÁRIO<strong>';
+                    $inconsistencyModel->school = $school->name;
                     $inconsistencyModel->description = 'Nome da disciplina com mais de 50 caracteres - ' . $scheduleType->getDisciplina();
                     $inconsistencyModel->action = 'Adicione um nome para a disciplina com até 50 caracteres';
                     $inconsistencyModel->identifier = '10';
                     $inconsistencyModel->idClass = $classId;
-                    #$inconsistencyModel->idSchool = $inepId;
+                    $inconsistencyModel->idSchool = $inepId;
                     $inconsistencyModel->insert();
                 }                
 
@@ -980,6 +983,7 @@ class SagresConsultModel
         $enrollmentList = [];
         $strMaxLength = 200;
         $strlen = 5;
+        $school = (object) \SchoolIdentification::model()->findByAttributes(array('inep_id' => $inepId));
 
         $query = "SELECT
                         se.id as numero,
@@ -1018,8 +1022,8 @@ class SagresConsultModel
 
             if (DateTime::createFromFormat("d/m/Y", $enrollment['birthdate']) === false) {
                 $inconsistencyModel = new ValidationSagresModel();
-                $inconsistencyModel->enrollment = 'ESTUDANTE';
-                $inconsistencyModel->school = '';
+                $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
+                $inconsistencyModel->school = $school->name;
                 $inconsistencyModel->description = 'Data de nascimento inválida';
                 $inconsistencyModel->action = 'Altere o formato de data para DD/MM/AAAA';
                 $inconsistencyModel->identifier = '9';
@@ -1049,10 +1053,10 @@ class SagresConsultModel
                     if (!is_null($studentType->getCpfAluno())) {
                         if (!$this->validaCPF($studentType->getCpfAluno())) {
                             $inconsistencyModel = new ValidationSagresModel();
-                            $inconsistencyModel->enrollment = 'ESTUDANTE';
-                            $inconsistencyModel->school = '';
-                            $inconsistencyModel->description = 'CPF DO ESTUDANTE É INVÁLIDO';
-                            $inconsistencyModel->action = 'INFORME UM CPF VÁLIDO PARA O ESTUDANTE: ' . $enrollment['name'];
+                            $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
+                            $inconsistencyModel->school = $school->name;
+                            $inconsistencyModel->description = 'Cpf do estudante é inválido';
+                            $inconsistencyModel->action = 'Informe um cpf válido para o estudante: <strong>' . $enrollment['name'] . '<strong>';
                             $inconsistencyModel->identifier = '9';
                             $inconsistencyModel->idStudent = $enrollment['student_fk'];
                             $inconsistencyModel->idClass = $classId;
@@ -1062,10 +1066,10 @@ class SagresConsultModel
 
                     if (is_null($studentType->getCpfAluno())) {
                         $inconsistencyModel = new ValidationSagresModel();
-                        $inconsistencyModel->enrollment = 'ESTUDANTE';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'É OBRIGATÓRIO INFORMAR O CPF DO ESTUDANTE';
-                        $inconsistencyModel->action = 'INFORME UM CPF PARA O ESTUDANTE: ' . $enrollment['name'];
+                        $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'É obrigatório informar o cpf do estudante';
+                        $inconsistencyModel->action = 'Informe um cpf para o estudante: <strong>' . $enrollment['name'] . '<strong>';
                         $inconsistencyModel->identifier = '9';
                         $inconsistencyModel->idStudent = $enrollment['student_fk'];
                         $inconsistencyModel->insert();
@@ -1073,10 +1077,10 @@ class SagresConsultModel
 
                     if (!$this->validateDate($studentType->getDataNascimento())) {
                         $inconsistencyModel = new ValidationSagresModel();
-                        $inconsistencyModel->enrollment = 'ESTUDANTE';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'DATA NO FORMATO INVÁLIDO: ' . $enrollment['birthdate'];
-                        $inconsistencyModel->action = 'ADICIONE UMA DATA NO FORMATO VÁLIDA';
+                        $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'Data no formato inválido: ' . $enrollment['birthdate'];
+                        $inconsistencyModel->action = 'Adicione uma data no formato válido';
                         $inconsistencyModel->identifier = '9';
                         $inconsistencyModel->idStudent = $enrollment['student_fk'];
                         $inconsistencyModel->idClass = $classId;
@@ -1086,10 +1090,10 @@ class SagresConsultModel
 
                     if (strlen($studentType->getNome()) < $strlen) {
                         $inconsistencyModel = new ValidationSagresModel();
-                        $inconsistencyModel->enrollment = 'ESTUDANTE';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'NOME DO ESTUDANTE COM MENOS DE 5 CARACTERES';
-                        $inconsistencyModel->action = 'ADICIONE UM NOME PARA O ESTUDANTE COM PELO MENOS 5 CARACTERES';
+                        $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'Nome do estudante com menos de 5 caracteres';
+                        $inconsistencyModel->action = 'Adicione um nome para o estudante com pelo menos 5 caracteres';
                         $inconsistencyModel->identifier = '9';
                         $inconsistencyModel->idStudent = $enrollment['student_fk'];
                         $inconsistencyModel->idClass = $classId;
@@ -1098,10 +1102,10 @@ class SagresConsultModel
 
                     if ($studentType->getNome() > $strMaxLength) {
                         $inconsistencyModel = new ValidationSagresModel();
-                        $inconsistencyModel->enrollment = 'ESTUDANTE';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'NOME DO ESTUDANTE COM MAIS DE 200 CARACTERES';
-                        $inconsistencyModel->action = 'ADICIONE UM NOME PARA O ESTUDANTE COM ATÉ 200 CARACTERES';
+                        $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'Nome do estudante com mais de 200 caracteres';
+                        $inconsistencyModel->action = 'Adicione um nome para o estudante com até 200 caracteres';
                         $inconsistencyModel->identifier = '9';
                         $inconsistencyModel->idStudent = $enrollment['student_fk'];
                         $inconsistencyModel->idClass = $classId;
@@ -1110,10 +1114,10 @@ class SagresConsultModel
 
                     if (!is_bool(boolval($studentType->getPcd()))) {
                         $inconsistencyModel = new ValidationSagresModel();
-                        $inconsistencyModel->enrollment = 'ESTUDANTE';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'CÓDIGO PCD É INVÁLIDO';
-                        $inconsistencyModel->action = 'ADICIONE UM VALOR VÁLIDO PARA O PCD';
+                        $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'Código pcd é inválido';
+                        $inconsistencyModel->action = 'Adicione um valor válido para o pcd';
                         $inconsistencyModel->identifier = '9';
                         $inconsistencyModel->idStudent = $enrollment['student_fk'];
                         $inconsistencyModel->idClass = $classId;
@@ -1122,10 +1126,10 @@ class SagresConsultModel
 
                     if ($studentType->getDataNascimento() === false) {
                         $inconsistencyModel = new ValidationSagresModel();
-                        $inconsistencyModel->enrollment = 'ESTUDANTE';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'DATA DE NASCIMENTO INVÁLIDA';
-                        $inconsistencyModel->action = 'ALTERE O FORMATO DE DATA PARA DD/MM/AAAA';
+                        $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'Data de nascimento inválida';
+                        $inconsistencyModel->action = 'Altere o formato de data para dd/mm/aaaa';
                         $inconsistencyModel->identifier = '9';
                         $inconsistencyModel->idStudent = $enrollment['student_fk'];
                         $inconsistencyModel->idClass = $classId;
@@ -1134,10 +1138,10 @@ class SagresConsultModel
 
                     if (!in_array($studentType->getSexo(), [1, 2, 3])) {
                         $inconsistencyModel = new ValidationSagresModel();
-                        $inconsistencyModel->enrollment = 'ESTUDANTE';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'SEXO NÃO É VÁLIDO';
-                        $inconsistencyModel->action = 'ADICIONE UM SEXO VÁLIDO PARA O ESTUDANTE';
+                        $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'Sexo não é válido';
+                        $inconsistencyModel->action = 'Adicione um sexo válido para o estudante';
                         $inconsistencyModel->identifier = '9';
                         $inconsistencyModel->idStudent = $enrollment['student_fk'];
                         $inconsistencyModel->idClass = $classId;
@@ -1154,10 +1158,10 @@ class SagresConsultModel
 
                     if (is_null($studentType)) {
                         $inconsistencyModel = new ValidationSagresModel();
-                        $inconsistencyModel->enrollment = 'ESTUDANTE';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'ESTUDANTE NÃO EXISTE PARA A MATRÍCULA DA TURMA: ';
-                        $inconsistencyModel->action = 'ADICIONE UM ESTUDANTE À TURMA DA ESCOLA';
+                        $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'Estudante não existe para a matrícula da turma: ';
+                        $inconsistencyModel->action = 'Adicione um estudante à turma da escola';
                         $inconsistencyModel->identifier = '9';
                         $inconsistencyModel->idStudent = $enrollment['student_fk'];
                         $inconsistencyModel->idClass = $classId;
@@ -1171,39 +1175,40 @@ class SagresConsultModel
                     if (empty($enrollmentType)) {
                         $inconsistencyModel = new ValidationSagresModel();
                         $inconsistencyModel->enrollment = 'MATRÍCULA';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'NÃO HÁ MATRÍCULA PARA A TURMA';
-                        $inconsistencyModel->action = 'ADICIONE UMA MATRÍCULA PARA A TURMA';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'Não há matrícula para a turma';
+                        $inconsistencyModel->action = 'Adicione uma matrícula para a turma';
                         $inconsistencyModel->idClass = $classId;
                         $inconsistencyModel->insert();
                     }
-
+                    
                     if (!$this->validateDate($enrollmentType->getDataMatricula())) {
                         $inconsistencyModel = new ValidationSagresModel();
                         $inconsistencyModel->enrollment = 'MATRÍCULA';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'DATA NO FORMATO INVÁLIDO';
-                        $inconsistencyModel->action = 'ADICIONE UMA DATA NO FORMATO VÁLIDO';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'Data no formato inválido';
+                        $inconsistencyModel->action = 'Adicione uma data no formato válido';
+                        $inconsistencyModel->idClass = $classId;
+                        $inconsistencyModel->insert();
+                    }
+                    
+                    if (!is_int($enrollmentType->getNumeroFaltas())) {
+                        $inconsistencyModel = new ValidationSagresModel();
+                        $inconsistencyModel->enrollment = 'MATRÍCULA';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'O valor para o número de faltas é inválido';
+                        $inconsistencyModel->action = 'Coloque um valor válido para o número de faltas';
                         $inconsistencyModel->idClass = $classId;
                         $inconsistencyModel->insert();
                     }
 
-                    if (!is_int($enrollmentType->getNumeroFaltas())) {
-                        $inconsistencyModel = new ValidationSagresModel();
-                        $inconsistencyModel->enrollment = 'MATRÍCULA';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'O VALOR PARA O NÚMERO DE FALTAS É INVÁLIDO';
-                        $inconsistencyModel->action = 'COLOQUE UM VALOR VÁLIDO PARA O NÚMERO DE FALTAS';
-                        $inconsistencyModel->idClass = $classId;
-                        $inconsistencyModel->insert();
-                    }
                     if (filter_var($finalClass, FILTER_VALIDATE_BOOLEAN)) {
                         if (!is_bool($enrollmentType->getAprovado())) {
                             $inconsistencyModel = new ValidationSagresModel();
                             $inconsistencyModel->enrollment = 'MATRÍCULA';
-                            $inconsistencyModel->school = '';
-                            $inconsistencyModel->description = 'VALOR INVÁLIDO PARA O STATUS APROVADO';
-                            $inconsistencyModel->action = 'ADICIONE UM VALOR VÁLIDO PARA O CAMPO APROVADO DO ALUNO: ' . $studentType->getNome();
+                            $inconsistencyModel->school = $school->name;
+                            $inconsistencyModel->description = 'Valor inválido para o status aprovado';
+                            $inconsistencyModel->action = 'Adicione um valor válido para o campo aprovado do aluno: ' . $studentType->getNome();
                             $inconsistencyModel->idClass = $classId;
                             $inconsistencyModel->insert();
                         }
@@ -1224,10 +1229,10 @@ class SagresConsultModel
                     if (!is_null($studentType->getCpfAluno())) {
                         if (!$this->validaCPF($studentType->getCpfAluno())) {
                             $inconsistencyModel = new ValidationSagresModel();
-                            $inconsistencyModel->enrollment = 'ESTUDANTE';
-                            $inconsistencyModel->school = '';
-                            $inconsistencyModel->description = 'CPF DO ESTUDANTE É INVÁLIDO';
-                            $inconsistencyModel->action = 'INFORME UM CPF VÁLIDO PARA O ESTUDANTE: ' . $enrollment['name'];
+                            $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
+                            $inconsistencyModel->school = $school->name;
+                            $inconsistencyModel->description = 'Cpf do estudante é inválido';
+                            $inconsistencyModel->action = 'Informe um cpf válido para o estudante: <strong>' . $enrollment['name'] . '<strong>';
                             $inconsistencyModel->identifier = '9';
                             $inconsistencyModel->idStudent = $enrollment['student_fk'];
                             $inconsistencyModel->idClass = $classId;
@@ -1237,10 +1242,10 @@ class SagresConsultModel
 
                     if (is_null($studentType->getCpfAluno())) {
                         $inconsistencyModel = new ValidationSagresModel();
-                        $inconsistencyModel->enrollment = 'ESTUDANTE';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'É OBRIGATÓRIO INFORMAR O CPF DO ESTUDANTE';
-                        $inconsistencyModel->action = 'INFORME UM CPF PARA O ESTUDANTE: ' . $enrollment['name'];
+                        $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'É obrigatório informar o cpf do estudante';
+                        $inconsistencyModel->action = 'Informe um cpf para o estudante: <strong>' . $enrollment['name'] . '<strong>';
                         $inconsistencyModel->identifier = '9';
                         $inconsistencyModel->idStudent = $enrollment['student_fk'];
                         $inconsistencyModel->insert();
@@ -1248,23 +1253,22 @@ class SagresConsultModel
 
                     if (!$this->validateDate($studentType->getDataNascimento())) {
                         $inconsistencyModel = new ValidationSagresModel();
-                        $inconsistencyModel->enrollment = 'ESTUDANTE';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'DATA NO FORMATO INVÁLIDO: ' . $enrollment['birthdate'];
-                        $inconsistencyModel->action = 'ADICIONE UMA DATA NO FORMATO VÁLIDA';
+                        $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'Data no formato inválido: ' . $enrollment['birthdate'];
+                        $inconsistencyModel->action = 'Adicione uma data no formato válido';
                         $inconsistencyModel->identifier = '9';
                         $inconsistencyModel->idStudent = $enrollment['student_fk'];
                         $inconsistencyModel->idClass = $classId;
                         $inconsistencyModel->insert();
                     }
 
-
                     if (strlen($studentType->getNome()) < $strlen) {
                         $inconsistencyModel = new ValidationSagresModel();
-                        $inconsistencyModel->enrollment = 'ESTUDANTE';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'NOME DO ESTUDANTE COM MENOS DE 5 CARACTERES';
-                        $inconsistencyModel->action = 'ADICIONE UM NOME PARA O ESTUDANTE COM PELO MENOS 5 CARACTERES';
+                        $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'Nome do estudante com menos de 5 caracteres';
+                        $inconsistencyModel->action = 'Adicione um nome para o estudante com pelo menos 5 caracteres';
                         $inconsistencyModel->identifier = '9';
                         $inconsistencyModel->idStudent = $enrollment['student_fk'];
                         $inconsistencyModel->idClass = $classId;
@@ -1273,10 +1277,10 @@ class SagresConsultModel
 
                     if ($studentType->getNome() > $strMaxLength) {
                         $inconsistencyModel = new ValidationSagresModel();
-                        $inconsistencyModel->enrollment = 'ESTUDANTE';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'NOME DO ESTUDANTE COM MAIS DE 200 CARACTERES';
-                        $inconsistencyModel->action = 'ADICIONE UM NOME PARA O ESTUDANTE COM ATÉ 200 CARACTERES';
+                        $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'Nome do estudante com mais de 200 caracteres';
+                        $inconsistencyModel->action = 'Adicione um nome para o estudante com até 200 caracteres';
                         $inconsistencyModel->identifier = '9';
                         $inconsistencyModel->idStudent = $enrollment['student_fk'];
                         $inconsistencyModel->idClass = $classId;
@@ -1285,10 +1289,10 @@ class SagresConsultModel
 
                     if (!is_bool(boolval($studentType->getPcd()))) {
                         $inconsistencyModel = new ValidationSagresModel();
-                        $inconsistencyModel->enrollment = 'ESTUDANTE';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'CÓDIGO PCD É INVÁLIDO';
-                        $inconsistencyModel->action = 'ADICIONE UM VALOR VÁLIDO PARA O PCD';
+                        $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'Código pcd é inválido';
+                        $inconsistencyModel->action = 'Adicione um valor válido para o pcd';
                         $inconsistencyModel->identifier = '9';
                         $inconsistencyModel->idStudent = $enrollment['student_fk'];
                         $inconsistencyModel->idClass = $classId;
@@ -1297,10 +1301,10 @@ class SagresConsultModel
 
                     if ($studentType->getDataNascimento() === false) {
                         $inconsistencyModel = new ValidationSagresModel();
-                        $inconsistencyModel->enrollment = 'ESTUDANTE';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'DATA DE NASCIMENTO INVÁLIDA';
-                        $inconsistencyModel->action = 'ALTERE O FORMATO DE DATA PARA DD/MM/AAAA';
+                        $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'Data de nascimento inválida';
+                        $inconsistencyModel->action = 'Altere o formato de data para dd/mm/aaaa';
                         $inconsistencyModel->identifier = '9';
                         $inconsistencyModel->idStudent = $enrollment['student_fk'];
                         $inconsistencyModel->idClass = $classId;
@@ -1309,10 +1313,10 @@ class SagresConsultModel
 
                     if (!in_array($studentType->getSexo(), [1, 2, 3])) {
                         $inconsistencyModel = new ValidationSagresModel();
-                        $inconsistencyModel->enrollment = 'ESTUDANTE';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'SEXO NÃO É VÁLIDO';
-                        $inconsistencyModel->action = 'ADICIONE UM SEXO VÁLIDO PARA O ESTUDANTE';
+                        $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'Sexo não é válido';
+                        $inconsistencyModel->action = 'Adicione um sexo válido para o estudante';
                         $inconsistencyModel->identifier = '9';
                         $inconsistencyModel->idStudent = $enrollment['student_fk'];
                         $inconsistencyModel->idClass = $classId;
@@ -1329,10 +1333,10 @@ class SagresConsultModel
 
                     if (is_null($studentType)) {
                         $inconsistencyModel = new ValidationSagresModel();
-                        $inconsistencyModel->enrollment = 'ESTUDANTE';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'ESTUDANTE NÃO EXISTE PARA A MATRÍCULA DA TURMA: ';
-                        $inconsistencyModel->action = 'ADICIONE UM ESTUDANTE À TURMA DA ESCOLA';
+                        $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'Estudante não existe para a matrícula da turma: ';
+                        $inconsistencyModel->action = 'Adicione um estudante à turma da escola';
                         $inconsistencyModel->identifier = '9';
                         $inconsistencyModel->idStudent = $enrollment['student_fk'];
                         $inconsistencyModel->idClass = $classId;
@@ -1346,9 +1350,9 @@ class SagresConsultModel
                     if (empty($enrollmentType)) {
                         $inconsistencyModel = new ValidationSagresModel();
                         $inconsistencyModel->enrollment = 'MATRÍCULA';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'NÃO HÁ MATRÍCULA PARA A TURMA';
-                        $inconsistencyModel->action = 'ADICIONE UMA MATRÍCULA PARA A TURMA';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'Não há matrícula para a turma';
+                        $inconsistencyModel->action = 'Adicione uma matrícula para a turma';
                         $inconsistencyModel->idClass = $classId;
                         $inconsistencyModel->insert();
                     }
@@ -1356,9 +1360,9 @@ class SagresConsultModel
                     if (!$this->validateDate($enrollmentType->getDataMatricula())) {
                         $inconsistencyModel = new ValidationSagresModel();
                         $inconsistencyModel->enrollment = 'MATRÍCULA';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'DATA NO FORMATO INVÁLIDO';
-                        $inconsistencyModel->action = 'ADICIONE UMA DATA NO FORMATO VÁLIDO';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'Data no formato inválido';
+                        $inconsistencyModel->action = 'Adicione uma data no formato válido';
                         $inconsistencyModel->idClass = $classId;
                         $inconsistencyModel->insert();
                     }
@@ -1366,19 +1370,20 @@ class SagresConsultModel
                     if (!is_int($enrollmentType->getNumeroFaltas())) {
                         $inconsistencyModel = new ValidationSagresModel();
                         $inconsistencyModel->enrollment = 'MATRÍCULA';
-                        $inconsistencyModel->school = '';
-                        $inconsistencyModel->description = 'O VALOR PARA O NÚMERO DE FALTAS É INVÁLIDO';
-                        $inconsistencyModel->action = 'COLOQUE UM VALOR VÁLIDO PARA O NÚMERO DE FALTAS';
+                        $inconsistencyModel->school = $school->name;
+                        $inconsistencyModel->description = 'O valor para o número de faltas é inválido';
+                        $inconsistencyModel->action = 'Coloque um valor válido para o número de faltas';
                         $inconsistencyModel->idClass = $classId;
                         $inconsistencyModel->insert();
                     }
+                    
                     if (filter_var($finalClass, FILTER_VALIDATE_BOOLEAN)) {
                         if (!is_bool($enrollmentType->getAprovado())) {
                             $inconsistencyModel = new ValidationSagresModel();
                             $inconsistencyModel->enrollment = 'MATRÍCULA';
-                            $inconsistencyModel->school = '';
-                            $inconsistencyModel->description = 'VALOR INVÁLIDO PARA O STATUS APROVADO';
-                            $inconsistencyModel->action = 'ADICIONE UM VALOR VÁLIDO PARA O CAMPO APROVADO DO ALUNO: ' . $studentType->getNome();
+                            $inconsistencyModel->school = $school->name;
+                            $inconsistencyModel->description = 'Valor inválido para o status aprovado';
+                            $inconsistencyModel->action = 'Adicione um valor válido para o campo aprovado do aluno: ' . $studentType->getNome();
                             $inconsistencyModel->idClass = $classId;
                             $inconsistencyModel->insert();
                         }

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.76.127');
+define("TAG_VERSION", '3.76.128');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');


### PR DESCRIPTION
## Motivação
Algumas inconsistências estavam ocorrendo e não estava sendo exibido as informações sobre a escola e os nomes das turmas. 

## Alterações Realizadas
Para resolver esse problema, foram realizadas alterações adicionando o campo "inpe_id", que permite a identificação da escola e das turmas.

## Fluxo de Teste

### `🧪 Test 01 `

1. Clicar em Integrações -> Sagres
2. Selecione um mês
3. Clique em Exportar Unidade
4. Clique em Inconsistências

Se estiver mostrando a escola na coluno 'ESCOLA' juntamente com os nomes das turmas, caso haja inconsistencias para este tipo, o teste e passou. Antes não mostrava o nome da escola na coluna escola e não mostrava o nome da turma.a

## Migrations Utilizadas

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
