### PR TITLE
Fix: date range correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.77.135]
+- Foi corrigido para incluir o intervalo de 1900 até o ano corrente
+
 ## [Versão 3.77.134]
 - Consertado tela de frequencia para os professores
 -

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.77.134');
+define("TAG_VERSION", '3.77.135');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');

--- a/themes/default/views/school/_form.php
+++ b/themes/default/views/school/_form.php
@@ -247,7 +247,6 @@ $form = $this->beginWidget('CActiveForm', array(
                                     array('class' => 't-field-text__label')
                                 ); ?>       
 								<?php 
-                                    $yearRange = (date('Y')-1) . ":";
 									$this->widget('zii.widgets.jui.CJuiDatePicker', array(
                                         'model' => $modelSchoolIdentification,
                                         'attribute' => 'initial_date',
@@ -255,7 +254,7 @@ $form = $this->beginWidget('CActiveForm', array(
                                             'dateFormat' => 'dd/mm/yy',
                                             'changeYear' => true,
                                             'changeMonth' => true,
-                                            'yearRange' => $yearRange . date('Y'),
+                                            'yearRange' => "1900:" . date('Y'),
                                                 'showOn' => 'focus',
                                                 'maxDate' => 0
                                         ),


### PR DESCRIPTION
## Motivação
O intervalo de datas para o ano de início da escola não estava correto.

## Alterações Realizadas
Foi corrigido para incluir o intervalo de 1900 até o ano corrente.

## Fluxo de Teste

## Migrations Utilizadas

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
