### PR TITLE
Fix/aee record permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.85.179]
+- Permitindo a visualização das fichas AEE para os gestores escolares e coordenadores
+
 ## [Versão 3.85.178]
 - Adicionado funcionalidade que permite manter informações na matrícula do aluno
 de um período no qual o aluno ficou afastado.

--- a/app/modules/aeerecord/controllers/DefaultController.php
+++ b/app/modules/aeerecord/controllers/DefaultController.php
@@ -34,7 +34,8 @@ class DefaultController extends Controller
                     'getClassroomStudents',
                     'getAeeRecord',
                     'checkStudentAeeRecord',
-                    'delete'
+                    'delete',
+                    'admin'
                 ),
                 'users' => array('@'),
             ),
@@ -245,19 +246,18 @@ class DefaultController extends Controller
 	 */
 	public function actionAdmin()
 	{
-		if(Yii::app()->getAuthManager()->checkAccess('admin', Yii::app()->user->loginInfos->id)){
-            $dataProvider = new CActiveDataProvider('StudentAeeRecord', array(
-                'criteria' => array(
-                    'with' => array(
-                        'schoolFk' => array(
-                            'together' => true,
-                            'condition' => 'schoolFk.inep_id=:schoolId',
-                            'params' => array(':schoolId' => Yii::app()->user->school),
-                        ),
+        $dataProvider = new CActiveDataProvider('StudentAeeRecord', array(
+            'criteria' => array(
+                'with' => array(
+                    'schoolFk' => array(
+                        'together' => true,
+                        'condition' => 'schoolFk.inep_id=:schoolId',
+                        'params' => array(':schoolId' => Yii::app()->user->school),
                     ),
                 ),
-            ));
-        }
+            ),
+        ));
+
 
         $this->render('admin',array(
             'dataProvider'=>$dataProvider,

--- a/app/modules/aeerecord/views/default/admin.php
+++ b/app/modules/aeerecord/views/default/admin.php
@@ -26,12 +26,6 @@ $hasAdminAccess = Yii::app()->getAuthManager()->checkAccess('admin', Yii::app()-
         <h1>Fichas AEE</h1>
     </div>
 
-    <div class="row">
-        <div class="t-buttons-container">
-            <a class="t-button-primary <?php echo $hasAdminAccess ? 'hide' : ''?>" href="<?php echo Yii::app()->createUrl('aeerecord/default/create')?>">Adicionar Ficha</a>
-        </div>
-    </div>
-
     <?php if (Yii::app()->user->hasFlash('success')): ?>
         <div class="alert alert-success">
             <?php echo Yii::app()->user->getFlash('success') ?>

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.85.178');
+define("TAG_VERSION", '3.85.179');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');

--- a/instance.php
+++ b/instance.php
@@ -15,7 +15,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'boquim.tag.ong.br';
+    $newdb = 'demo.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;

--- a/instance.php
+++ b/instance.php
@@ -15,7 +15,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'demo.tag.ong.br';
+    $newdb = 'boquim.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;

--- a/themes/default/views/layouts/fullmenu.php
+++ b/themes/default/views/layouts/fullmenu.php
@@ -328,7 +328,8 @@ $cs->registerCssFile(Yii::app()->baseUrl . "/sass/css/main.css?v=" . TAG_VERSION
                                         </a>
                                     </li>
                                 <?php endif ?>
-                                <?php if (Yii::app()->getAuthManager()->checkAccess('admin', Yii::app()->user->loginInfos->id)) : ?>
+                                <?php if (Yii::app()->getAuthManager()->checkAccess('admin', Yii::app()->user->loginInfos->id) ||
+                                Yii::app()->getAuthManager()->checkAccess('manager', Yii::app()->user->loginInfos->id)) : ?>
                                     <li class="t-menu-item <?= strpos($_SERVER['REQUEST_URI'], "?r=aeerecord") ? 'active' : '' ?>">
                                         <a class="t-menu-item__link" href="<?php echo yii::app()->createUrl('aeerecord/default/admin') ?> ">
                                             <span class="t-icon-copy t-menu-item__icon"></span>
@@ -347,6 +348,14 @@ $cs->registerCssFile(Yii::app()->baseUrl . "/sass/css/main.css?v=" . TAG_VERSION
                                 </a>
                             </li>
                          <?php endif ?>
+                         <?php if (Yii::app()->getAuthManager()->checkAccess('coordinator', Yii::app()->user->loginInfos->id)) : ?>
+                            <li class="t-menu-item <?= strpos($_SERVER['REQUEST_URI'], "?r=aeerecord") ? 'active' : '' ?>">
+                                <a class="t-menu-item__link" href="<?php echo yii::app()->createUrl('aeerecord/default/admin') ?> ">
+                                    <span class="t-icon-copy t-menu-item__icon"></span>
+                                    <span class="t-menu-item__text">Ficha AEE</span>
+                                </a>
+                            </li>
+                        <?php endif ?>
                         <?php if (Yii::app()->getAuthManager()->checkAccess('instructor', Yii::app()->user->loginInfos->id)) : ?>
                             <li class="t-menu-item <?= strpos($_SERVER['REQUEST_URI'], "?r=classdiary/default/") ? 'active' : '' ?>">
                                 <a class="t-menu-item__link" href="<?php echo yii::app()->createUrl('classdiary/default/') ?> ">


### PR DESCRIPTION
## Motivação
Foi necessário permitir a visualização das fichas AEE com os usuários de gestor escolar e coordenador

## Alterações Realizadas
- Permitindo a visualização das fichas AEE para os gestores escolares e coordenadores

## Fluxo de Teste
```
- Fazer o login no tag com um usuário gestor escolar ou coordenador
- Verificar se no menu lateral aparece a opção ficha AEE
- Acessar a tela de ficha AEE e verificar os registros estão sendo exibidos
```
Observação: Para realizar o fluxo de teste corretamente, é necessário ter cadastrado previamente alguma ficha AEE.

## Migrations Utilizadas

## Checklist de revisão
- [X] O número da versão foi alterado no arquivo ``` config.php ```?
- [X] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
