### PR TITLE
fix: allow delete matrix

### DIFF
--- a/app/modules/curricularmatrix/resources/common/js/curricularmatrix.js
+++ b/app/modules/curricularmatrix/resources/common/js/curricularmatrix.js
@@ -47,3 +47,21 @@ $(document).on("click", ".confirm-matrix-reuse", function () {
         $(".alert-container").show();
     });
 });
+
+$(".confirm-delete").on("click", function (e) {
+    e.preventDefault();
+    var th = this,
+        afterDelete = function () { };
+    jQuery('#matrizgridview').yiiGridView('update', {
+        type: 'POST',
+        url: jQuery(this).attr('href'),
+        success: function (data) {
+            jQuery('#matrizgridview').yiiGridView('update');
+            afterDelete(th, true, data);
+        },
+        error: function (XHR) {
+            return afterDelete(th, false, XHR);
+        }
+    });
+    return false;
+});

--- a/js/datatables/init.js
+++ b/js/datatables/init.js
@@ -128,7 +128,6 @@ function initDatatable() {
     }
 
     if ($(".js-tag-table").length) {
-        debugger;
         const isMobile = window.innerWidth <= 768;
         const numColumns = $(".js-tag-table th").length;
         const columnsIndex = new Array(numColumns - 1).fill(1).map((_, i) => i + 1);

--- a/themes/default/views/curricularmatrix/curricularmatrix/index.php
+++ b/themes/default/views/curricularmatrix/curricularmatrix/index.php
@@ -10,7 +10,7 @@ $baseScriptUrl = Yii::app()->controller->module->baseScriptUrl;
 $themeUrl = Yii::app()->theme->baseUrl;
 $cs = Yii::app()->getClientScript();
 $cs->registerCssFile($baseScriptUrl . '/common/css/layout.css?v=1.2');
-$cs->registerScriptFile($baseScriptUrl . '/common/js/curricularmatrix.js?v='.TAG_VERSION, CClientScript::POS_END);
+$cs->registerScriptFile($baseScriptUrl . '/common/js/curricularmatrix.js?v=' . TAG_VERSION, CClientScript::POS_END);
 $cs->registerScript("vars", "var addMatrix = '" . $this->createUrl("addMatrix") . "';", CClientScript::POS_HEAD);
 $this->setPageTitle('TAG - ' . Yii::t('curricularMatrixModule.index', 'Curricular Matrix'));
 //
@@ -26,49 +26,53 @@ $this->setPageTitle('TAG - ' . Yii::t('curricularMatrixModule.index', 'Curricula
         </div>
     </div>
     <div class="column">
-        <?php if (Yii::app()->getAuthManager()->checkAccess('admin', Yii::app()->user->loginInfos->id)) : ?>
+        <?php if (Yii::app()->getAuthManager()->checkAccess('admin', Yii::app()->user->loginInfos->id)): ?>
             <form onsubmit="return false">
-                    <div class="column" style="flex:4">
-                        <div class="row clear-margin--left">
-                            <div class="column">
-                                <div class="t-multiselect">
-                                    <?= CHtml::label(Yii::t('curricularMatrixModule.index', 'Stage'), 'stages', ['class' => "control-label"]) ?>
-                                    <?= CHtml::dropDownList("stages", [], CHtml::listData(EdcensoStageVsModality::model()->findAll(), "id", "name"), [
-                                        "multiple" => "multiple", "class" => "select-search-on control-input multiselect select3-choices"
-                                    ]) ?>
-                                </div>
-                            </div>
-                            <div class="column">
-                                <div class="t-multiselect">
-                                    <?= CHtml::label(Yii::t('curricularMatrixModule.index', 'Disciplines'), 'disciplines', ['class' => "control-label", 'style' => 'white-space: nowrap;']) ?>
-                                    <?= CHtml::dropDownList("disciplines", [], CHtml::listData(EdcensoDiscipline::model()->findAll(), "id", "name"), [
-                                        "multiple" => "multiple", "class" => "select-search-on control-input multiselect select3-choices"
-                                    ]) ?>
-                                </div>
+                <div class="column" style="flex:4">
+                    <div class="row clear-margin--left">
+                        <div class="column">
+                            <div class="t-multiselect">
+                                <?= CHtml::label(Yii::t('curricularMatrixModule.index', 'Stage'), 'stages', ['class' => "control-label"]) ?>
+                                <?= CHtml::dropDownList("stages", [], CHtml::listData(EdcensoStageVsModality::model()->findAll(), "id", "name"), [
+                                    "multiple" => "multiple",
+                                    "class" => "select-search-on control-input multiselect select3-choices"
+                                ]) ?>
                             </div>
                         </div>
-
-                        <div class="row clear-margin--left">
-                            <div class="column">
-                                <div class="t-field-number">
-                                    <?= CHtml::label(Yii::t('curricularMatrixModule.index', 'Workload'), 'workload', ['class' => "t-field-number__label control-label"]) ?>
-                                    <?= CHtml::numberField("workload", "0", ["min" => "0", "max" => "9999", 'style' => 'border: 1px solid #aaa;box-sizing:border-box;height: 43px']) ?>
-                                </div>
-                            </div>
-                            <div class="column">
-                                <div class="t-field-number">
-                                    <?= CHtml::label(Yii::t('curricularMatrixModule.index', 'Credits'), 'credits', ['class' => "t-field-number__label control-label"]) ?>
-                                    <?= CHtml::numberField("credits", "0", ["min" => "0", "max" => "9999", 'style' => 'border: 1px solid #aaa;box-sizing:border-box;height: 43px']) ?>
-                                </div>
+                        <div class="column">
+                            <div class="t-multiselect">
+                                <?= CHtml::label(Yii::t('curricularMatrixModule.index', 'Disciplines'), 'disciplines', ['class' => "control-label", 'style' => 'white-space: nowrap;']) ?>
+                                <?= CHtml::dropDownList("disciplines", [], CHtml::listData(EdcensoDiscipline::model()->findAll(), "id", "name"), [
+                                    "multiple" => "multiple",
+                                    "class" => "select-search-on control-input multiselect select3-choices"
+                                ]) ?>
                             </div>
                         </div>
                     </div>
 
-                    <div class="column justify-content--start">
-                        <?= CHtml::button(Yii::t('curricularMatrixModule.index', 'Add'), [
-                            "id" => "add-matrix", "class" => "t-button-primary", "style" => "padding: 10px 10px;margin:0px 15px"
-                        ]) ?>
+                    <div class="row clear-margin--left">
+                        <div class="column">
+                            <div class="t-field-number">
+                                <?= CHtml::label(Yii::t('curricularMatrixModule.index', 'Workload'), 'workload', ['class' => "t-field-number__label control-label"]) ?>
+                                <?= CHtml::numberField("workload", "0", ["min" => "0", "max" => "9999", 'style' => 'border: 1px solid #aaa;box-sizing:border-box;height: 43px']) ?>
+                            </div>
+                        </div>
+                        <div class="column">
+                            <div class="t-field-number">
+                                <?= CHtml::label(Yii::t('curricularMatrixModule.index', 'Credits'), 'credits', ['class' => "t-field-number__label control-label"]) ?>
+                                <?= CHtml::numberField("credits", "0", ["min" => "0", "max" => "9999", 'style' => 'border: 1px solid #aaa;box-sizing:border-box;height: 43px']) ?>
+                            </div>
+                        </div>
                     </div>
+                </div>
+
+                <div class="column justify-content--start">
+                    <?= CHtml::button(Yii::t('curricularMatrixModule.index', 'Add'), [
+                        "id" => "add-matrix",
+                        "class" => "t-button-primary",
+                        "style" => "padding: 10px 10px;margin:0px 15px"
+                    ]) ?>
+                </div>
 
             </form>
             <hr>
@@ -82,7 +86,7 @@ $this->setPageTitle('TAG - ' . Yii::t('curricularMatrixModule.index', 'Curricula
                     </div>
                 </div>
             </div>
-            <?php if (Yii::app()->user->hasFlash('success')) : ?>
+            <?php if (Yii::app()->user->hasFlash('success')): ?>
                 <div class="row-fluid">
                     <div class="span12">
                         <div class="alert alert-success">
@@ -91,7 +95,7 @@ $this->setPageTitle('TAG - ' . Yii::t('curricularMatrixModule.index', 'Curricula
                     </div>
                 </div>
             <?php endif ?>
-            <?php if (Yii::app()->user->hasFlash('error')) : ?>
+            <?php if (Yii::app()->user->hasFlash('error')): ?>
                 <div class="row-fluid">
                     <div class="span12">
                         <div class="alert alert-error">
@@ -103,26 +107,33 @@ $this->setPageTitle('TAG - ' . Yii::t('curricularMatrixModule.index', 'Curricula
             <div class="widget-body">
                 <?php
                 $this->widget('zii.widgets.grid.CGridView', [
-                    'id' => 'matrizgridview', 'dataProvider' => $dataProvider, 'ajaxUpdate' => false,
+                    'id' => 'matrizgridview',
+                    'dataProvider' => $dataProvider,
+                    'ajaxUpdate' => false,
                     'itemsCssClass' => 'js-tag-table curricularmatrix-table tag-table-primary table table-condensed table-striped table-hover table-primary table-vertical-center checkboxs',
-                    'enablePagination' => false, 'columns' => [
+                    'enablePagination' => false,
+                    'columns' => [
                         [
                             'header' => Yii::t('curricularMatrixModule.index', 'Stage'),
                             'name' => 'stage_fk',
                             'value' => '$data->stageFk->name',
-                        ], [
+                        ],
+                        [
                             'header' => Yii::t('curricularMatrixModule.index', 'Discipline'),
                             'name' => 'discipline_fk',
                             'value' => '$data->disciplineFk->name',
-                        ], [
+                        ],
+                        [
                             'header' => Yii::t('curricularMatrixModule.index', 'Workload'),
                             'name' => 'workload',
                             'htmlOptions' => ['width' => '150px']
-                        ], [
+                        ],
+                        [
                             'header' => Yii::t('curricularMatrixModule.index', 'Credits'),
                             'name' => 'credits',
                             'htmlOptions' => ['width' => '150px']
-                        ], [
+                        ],
+                        [
                             'header' => 'Ações',
                             'class' => 'CButtonColumn',
                             'template' => Yii::app()->getAuthManager()->checkAccess('admin', Yii::app()->user->loginInfos->id) ? '{delete}' : '',
@@ -140,26 +151,32 @@ $this->setPageTitle('TAG - ' . Yii::t('curricularMatrixModule.index', 'Curricula
             </div>
         </div>
         <div class="reuse">
-            <a class="matrix-reuse" href="javascript:;"><?php echo 'Reaproveitamento da Matriz Curricular de ' . (Yii::app()->user->year - 1) ?></a>
+            <a class="matrix-reuse"
+                href="javascript:;"><?php echo 'Reaproveitamento da Matriz Curricular de ' . (Yii::app()->user->year - 1) ?></a>
         </div>
     </div>
 </div>
-<div class="modal fade modal-content" id="matrix-reuse-modal" tabindex="-1" role="dialog" aria-labelledby="Reaproveitamento de Matriz Curricular">
+<div class="modal fade modal-content" id="matrix-reuse-modal" tabindex="-1" role="dialog"
+    aria-labelledby="Reaproveitamento de Matriz Curricular">
     <div class="modal-dialog" role="document">
         <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-label="Close" style="position:static;">
-                <img src="<?php echo Yii::app()->theme->baseUrl; ?>/img/Close.svg" alt="" style="vertical-align: -webkit-baseline-middle">
+                <img src="<?php echo Yii::app()->theme->baseUrl; ?>/img/Close.svg" alt=""
+                    style="vertical-align: -webkit-baseline-middle">
             </button>
             <h4 class="modal-title" id="myModalLabel">Reaproveitamento de Matriz Curricular</h4>
         </div>
         <form method="post">
             <div class="modal-body">
                 <div class="row-fluid">
-                    <b>Tem certeza</b> que deseja reaproveitar a matriz curricular de <?php echo (Yii::app()->user->year - 1) ?>?</b>
+                    <b>Tem certeza</b> que deseja reaproveitar a matriz curricular de
+                    <?php echo (Yii::app()->user->year - 1) ?>?</b>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="tag-button-light btn btn-default" data-dismiss="modal">Cancelar</button>
-                    <button type="button" class="btn btn-primary confirm-matrix-reuse" data-dismiss="modal">Confirmar</button>
+                    <button type="button" class="tag-button-light btn btn-default"
+                        data-dismiss="modal">Cancelar</button>
+                    <button type="button" class="btn btn-primary confirm-matrix-reuse"
+                        data-dismiss="modal">Confirmar</button>
                 </div>
             </div>
         </form>


### PR DESCRIPTION
## Motivação

Alguns municípios relataram problemas ao deletar as matrizes curriculares.

## Alterações Realizadas

Foram removidas as validações que impediam a remoção da matriz, agora permite deletar a Matriz e em cascata deleta presença e o registro do quadro de horário vinculado a essa matriz.

## Fluxo de Teste

Como administrador, ao deletar uma matriz, deve aparecer uma confirmação avisando dos riscos de deletar uma matriz curricular.

Como administrador, ao confirmar a ação de deletar uma matriz, deve remover a matriz da listagem.

## Migrations Utilizadas

Nenhum.

## Checklist de revisão
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
