### PR TITLE
Fix/timesheet at calendar change event

### DIFF
--- a/app/modules/calendar/resources/common/js/calendar.js
+++ b/app/modules/calendar/resources/common/js/calendar.js
@@ -458,7 +458,7 @@ $(document).on("click", ".save-event", function (e, confirm = 0) {
                 }
                 var oldEventDays = $("a.change-event[data-id=" + data.eventId + "]");
                 oldEventDays.attr("data-id", "-1").removeAttr("data-toggle").removeAttr("data-placement").removeAttr("data-original-title");
-                oldEventDays.parent().removeClass("calendar-" + data.color);
+                oldEventDays.parent().removeClass("calendar-" + data.oldColor);
                 oldEventDays.find(".calendar-icon").remove();
                 $.each(data.datesToFill, function () {
                     var date = calendar.find(".change-event[data-year=" + this.year + "][data-month=" + this.month + "][data-day=" + this.day + "]");


### PR DESCRIPTION
## Motivação

Um funcionário de uma escola relatou que, apesar de incluir um dia de reposição em um dia anterior, esse dia não aparecia em frequencia e aula ministrada. Descobriu-se um bug no código de salvar evento e foi resolvido.

## Alterações Realizadas

Re-disponibilizar as aulas na mudança de evento quando se trocar um dia de indisponível para disponível.

## Fluxo de Teste

## Migrations Utilizadas

## Checklist de revisão
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
