### PR TITLE
Fix: correction in description class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.76.129]
+- Correção na descrição da séries para as inconsistências sagres
+
 ## [Versão 3.76.128]
 - Corrigido erro que não mostrava o nome da escola e das turmas nas inconsistências sagres
 - Corrigido na busca por profissional na mesma escola

--- a/app/modules/sagres/models/SagresConsultModel.php
+++ b/app/modules/sagres/models/SagresConsultModel.php
@@ -25,12 +25,17 @@ use ValidationSagresModel;
 use Yii;
 use ZipArchive;
 
+define('TURMA_STRONG', '<strong>TURMA<strong>');
+define('SERIE_STRONG', '<strong>SÉRIE<strong>');
+
+
 /**
  * Summary of SagresConsultModel
  */
 class SagresConsultModel
 {
     private $dbCommand;
+    
 
     public function __construct()
     {
@@ -368,7 +373,7 @@ class SagresConsultModel
              */
             if (!in_array($classType->getPeriodo(), [0, 1, 2])) {
                 $inconsistencyModel = new ValidationSagresModel();
-                $inconsistencyModel->enrollment = '<strong>TURMA<strong>';
+                $inconsistencyModel->enrollment = TURMA_STRONG;
                 $inconsistencyModel->school = $schoolRes['name'];
                 $inconsistencyModel->description = 'Valor inválido para o período';
                 $inconsistencyModel->action = 'Adicione um valor válido para o período da turma: ' . $classType->getDescricao();
@@ -380,7 +385,7 @@ class SagresConsultModel
             
             if (strlen($classType->getDescricao()) <= $strlen && !is_null($classType->getDescricao())) {
                 $inconsistencyModel = new ValidationSagresModel();
-                $inconsistencyModel->enrollment = '<strong>TURMA<strong>';
+                $inconsistencyModel->enrollment = TURMA_STRONG;
                 $inconsistencyModel->school = $schoolRes['name'];
                 $inconsistencyModel->description = 'Descrição para a turma menor que 3 caracteres';
                 $inconsistencyModel->action = 'Adicione uma descrição mais detalhada, contendo mais de 5 caracteres';
@@ -392,7 +397,7 @@ class SagresConsultModel
             
             if (strlen($classType->getDescricao()) > $strMaxLength) {
                 $inconsistencyModel = new ValidationSagresModel();
-                $inconsistencyModel->enrollment = '<strong>TURMA<strong>';
+                $inconsistencyModel->enrollment = TURMA_STRONG;
                 $inconsistencyModel->school = $schoolRes['name'];
                 $inconsistencyModel->description = 'Descrição para a turma com mais de 50 caracteres';
                 $inconsistencyModel->action = 'Adicione uma descrição menos detalhada, contendo até 50 caracteres';
@@ -404,7 +409,7 @@ class SagresConsultModel
             
             if (!in_array($classType->getTurno(), [1, 2, 3, 4])) {
                 $inconsistencyModel = new ValidationSagresModel();
-                $inconsistencyModel->enrollment = '<strong>TURMA<strong>';
+                $inconsistencyModel->enrollment = TURMA_STRONG;
                 $inconsistencyModel->school = $schoolRes['name'];
                 $inconsistencyModel->description = 'Valor inválido para o turno da turma';
                 $inconsistencyModel->action = 'Selecione um turno válido para o horário de funcionamento';
@@ -416,7 +421,7 @@ class SagresConsultModel
             
             if (!is_bool($classType->getFinalTurma())) {
                 $inconsistencyModel = new ValidationSagresModel();
-                $inconsistencyModel->enrollment = '<strong>TURMA<strong>';
+                $inconsistencyModel->enrollment = TURMA_STRONG;
                 $inconsistencyModel->school = $schoolRes['name'];
                 $inconsistencyModel->description = 'Valor inválido para o final turma';
                 $inconsistencyModel->action = 'Selecione um valor válido para o encerramento do período';
@@ -460,7 +465,7 @@ class SagresConsultModel
 
                 if (empty($serieType)) {
                     $inconsistencyModel = new ValidationSagresModel();
-                    $inconsistencyModel->enrollment = '<strong>SÉRIE<strong>';
+                    $inconsistencyModel->enrollment = SERIE_STRONG;
                     $inconsistencyModel->school = $school->name;
                     $inconsistencyModel->description = 'Não há série para a escola: ' . $school->name;
                     $inconsistencyModel->action = 'Adicione uma série para a turma';
@@ -472,7 +477,7 @@ class SagresConsultModel
 
                 if (strlen($serieType->getDescricao()) <= $strlen) {
                     $inconsistencyModel = new ValidationSagresModel();
-                    $inconsistencyModel->enrollment = '<strong>SÉRIE<strong>';
+                    $inconsistencyModel->enrollment = SERIE_STRONG;
                     $inconsistencyModel->school = $school->name;
                     $inconsistencyModel->description = 'Descrição para a série: ' . $serieType->getDescricao() . ' menor que 3 caracteres';
                     $inconsistencyModel->action = 'Forneça uma descrição mais detalhada, contendo mais de 5 caracteres';
@@ -484,7 +489,7 @@ class SagresConsultModel
 
                 if (strlen($serieType->getDescricao()) > $strMaxLength) {
                     $inconsistencyModel = new ValidationSagresModel();
-                    $inconsistencyModel->enrollment = '<strong>SÉRIE<strong>';
+                    $inconsistencyModel->enrollment = SERIE_STRONG;
                     $inconsistencyModel->school = $school->name;
                     $inconsistencyModel->description = 'Descrição para a série: ' . $serieType->getDescricao() . ' com mais de 50 caracteres';
                     $inconsistencyModel->action = 'Forneça uma descrição menos detalhada, contendo até 50 caracteres';
@@ -502,7 +507,7 @@ class SagresConsultModel
                  */
                 if (!in_array($serieType->getModalidade(), [1, 2, 3, 4, 5])) {
                     $inconsistencyModel = new ValidationSagresModel();
-                    $inconsistencyModel->enrollment = '<strong>SÉRIE<strong>';
+                    $inconsistencyModel->enrollment = SERIE_STRONG;
                     $inconsistencyModel->school = $school->name;
                     $inconsistencyModel->description = 'Modalidade inválida';
                     $inconsistencyModel->action = 'Selecione uma modalidade válida para a série';

--- a/app/modules/sagres/models/SagresConsultModel.php
+++ b/app/modules/sagres/models/SagresConsultModel.php
@@ -326,7 +326,7 @@ class SagresConsultModel
         
         if(empty($turmas)) {
             $inconsistencyModel = new ValidationSagresModel();
-            $inconsistencyModel->enrollment = 'ESCOLA';
+            $inconsistencyModel->enrollment = '<strong>ESCOLA<strong>';
             $inconsistencyModel->school = $schoolName;
             $inconsistencyModel->description = 'Não há turmas para a escola: ' . $schoolName;
             $inconsistencyModel->action = 'Adicione turmas para a escola';
@@ -368,7 +368,7 @@ class SagresConsultModel
              */
             if (!in_array($classType->getPeriodo(), [0, 1, 2])) {
                 $inconsistencyModel = new ValidationSagresModel();
-                $inconsistencyModel->enrollment = 'TURMA';
+                $inconsistencyModel->enrollment = '<strong>TURMA<strong>';
                 $inconsistencyModel->school = $schoolRes['name'];
                 $inconsistencyModel->description = 'Valor inválido para o período';
                 $inconsistencyModel->action = 'Adicione um valor válido para o período da turma: ' . $classType->getDescricao();
@@ -380,7 +380,7 @@ class SagresConsultModel
             
             if (strlen($classType->getDescricao()) <= $strlen && !is_null($classType->getDescricao())) {
                 $inconsistencyModel = new ValidationSagresModel();
-                $inconsistencyModel->enrollment = 'TURMA';
+                $inconsistencyModel->enrollment = '<strong>TURMA<strong>';
                 $inconsistencyModel->school = $schoolRes['name'];
                 $inconsistencyModel->description = 'Descrição para a turma menor que 3 caracteres';
                 $inconsistencyModel->action = 'Adicione uma descrição mais detalhada, contendo mais de 5 caracteres';
@@ -392,7 +392,7 @@ class SagresConsultModel
             
             if (strlen($classType->getDescricao()) > $strMaxLength) {
                 $inconsistencyModel = new ValidationSagresModel();
-                $inconsistencyModel->enrollment = 'TURMA';
+                $inconsistencyModel->enrollment = '<strong>TURMA<strong>';
                 $inconsistencyModel->school = $schoolRes['name'];
                 $inconsistencyModel->description = 'Descrição para a turma com mais de 50 caracteres';
                 $inconsistencyModel->action = 'Adicione uma descrição menos detalhada, contendo até 50 caracteres';
@@ -404,7 +404,7 @@ class SagresConsultModel
             
             if (!in_array($classType->getTurno(), [1, 2, 3, 4])) {
                 $inconsistencyModel = new ValidationSagresModel();
-                $inconsistencyModel->enrollment = 'TURMA';
+                $inconsistencyModel->enrollment = '<strong>TURMA<strong>';
                 $inconsistencyModel->school = $schoolRes['name'];
                 $inconsistencyModel->description = 'Valor inválido para o turno da turma';
                 $inconsistencyModel->action = 'Selecione um turno válido para o horário de funcionamento';
@@ -416,7 +416,7 @@ class SagresConsultModel
             
             if (!is_bool($classType->getFinalTurma())) {
                 $inconsistencyModel = new ValidationSagresModel();
-                $inconsistencyModel->enrollment = 'TURMA';
+                $inconsistencyModel->enrollment = '<strong>TURMA<strong>';
                 $inconsistencyModel->school = $schoolRes['name'];
                 $inconsistencyModel->description = 'Valor inválido para o final turma';
                 $inconsistencyModel->action = 'Selecione um valor válido para o encerramento do período';
@@ -452,14 +452,15 @@ class SagresConsultModel
         $series = Yii::app()->db->createCommand($query)->bindValue(":id", $classId)->queryAll();
 
         foreach ($series as $serie) {
+            $serie = (object) $serie;
             $serieType = new SerieTType();
             $serieType
-                ->setDescricao($serie['serieDescription'])
-                ->setModalidade($serie['serieModality']);
+                ->setDescricao($serie->serieDescription)
+                ->setModalidade($serie->serieModality);
 
                 if (empty($serieType)) {
                     $inconsistencyModel = new ValidationSagresModel();
-                    $inconsistencyModel->enrollment = 'SÉRIE';
+                    $inconsistencyModel->enrollment = '<strong>SÉRIE<strong>';
                     $inconsistencyModel->school = $school->name;
                     $inconsistencyModel->description = 'Não há série para a escola: ' . $school->name;
                     $inconsistencyModel->action = 'Adicione uma série para a turma';
@@ -471,7 +472,7 @@ class SagresConsultModel
 
                 if (strlen($serieType->getDescricao()) <= $strlen) {
                     $inconsistencyModel = new ValidationSagresModel();
-                    $inconsistencyModel->enrollment = 'SÉRIE';
+                    $inconsistencyModel->enrollment = '<strong>SÉRIE<strong>';
                     $inconsistencyModel->school = $school->name;
                     $inconsistencyModel->description = 'Descrição para a série: ' . $serieType->getDescricao() . ' menor que 3 caracteres';
                     $inconsistencyModel->action = 'Forneça uma descrição mais detalhada, contendo mais de 5 caracteres';
@@ -483,7 +484,7 @@ class SagresConsultModel
 
                 if (strlen($serieType->getDescricao()) > $strMaxLength) {
                     $inconsistencyModel = new ValidationSagresModel();
-                    $inconsistencyModel->enrollment = 'SÉRIE';
+                    $inconsistencyModel->enrollment = '<strong>SÉRIE<strong>';
                     $inconsistencyModel->school = $school->name;
                     $inconsistencyModel->description = 'Descrição para a série: ' . $serieType->getDescricao() . ' com mais de 50 caracteres';
                     $inconsistencyModel->action = 'Forneça uma descrição menos detalhada, contendo até 50 caracteres';
@@ -501,7 +502,7 @@ class SagresConsultModel
                  */
                 if (!in_array($serieType->getModalidade(), [1, 2, 3, 4, 5])) {
                     $inconsistencyModel = new ValidationSagresModel();
-                    $inconsistencyModel->enrollment = 'SÉRIE';
+                    $inconsistencyModel->enrollment = '<strong>SÉRIE<strong>';
                     $inconsistencyModel->school = $school->name;
                     $inconsistencyModel->description = 'Modalidade inválida';
                     $inconsistencyModel->action = 'Selecione uma modalidade válida para a série';

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.76.128');
+define("TAG_VERSION", '3.76.129');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');


### PR DESCRIPTION
## Motivação
Ao tentar gerar o arquivo para verificar as inconsistência e em seguida fazer as devidas correções, está aparecendo uma inconsistência que não condiz com o real, ou seja, a inconsistência informa que tem quantidade de caractere inferior ao obrigatório (que são 5), ao verificar as turmas constata-se que a quantidade de caractere atende a quantidade mínima exigida.

O problema estava na branch `main`:

```
$serieType
  ->setDescricao($serie['serieDescriptiactionon'])
```

Mas na `dev` estava correto:
```
$serieType
  ->setDescricao($serie['serieDescription'])
```

## Alterações Realizadas
O código foi refatorado para converter os elementos do array em objetos.

## Fluxo de Teste
### `🧪 Teste 01`

```
1.  Acesse o menu "Integrações" e clique em "Sagres".
2.  Selecione um mês.
3.  Clique em "Exportar Unidade".
4.  Clique em "Inconsistências".
```

5. **Verificação:** Verifique se existem inconsistências do tipo de cadastro `SÉRIE` com a descrição conforme indicado na imagem abaixo:

   ![image-20240327-110015](https://github.com/ipti/br.tag/assets/117388330/75953d02-65c0-40c7-89f4-76302059e504)
6. **Verificação Adicional:** Para cada inconsistência encontrada, verifique se a descrição da turma tem menos de 3 caracteres.
   
7. **Resultado Esperado:**
   - Se a descrição da turma tiver menos de 3 caracteres, o teste passou ✅.
   - Se a descrição da turma tiver 3 ou mais caracteres e tenha a inconsistência sendo mostrada, o teste falhou ❌.


## Migrations Utilizadas

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
