### PR TITLE
Fix/sagres componentes curriculares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.77.135]
+- Adicionado novas inconsistências para a falta de componentes curriculasres
+
 ## [Versão 3.77.134]
 - Consertado tela de frequencia para os professores
 - 

--- a/app/modules/sagres/models/SagresConsultModel.php
+++ b/app/modules/sagres/models/SagresConsultModel.php
@@ -561,19 +561,37 @@ class SagresConsultModel
 
 
         $schedules = Yii::app()->db->createCommand($query)->bindValues($params)->queryAll();
-
         $class = (object) \Classroom::model()->findByAttributes(array('id' => $classId));
+       
 
-        if(empty($schedules)) {
+        $getTeachersForClass = $this->getTeachersForClass($classId);
+        if(empty($getTeachersForClass)) {
             $inconsistencyModel = new ValidationSagresModel();
-            $inconsistencyModel->enrollment = '<strong>HORÁRIO<strong>';
+            $inconsistencyModel->enrollment = TURMA_STRONG;
             $inconsistencyModel->school = $school->name;
-            $inconsistencyModel->description = 'Não há um quadro de horários para a turma: <strong>' . $class->name . '<strong>';
-            $inconsistencyModel->action = 'Adicione um quadro de horários para turma';
+            $inconsistencyModel->description = 'Não há professores registrados para a turma: <strong>' . $class->name . '<strong>';
+            $inconsistencyModel->action = 'Adicione os professores juntamente com os seus componentes curriculares';
             $inconsistencyModel->identifier = '10';
             $inconsistencyModel->idClass = $classId;
             $inconsistencyModel->idSchool = $inepId;
             $inconsistencyModel->insert();
+        }
+
+        if(!empty($getTeachersForClass)) {
+            foreach($getTeachersForClass as $teachers) {
+                $componentesCurriculares = $this->getComponentesCurriculares($classId, $teachers['instructor_fk']);
+                if(empty($componentesCurriculares)){
+                    $inconsistencyModel = new ValidationSagresModel();
+                    $inconsistencyModel->enrollment = TURMA_STRONG;
+                    $inconsistencyModel->school = $school->name;
+                    $inconsistencyModel->description = 'O professor <strong>' . $teachers['name'] . '</strong> está sem seus componentes curriculares para a turma: <strong>' . $class->name . '<strong>';
+                    $inconsistencyModel->action = 'Adicione os componentes curriculares para o professor: <strong>' . $teachers['name'] . '</strong>';
+                    $inconsistencyModel->identifier = '10';
+                    $inconsistencyModel->idClass = $classId;
+                    $inconsistencyModel->idSchool = $inepId;
+                    $inconsistencyModel->insert();
+                }   
+            }    
         }
 
 
@@ -682,7 +700,43 @@ class SagresConsultModel
         return $scheduleList;
     }
 
+    private function getComponentesCurriculares($classId, $instructorId) {
+        $query = "SELECT 
+                        *
+                    FROM instructor_teaching_data itd
+                        JOIN teaching_matrixes tm on itd.id = tm.teaching_data_fk
+                        JOIN curricular_matrix cm on tm.curricular_matrix_fk = cm.id
+                        JOIN classroom c on c.id = itd.classroom_id_fk
+                    WHERE
+                        c.id = :classId and
+                        itd.instructor_fk = :instructorId
+                    ORDER BY
+                        c.create_date DESC;";
+        $params = [
+            ':classId' => $classId,
+            ':instructorId' => $instructorId
+        ];
+    
+        return Yii::app()->db->createCommand($query)->bindValues($params)->queryAll();
+    }
 
+    private function getTeachersForClass($classId) {
+        $query = "SELECT itd.instructor_fk, ii.name
+                    FROM instructor_teaching_data itd
+                        JOIN instructor_identification ii ON ii.id = itd.instructor_fk 
+                        JOIN classroom c ON c.id = itd.classroom_id_fk
+                    WHERE
+                        c.id = :classId
+                    ORDER BY
+                        c.create_date DESC;";
+        $params = [
+            ':classId' => $classId
+        ];
+    
+        return Yii::app()->db->createCommand($query)->bindValues($params)->queryAll();
+    }
+    
+    
     /**
      * Calculates the start time for a given schedule and initial hour.
      *
@@ -1061,7 +1115,7 @@ class SagresConsultModel
                             $inconsistencyModel = new ValidationSagresModel();
                             $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
                             $inconsistencyModel->school = $school->name;
-                            $inconsistencyModel->description = 'Cpf do estudante é inválido';
+                            $inconsistencyModel->description = 'Cpf do estudante é inválido: <strong>' . $cpf . '<strong>';
                             $inconsistencyModel->action = 'Informe um cpf válido para o estudante: <strong>' . $enrollment['name'] . '<strong>';
                             $inconsistencyModel->identifier = '9';
                             $inconsistencyModel->idStudent = $enrollment['student_fk'];
@@ -1085,7 +1139,7 @@ class SagresConsultModel
                         $inconsistencyModel = new ValidationSagresModel();
                         $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
                         $inconsistencyModel->school = $school->name;
-                        $inconsistencyModel->description = 'Data no formato inválido: ' . $enrollment['birthdate'];
+                        $inconsistencyModel->description = 'Data no formato inválido: <strong>' . $enrollment['birthdate'] . '</strong>';
                         $inconsistencyModel->action = 'Adicione uma data no formato válido';
                         $inconsistencyModel->identifier = '9';
                         $inconsistencyModel->idStudent = $enrollment['student_fk'];
@@ -1237,7 +1291,7 @@ class SagresConsultModel
                             $inconsistencyModel = new ValidationSagresModel();
                             $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
                             $inconsistencyModel->school = $school->name;
-                            $inconsistencyModel->description = 'Cpf do estudante é inválido';
+                            $inconsistencyModel->description = 'Cpf do estudante é inválido: <strong>' . $cpf . '<strong>';
                             $inconsistencyModel->action = 'Informe um cpf válido para o estudante: <strong>' . $enrollment['name'] . '<strong>';
                             $inconsistencyModel->identifier = '9';
                             $inconsistencyModel->idStudent = $enrollment['student_fk'];
@@ -1535,7 +1589,7 @@ class SagresConsultModel
         }
 
         $d = DateTime::createFromFormat($format, $dat);
-        if (intval($d->format('Y')) <= 1900)
+        if (intval($d->format('Y')) <= 1924)
             return false;
 
         return $d && $d->format($format) == $dat;

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.77.134');
+define("TAG_VERSION", '3.77.135');
 
 
 define("YII_VERSION", Yii::getVersion());


### PR DESCRIPTION
## Motivação
Anteriormente, a descrição para a falta de componentes curriculares ou a falta de professor para a turma estava incluída numa mesma notificação de inconsistências.

## Alterações Realizadas
As inconsistências foram separadas. Agora haverá uma notificação de inconsistências para a falta de componentes curriculares do professor e outra para a falta de professor para a turma.

## Fluxo de Teste

## Migrations Utilizadas

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
