### PR TITLE
[TCDA-614] Fix/add creation date enrollment view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.85.179]
+- Adicionada a exibição da data de matricula do aluno em uma turma na aba de matrículas no formulário do aluno
+
 ## [Versão 3.85.178]
 - Adicionado funcionalidade que permite manter informações na matrícula do aluno
 de um período no qual o aluno ficou afastado.

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.85.178');
+define("TAG_VERSION", '3.85.179');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');

--- a/instance.php
+++ b/instance.php
@@ -15,7 +15,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'buzios.tag.ong.br';
+    $newdb = 'demo.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;

--- a/instance.php
+++ b/instance.php
@@ -15,7 +15,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'demo.tag.ong.br';
+    $newdb = 'buzios.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;

--- a/themes/default/views/enrollment/_form.php
+++ b/themes/default/views/enrollment/_form.php
@@ -227,8 +227,6 @@ $form = $this->beginWidget('CActiveForm', array(
 
                         </div>
                         <div class="column">
-                            <div class="separator"></div>
-
                             <div class="t-field-text">
                                     <?php echo $form->labelEx($model, 'school_admission_date', array('class' => 't-field-text__label')); ?>
                                     <?php echo $form->textField($model, 'school_admission_date', array('size' => 10, 'maxlength' => 10, 'class'=>'t-field-text__input')); ?>

--- a/themes/default/views/student/_form.php
+++ b/themes/default/views/student/_form.php
@@ -2143,7 +2143,11 @@ $form = $this->beginWidget(
                                                         <?php
                                                         switch ($me->status) {
                                                             case "1":
-                                                                echo "<label class='t-badge-success'>Matriculado</label>";
+                                                                $created_at = "";
+                                                                if (isset($me->create_date)) {
+                                                                    $created_at = date_create_from_format('Y-m-d H:i:s', $me->create_date)->format('d/m/Y');
+                                                                }
+                                                                echo "<label class='t-badge-success'>Matriculado " . $created_at . "</label>";
                                                                 break;
                                                             case "2":
                                                                 $transfer_date = "";


### PR DESCRIPTION
## Motivação
Foi solicitado a exibição da data de matrícula de um aluno em cada uma de suas turmas na listagem de matrícula dentro do formulário de aluno.  

## Alterações Realizadas
- Adicionada a exibição da data de matricula do aluno em uma turma na aba de matrículas no formulário do aluno

## Fluxo de Teste
### 🧪 Fluxo de Teste 1:  Verificar matrícula do aluno
```
- Acessar um aluno
- Verificar as matrículas que estão marcadas como "Matriculado" e verificar se a data de matrícula é apresentada ao lado
```
Observação: Caso não seja exibida nenhuma data ao lado do matriculado, verificar no banco de dados se o campo "create_date" do enrollment correspondente está com alguma informação, se não estiver, a não exibição da data está correta, pois não tem como verificar qual a data de matrícula se isso não foi informado na criação.

### 🧪 Fluxo de Teste 2:  Adicionar matrícula do aluno
```
- Acessar um aluno
- Adicionar uma nova matrícula para aquele aluno
- Verificar se a data está sendo exibida ao lado do status "matriculado" na matrícula recém criada
```
### 🧪 Fluxo de Teste 3:  Tranferir o aluno de turma
```
- Acessar um aluno
- Clicar em "transferir matrícula"
- Tranferir a matrícula do aluno para uma outra turma
- Verificar se a turma anterior está como "Transferido" e a data informada
- Verificar se a turma atual está como "Matriculado" com a data de matrícula
```

## Migrations Utilizadas

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
