### PR TITLE
Fix/sinalizacao faltas professores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.77.135]
+- Foram feitas modificações para garantir que os professores não possam adicionar um plano de aula para os dias em que estão marcados com falta.
+
 ## [Versão 3.77.134]
 - Consertado tela de frequencia para os professores
 - 

--- a/app/controllers/ClassesController.php
+++ b/app/controllers/ClassesController.php
@@ -177,10 +177,20 @@ class ClassesController extends Controller
                 }
             }
 
+            $command = Yii::app()->db->createCommand("
+                SELECT s.day
+                FROM instructor_faults if2 
+                JOIN schedule s ON if2.schedule_fk = s.id 
+                WHERE if2.instructor_fk = :instructor_id
+            ");
+            $command->bindValue(':instructor_id', 305);
+            $daysFaults = $command->queryColumn();
+
             echo json_encode([
                 "valid" => true,
                 "classContents" => $classContents,
                 "courseClasses" => $courseClasses,
+                "daysFaults" =>  $daysFaults
             ]);
         } else {
             echo json_encode(["valid" => false, "error" => "Mês/Ano " . ($_POST["fundamentalMaior"] == "1" ? "e Disciplina" : "") . " sem aula no Quadro de Horário."]);

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.77.134');
+define("TAG_VERSION", '3.77.135');
 
 
 define("YII_VERSION", Yii::getVersion());

--- a/js/classes/class-contents/functions.js
+++ b/js/classes/class-contents/functions.js
@@ -11,6 +11,13 @@ function createTable(data) {
     let accordionBuilt = false;
     let accordionHtml = "";
     accordionHtml += `<div id='accordion' class='t-accordeon-primary'>`
+
+    $arrayFaults = [];
+
+    $.each(data.daysFaults, function (index, daysFaults) {
+        $arrayFaults.push(daysFaults);
+    });
+
     $.each(data.classContents, function (day, classContent) {
         let studentInputs = "";
         if (Object.keys(classContent.students).length) {
@@ -39,11 +46,13 @@ function createTable(data) {
         }
 
         let head = '<th class="center vmiddle contents-day ">' + ((day < 10) ? '0' : '') + day + '</th>';
+        let disabledRow = (!classContent.available || $arrayFaults.includes(day)) ? "disabled" : "";
+        
         let body = '<td class="t-multiselect">'
             + '<input type="hidden" class="classroom-diary-of-the-day" value="' + classContent.diary + '">'
             + studentInputs
             + '<span class="t-icon-annotation t-icon classroom-diary-button ' + (!classContent.available ? "disabled" : "") + '" data-toggle="tooltip" title="Diário"></span>'
-            + '<select id="day[' + day + ']" name="day[' + day + '][]" class=" course-classes-select vmiddle" ' + (!classContent.available ? "disabled" : "") + ' multiple="yes">'
+            + '<select id="day[' + day + ']" name="day[' + day + '][]" class=" course-classes-select vmiddle" ' + disabledRow + ' multiple="yes">'
             + options
             + '</select>'
             + '</td>';

--- a/js/classes/class-contents/functions.js
+++ b/js/classes/class-contents/functions.js
@@ -12,10 +12,10 @@ function createTable(data) {
     let accordionHtml = "";
     accordionHtml += `<div id='accordion' class='t-accordeon-primary'>`
 
-    $arrayFaults = [];
+    arrayFaults = [];
 
     $.each(data.daysFaults, function (index, daysFaults) {
-        $arrayFaults.push(daysFaults);
+        arrayFaults.push(parseInt(daysFaults, 10));
     });
 
     $.each(data.classContents, function (day, classContent) {
@@ -46,7 +46,7 @@ function createTable(data) {
         }
 
         let head = '<th class="center vmiddle contents-day ">' + ((day < 10) ? '0' : '') + day + '</th>';
-        let disabledRow = (!classContent.available || $arrayFaults.includes(day)) ? "disabled" : "";
+        let disabledRow = (!classContent.available || arrayFaults.includes(parseInt(day, 10))) ? "disabled" : "";
         
         let body = '<td class="t-multiselect">'
             + '<input type="hidden" class="classroom-diary-of-the-day" value="' + classContent.diary + '">'


### PR DESCRIPTION
## Motivação
Anteriormente, a descrição para a falta de componentes curriculares ou a falta de professor para a turma estava incluída numa mesma notificação de inconsistências.

## Alterações Realizadas
As inconsistências foram separadas. Agora haverá uma notificação de inconsistências para a falta de componentes curriculares do professor e outra para a falta de professor para a turma.

## Fluxo de Teste

## Migrations Utilizadas

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
