### PR TITLE
Fix/add lunch unities [Versão 3.77.132]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.77.132]
+- Adicionado unidades de medida para o lançamento no estoque
+
 ## [Versão 3.77.130]
 - Criando as telas relacionadas a agricultor no novo módulo de merenda escolar
 

--- a/app/migrations/2024-06-04_add_lunch_unities/sql.sql
+++ b/app/migrations/2024-06-04_add_lunch_unities/sql.sql
@@ -1,0 +1,14 @@
+insert into lunch_unity (name, acronym) values
+("Grama", "G"),
+("Mililitro", "ML"),
+("Unidade", "U"),
+("Duzia", "DZ"),
+("Pacote", "PCT");
+
+UPDATE lunch_unity
+SET acronym = 'L'
+WHERE acronym = 'ML' AND name = 'litro';
+
+UPDATE lunch_unity
+SET acronym = 'ML'
+WHERE acronym = 'mL' AND name = 'Mililitro';

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.77.130');
+define("TAG_VERSION", '3.77.132');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');

--- a/themes/default/views/lunch/stock/index.php
+++ b/themes/default/views/lunch/stock/index.php
@@ -173,7 +173,7 @@ $cs->registerCssFile($baseUrl . '/css/lunch.css');
                 </div>
                 <div class="widget-body" style="overflow: hidden;">
                     <div class="row-fluid">
-                        <div class=" span6" style="margin-right:12px">
+                        <div class=" span5" style="margin-right:12px">
                             <?= CHtml::label(Yii::t('lunchModule.labels', 'Name'), 'Name', array('class' => 'control-label')); ?>
                             <div class="controls span12">
                                 <?= CHtml::textField('Item[name]', '', ['class' => ' span10', 'style' => 'height:44px;width:100%;']); ?>
@@ -191,14 +191,14 @@ $cs->registerCssFile($baseUrl . '/css/lunch.css');
                                 <?= CHtml::numberField('Item[measure]', '1', ['min' => '0', 'step' => '1', 'class' => 'span10', 'style' => 'height:44px;width:100%;']); ?>
                             </div>
                         </div>
-                        <div class=" span2" style="width: 10%;">
+                        <div class=" span2" style="">
                             <?= CHtml::label(Yii::t('lunchModule.labels', 'Measure'), 'Measure', array('class' => 'control-label', 'style' => 'width:auto')); ?>
                             <div class="controls span12">
                                 <?= CHtml::dropDownList(
                                     'Item[unity_fk]',
                                     '',
-                                    CHtml::listData(Unity::model()->findAll(), 'id', 'acronym'),
-                                    ['class' => ' span8', 'style' => 'width:100%']
+                                    CHtml::listData(Unity::model()->findAll(), 'id', 'name'),
+                                    ['class' => ' span10', 'style' => 'width:100%']
                                 ); ?>
                             </div>
                         </div>


### PR DESCRIPTION
## :adhesive_bandage: Motivação
Adicionar unidades de medidas necessárias para o lançamento no estoque segundo o relatado no chamado de chave TCDA-349.

## :adhesive_bandage: Alterações Realizadas

 Foi criada uma migration com as novas unidades de medida para a tabela lunch_unity do módulo de merenda antigo bem como uma pequena correção visual no modal de lançamento de estoque

## :adhesive_bandage: Fluxo de Teste
 Após rodar a migration indicada na seção abaixo você deve desabilitar o novo módulo de merenda caso esteja ativo no seu localhost. Após isso, navegue até a tela de estoque e clique no botão de _adicionar ao estoque_ . Quando o modal de lançamento de estoque for aberto clique no icone de "panela" ele abrira um novo formulário. Nesse formulário, verifique no select de _medidas_ se as novas unidades de medidas estão disponíveis e realize o lançamento no estoque.

 tela de estoque
![image](https://github.com/ipti/br.tag/assets/84946326/2982b1b7-efa4-43dc-8337-b02c02a49c38)

modal de lançamento de estoque(1/2):
![image](https://github.com/ipti/br.tag/assets/84946326/800324ea-807f-4254-92c0-fcf9a190c9c0)

modal de lançamento de estoque(2/2):
![image](https://github.com/ipti/br.tag/assets/84946326/bf04fa8d-c7e0-4ea3-a06b-2c6e65781c48)


## :adhesive_bandage: Migrations Utilizadas
      2024-06-04_add_lunch_unities

## :adhesive_bandage: Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
