### PR TITLE
fix/Food Inventory Expiration Date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Versão 3.85.180]
+- Retirada a obrigatóriedade do campo de validade no lançamento de estoque
+- Corrigido o erro que ao adicionar um alimento, modificava o valor de uma outra escola que já tinha esse alimento salvo
+
 ## [Versão 3.85.178]
 - Adicionado funcionalidade que permite manter informações na matrícula do aluno
 de um período no qual o aluno ficou afastado.

--- a/app/modules/foods/controllers/FoodinventoryController.php
+++ b/app/modules/foods/controllers/FoodinventoryController.php
@@ -98,8 +98,11 @@ class FoodinventoryController extends Controller
 
         if (!empty($foodsOnStock)) {
             foreach ($foodsOnStock as $foodData) {
-                $existingFood = FoodInventory::model()->findByAttributes(array('food_fk' => $foodData['id']));
-                $expiration_date_Timestamp = strtotime(str_replace('/', '-', $foodData['expiration_date']));
+                $existingFood = FoodInventory::model()->findByAttributes(array('food_fk' => $foodData['id'], 'school_fk' => Yii::app()->user->school));
+                $expirationDate = null;
+                if($foodData['expiration_date'] != "") {
+                    $expirationDate = date('Y-m-d', strtotime(str_replace('/', '-', $foodData['expiration_date'])));
+                }
 
                 if (!$existingFood) {
                     $FoodInventory = new FoodInventory;
@@ -109,7 +112,7 @@ class FoodinventoryController extends Controller
                     $FoodInventory->school_fk = Yii::app()->user->school;
                     $FoodInventory->amount = $foodData['amount'];
                     $FoodInventory->measurementUnit = $foodData['measurementUnit'];
-                    $FoodInventory->expiration_date = date('Y-m-d', $expiration_date_Timestamp);
+                    $FoodInventory->expiration_date = $expirationDate;
 
                     if ($FoodInventory->save()) {
                         $FoodInventoryReceived = new FoodInventoryReceived;
@@ -139,7 +142,7 @@ class FoodinventoryController extends Controller
                     } else {
                         $existingFood->amount += $foodData['amount'];
                     }
-                    $existingFood->expiration_date = date('Y-m-d', $expiration_date_Timestamp);
+                    $existingFood->expiration_date = $expirationDate;
                     $existingFood->status = 'Disponivel';
                     $existingFood->save();
                 }

--- a/app/modules/foods/models/FoodInventory.php
+++ b/app/modules/foods/models/FoodInventory.php
@@ -41,14 +41,13 @@ class FoodInventory extends CActiveRecord
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
         return array(
-            array('school_fk, food_fk, amount, expiration_date', 'required'),
+            array('school_fk, food_fk, amount', 'required'),
             array('food_fk', 'numerical', 'integerOnly'=>true),
             array('amount', 'numerical'),
             array('school_fk', 'length', 'max'=>8),
             array('measurementUnit', 'length', 'max'=>7),
             array('expiration_date', 'safe'),
             // The following rule is used by search().
-            // @todo Please remove those attributes that should not be searched.
             array('id, school_fk, food_fk, amount, measurementUnit, expiration_date', 'safe', 'on'=>'search'),
         );
     }
@@ -94,7 +93,6 @@ class FoodInventory extends CActiveRecord
      */
     public function search()
     {
-        // @todo Please modify the following code to remove attributes that should not be searched.
 
         $criteria=new CDbCriteria;
 

--- a/app/modules/foods/resources/inventory/_initialization.js
+++ b/app/modules/foods/resources/inventory/_initialization.js
@@ -125,7 +125,7 @@ $(document).on("click", "#add-food", function () {
     let amount = $('.js-amount').val();
     let expiration_date = $('.js-expiration-date').val();
 
-    if(foodId == "alimento" || amount == "" || expiration_date == "") {
+    if(foodId == "alimento" || amount == "") {
         $('#stock-modal-alert').removeClass('hide').addClass('alert-error').html("Campos obrigatórios precisam ser informados.");
     } else {
         if(amount !== "" && !isNaN(amount) && parseFloat(amount) >= 0 && amount.indexOf(',') === -1) {
@@ -144,6 +144,7 @@ $(document).on("click", "#stock_button", function () {
 });
 
 $(document).on("click", "#save-food", function () {
+    console.log(foodsOnStock);
     if (foodsOnStock != 0){
         $.ajax({
             type: 'POST',

--- a/app/modules/foods/views/foodinventory/_form.php
+++ b/app/modules/foods/views/foodinventory/_form.php
@@ -131,7 +131,7 @@ $isNutritionist = Yii::app()->getAuthManager()->checkAccess('nutritionist', Yii:
                             </select>
                         </div>
                         <div class="column is-one-tenth clearleft--on-mobile t-field-text t-margin-none--bottom clearfix">
-                            <?php echo $form->label($model,'expiration_date',  array('class' => 't-field-text__label--required')); ?>
+                            <?php echo $form->label($model,'expiration_date',  array('class' => 't-field-text__label')); ?>
                             <?php echo $form->textField($model,'expiration_date', array('class'=>'t-field-text__input js-date t-margin-none--top js-expiration-date', 'placeholder' => 'Selecione')); ?>
                             <?php echo $form->error($model,'expiration_date'); ?>
                         </div>

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.85.178');
+define("TAG_VERSION", '3.85.180');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');


### PR DESCRIPTION
## Motivação
Foi observada uma incosistência ao adicionar um alimento no estoque, pois a data de validade estava como obrigatória, porém existem alimentos não perecíveis, sendo assim, não é necessário informar a data de validade. Além disso, foi observada uma outra inconsistência ao adicionar um alimento em uma escola A que já estava no estoque de uma escola B, o sistema estava atualizando o estoque da escola B ao invés de adicionar no alimento na escola A.

## Alterações Realizadas
- Retirada a obrigatóriedade do campo de validade no lançamento de estoque
- Corrigido o erro que ao adicionar um alimento, modificava o valor de uma outra escola que já tinha esse alimento salvo

## Fluxo de Teste
### 🧪 Fluxo de Teste 01: Data de validade
```
- Verificar se o novo módulo de merenda está ativo
- Acessar a tela de estoque no novo módulo de merenda
- Clicar em "Lançamento de estoque"
- Preencher as informações para adicionar um alimento e não informar a data de validade
- Clicar em "Adicionar ao estoque"
- Verificar se o alimento foi salvo e se o campo de data de validade aparece como "Não informada"
```

### 🧪 Fluxo de Teste 02: Correção do erro ao adicionar estoque
```
- Acessar a tela de estoque no novo módulo de merenda
- Modificar a escola para uma que não seja a do teste anterior
- Repetir o processo de adicionar ao estoque para o mesmo alimento, de preferência com uma quantidade diferente para ajudar na diferenciação
- Clicar em "Adicionar ao estoque"
- Verificar se o alimento foi salvo na nova escola
- Verificar se o estoque do alimento na escola anterior permanece inalterado
```

## Migrations Utilizadas

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
