### PR TITLE
Feat/school management signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.78.130]
+- Adicionado campo para a assinatura do diretor 
+
 ## [Versão 3.77.130]
 - Criando as telas relacionadas a agricultor no novo módulo de merenda escolar
 

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.77.130');
+define("TAG_VERSION", '3.78.130');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');

--- a/themes/default/views/forms/EnrollmentDeclarationReport.php
+++ b/themes/default/views/forms/EnrollmentDeclarationReport.php
@@ -377,13 +377,18 @@ $school = SchoolIdentification::model()->findByPk(Yii::app()->user->school);
 
                 <span id="box-obs">
                     <br>
-                    OBS: <textarea id="obs" placeholder="Digite aqui sua observação."></textarea>
+                         OBS: <textarea id="obs" placeholder="Digite aqui sua observação."></textarea>
                 </span>
                 <br/><br/><br/><br/>
                 <span class="pull-right">
                     <?=$school->edcensoCityFk->name?>(<?=$school->edcensoUfFk->acronym?>), <?php echo date('d') . " de " . yii::t('default', date('F')) . " de " . date('Y') . "." ?>
                 </span>
                 <br/><br/><br/><br/>
+                <p style="margin: 0 auto; text-align: center; width:600px">
+                _______________________________________________________<br>
+                    <b>ASSINATURA DO DIRETOR(A)/SECRETÁRIO(A)</b>
+                </p>
+                <br>
                 <?php if(!(isset($school->act_of_acknowledgement))){?>
                     <!--<div style="text-align: center">
                         <span style="font-size: 14px">


### PR DESCRIPTION
## Motivação
Na seção de declaração dos estudantes no TAG, não havia nenhum campo designado para a assinatura da direção escolar.

## Alterações Realizadas
Um campo para a assinatura por parte do diretor foi adicionado.

![Screenshot 2024-04-10 191050](https://github.com/ipti/br.tag/assets/117388330/aedbe1a9-b7aa-4aed-82d1-300665880eac)


## Fluxo de Teste

### `🧪 Teste 01` 
1. Acesse a seção "Alunos".
2. Selecione um aluno.
3. Navegue até a seção "Matrícula".
4. Escolha uma matrícula associada ao aluno selecionado.
5. Clique na opção "Declaração de Matrícula".

Se o relatório incluir o campo de assinatura do diretor/secretário, o teste será considerado bem-sucedido. Caso contrário, o teste será considerado falho.


## Migrations Utilizadas

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
