### PR TITLE
[TCDA-475] Fix/erro-educacenso-stage

### DIFF
--- a/app/controllers/CensoController.php
+++ b/app/controllers/CensoController.php
@@ -648,8 +648,8 @@ class CensoController extends Controller
         if (!$result['status']) array_push($log, array('stage' => $result['erro']));
 
         //campo 39
-        $result = $crv->isValidProfessionalEducation($column['course'], $column['edcenso_stage_vs_modality_fk']);
-        if (!$result['status']) array_push($log, array('course' => $result['erro']));
+        $result = $crv->isValidProfessionalEducation($column['modality'], $column['course'], $column['edcenso_stage_vs_modality_fk']);
+        if ( !$result['status']) array_push($log, array('course' => $result['erro']));
 
         //campos 40 a 65
 //        $disciplinesArray = array($column['discipline_chemistry'], $column['discipline_physics'], $column['discipline_mathematics'], $column['discipline_biology'], $column['discipline_science'],

--- a/app/extensions/Validator/ClassroomValidation.php
+++ b/app/extensions/Validator/ClassroomValidation.php
@@ -413,18 +413,18 @@ class ClassroomValidation extends Register
     }
 
     //campo 39
-    function isValidProfessionalEducation($professionalEducation, $stage)
+    function isValidProfessionalEducation($modality, $professionalEducation, $stage)
     {
-        $emptyProfessionalEducation = $this->isEmpty($professionalEducation);
+        // $emptyProfessionalEducation = $this->isEmpty($professionalEducation);
 
-        if (strlen($professionalEducation) > 8) {
-            return array('status' => false, 'erro' => 'O campo deve ter no maximo 8 caracteres');
-        }
+        // if (strlen($professionalEducation) > 8) {
+        //     return array('status' => false, 'erro' => 'O campo deve ter no maximo 8 caracteres');
+        // }
 
-        if ($emptyProfessionalEducation['status'] && in_array($stage, array(30, 31, 32, 33, 34, 39, 40, 64, 74))) {
-            return array('status' => false, 'erro' => $this->replaceCodeModalities('O campo deve ser preenchido quando a etapa for 30, 31, 32, 33, 34, 39, 40, 64 ou 74'));
-        }
-        if (!$emptyProfessionalEducation['status'] && !in_array($stage, array(30, 31, 32, 33, 34, 39, 40, 64, 74))) {
+        // if ($emptyProfessionalEducation['status'] && in_array($stage, array(30, 31, 32, 33, 34, 39, 40, 64, 74))) {
+        //     return array('status' => false, 'erro' => $this->replaceCodeModalities('O campo deve ser preenchido quando a etapa for 30, 31, 32, 33, 34, 39, 40, 64 ou 74'));
+        // }
+        if ($modality == 4 && !in_array($stage, array(30, 31, 32, 33, 34, 39, 40, 73, 74, 64, 67, 68))) {
             return array('status' => false, 'erro' => $this->replaceCodeModalities('O campo nao pode ser preenchido quando a etapa for 30, 31, 32, 33, 34, 39, 40, 64 ou 74'));
         }
 

--- a/app/migrations/2024-05-21-update-classroom-modality-set-100/2024-05-21-update-classroom-modality-set-100.sql
+++ b/app/migrations/2024-05-21-update-classroom-modality-set-100/2024-05-21-update-classroom-modality-set-100.sql
@@ -1,0 +1,3 @@
+UPDATE classroom
+SET modality = '100'
+WHERE modality = '4';

--- a/instance.php
+++ b/instance.php
@@ -15,7 +15,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'buzios.tag.ong.br';
+    $newdb = 'demo.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;

--- a/instance.php
+++ b/instance.php
@@ -15,7 +15,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'demo.tag.ong.br';
+    $newdb = 'buzios.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;

--- a/themes/default/views/classroom/_form.php
+++ b/themes/default/views/classroom/_form.php
@@ -167,8 +167,9 @@ $form = $this->beginWidget(
                                     '1' => 'Ensino Regular',
                                     '2' => 'Educação Especial - Modalidade Substitutiva',
                                     '3' => 'Educação de Jovens e Adultos (EJA)',
-                                    '4' => 'Não se aplica',
-                                    '5' => 'Atendimento Educacional Especializado'
+                                    '4' => 'Profissional',
+                                    '5' => 'Atendimento Educacional Especializado',
+                                    '100' => 'Não se aplica'
                                 ), array('prompt' => 'Selecione a Modalidade', 'class' => 'select-search-off t-field-select__input', 'style' => 'width: 100%'));
                                 ?>
                                 <?php echo $form->error($modelClassroom, 'modality'); ?>

--- a/themes/default/views/classroom/_form.php
+++ b/themes/default/views/classroom/_form.php
@@ -167,7 +167,7 @@ $form = $this->beginWidget(
                                     '1' => 'Ensino Regular',
                                     '2' => 'Educação Especial - Modalidade Substitutiva',
                                     '3' => 'Educação de Jovens e Adultos (EJA)',
-                                    '4' => 'Profissional',
+                                    '4' => 'Educação Profissional',
                                     '5' => 'Atendimento Educacional Especializado',
                                     '100' => 'Não se aplica'
                                 ), array('prompt' => 'Selecione a Modalidade', 'class' => 'select-search-off t-field-select__input', 'style' => 'width: 100%'));


### PR DESCRIPTION
## 🚨 Motivação
Erro na tela do educacenso: O campo nao pode ser preenchido quando a etapa for Curso Técnico Integrado (Ensino Médio Integrado)...
 
## 🚨 Alterações Realizadas
- Implementada uma migration para alterar os dados das modalidades das turmas, caso sejam o número 4, agora receberá o valor 100.
- Adicionada opção de “Ensino Profissional”, ao cadastrar uma turma.
- Alterada função de validação, para aparecer a mensagem de erro apenas quando a modalidade for ensino profissional e as etapas forem diferente de 30, 31, 32, 33, 34, 39, 40, 73, 74, 64, 67, 68
 
## 🚨 Fluxo de Teste
- Realize a migration.
- Entrar na tela de turmas.
- Selecionar uma turma.
- Selecionar a Etapa de Ensino: Ensino Fundamental de 9 anos - Multi.
- Selecionar Modalidade: Educação Profissional.
- Salvar a alteração.
- Entrar na tela de educacenso, verificar se a turma aparece o erro: 
`Curso - O campo nao pode ser preenchido quando a etapa for Curso Técnico Integrado (Ensino Médio Integrado) Educação Infantil - Creche (0 a Educação Infantil - Unificad...`
 - Aperte em corrigir.
 - Mude a modalidade para: Não se aplica.
 - Verifique se o erro sumiu do educacenso.
 
✅ Caso tenha sumido o caso de teste está correto.

## 🚨 Migrations Utilizadas
`2024-05-21-update-classroom-modality-set-100.sql`
 
## 🚨 Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
