### PR TITLE
[TCDA - 569] fix: dynamic width for lesson plans

### DIFF
--- a/sass/scss/components/_field-multiselect.scss
+++ b/sass/scss/components/_field-multiselect.scss
@@ -27,7 +27,6 @@
     }
     .select2-choices {
         overflow: auto !important;
-        max-height: 42px;
         width: 100% !important;
     }
     .select3-choices {


### PR DESCRIPTION
## Motivação

Ao imprimir o relatório de aulas ministradas, os planos de aula não estavam sendo exibidos completamente devido a uma limitação na formatação CSS. Isso causava problemas na visualização e entendimento do conteúdo completo das aulas.

## Alterações Realizadas

Foi removida a propriedade CSS que limitava o tamanho da célula dos planos de aula. Isso permitiu que o conteúdo dos planos fosse exibido integralmente, garantindo que todas as informações importantes estivessem visíveis no relatório impresso.

## Fluxo de Teste

### 🧪 Teste 01

#### Objetivo

O objetivo deste teste é verificar se os planos de aula estão sendo exibidos completamente ao imprimir o relatório de aulas ministradas, após a remoção da propriedade CSS que limitava o tamanho da célula dos planos de aula.

#### Passos do Teste

1. **Acessar 'Diário Eletrônico'**
2. **Acessar 'Aulas Ministradas'**
3. **Escolher uma turma e um mês**
    - Selecione uma turma e um mês específico. Certifique-se de que essa turma e mês possuem planos de aula. Se não houver planos de aula, adicione alguns para realizar o teste.

4. **Validar a exibição dos planos de aula ao imprimir**
    - Reduza o tamanho da tela (diminuindo a janela do navegador) para simular diferentes resoluções de tela.
    - Imprima o relatório de aulas ministradas e verifique se todos os planos de aula são exibidos completamente no relatório impresso.

Portando, se for mostrado os planos completos, o teste passou, se não, o teste falhou.


## Migrations Utilizadas

## Checklist de revisão
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
