### PR TITLE
Fix/Student frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
+## [Versão 3.85.179]
+- Correção na funcionalidade de frequência de aluno transferido.
+
 ## [Versão 3.85.178]
-- Adicionado funcionalidade que permite manter informações na matrícula do aluno
-de um período no qual o aluno ficou afastado.
+- Adicionado funcionalidade que permite manter informações na matrícula do aluno de um período no qual o aluno ficou afastado.
 
 ## [Versão 3.84.178]
 - Criado o módulo de ficha AEE, permitindo o cadastro, alteração e relatórios de fichas de alunos pertencentes a turmas AEE

--- a/app/controllers/AdminController.php
+++ b/app/controllers/AdminController.php
@@ -312,7 +312,7 @@ class AdminController extends Controller
             ]
         );
         if (isset($_POST['Users'])) {
-            if(!isset($_POST['schools']) && ($_POST['Role']) != 'admin')
+            if(!isset($_POST['schools']) && ($_POST['Role']) != 'admin' && ($_POST['Role']) != 'nutritionist')
             {
                 Yii::app()->user->setFlash('error', Yii::t('default', 'É necessário atribuir uma escola para o novo usuário criado!'));
                 $this->redirect(['index']);

--- a/app/controllers/ClassesController.php
+++ b/app/controllers/ClassesController.php
@@ -618,7 +618,7 @@ class ClassesController extends Controller
         $startDate = date_create_from_format($dateFormat, $enrollment->school_readmission_date);
         $transferedDate = date_create_from_format($dateFormat, $enrollment->class_transfer_date);
         $scheduleDate = date_create_from_format($dateFormat, $date);
-        return !(($scheduleDate < $startDate && $scheduleDate > $transferedDate) && $enrollment->status == '13' || $enrollment->status == '2');
+        return !(($scheduleDate < $startDate && $scheduleDate > $transferedDate) && $enrollment->status == '13' || $enrollment->status == '2' || $enrollment->status = '11');
     }
 
     public function actionSaveJustifications()

--- a/app/controllers/ClassesController.php
+++ b/app/controllers/ClassesController.php
@@ -618,7 +618,7 @@ class ClassesController extends Controller
         $startDate = date_create_from_format($dateFormat, $enrollment->school_readmission_date);
         $transferedDate = date_create_from_format($dateFormat, $enrollment->class_transfer_date);
         $scheduleDate = date_create_from_format($dateFormat, $date);
-        return !(($scheduleDate < $startDate && $scheduleDate > $transferedDate) && $enrollment->status == '13' || $enrollment->status == '2' || $enrollment->status = '11');
+        return !(($scheduleDate < $startDate && $scheduleDate > $transferedDate) && $enrollment->status == '13') && $enrollment->status != '2' && $enrollment->status != '11';
     }
 
     public function actionSaveJustifications()

--- a/app/controllers/ClassesController.php
+++ b/app/controllers/ClassesController.php
@@ -618,7 +618,7 @@ class ClassesController extends Controller
         $startDate = date_create_from_format($dateFormat, $enrollment->school_readmission_date);
         $transferedDate = date_create_from_format($dateFormat, $enrollment->class_transfer_date);
         $scheduleDate = date_create_from_format($dateFormat, $date);
-        return !(($scheduleDate < $startDate && $scheduleDate > $transferedDate) && $enrollment->status == '13');
+        return !(($scheduleDate < $startDate && $scheduleDate > $transferedDate) && $enrollment->status == '13' || $enrollment->status == '2');
     }
 
     public function actionSaveJustifications()

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.85.178');
+define("TAG_VERSION", '3.85.179');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');

--- a/js/classes/frequency/_initialization.js
+++ b/js/classes/frequency/_initialization.js
@@ -54,7 +54,7 @@ function load() {
                             }
                         }
 
-                        html += "<td class='frequency-checkbox-student frequency-checkbox-container " + (!this.available || !schedule.valid ? "disabled" : "") + "'><input class='frequency-checkbox' type='checkbox' " + (!schedule.available || !schedule.valid ? "disabled" : "") + " " + (schedule.fault ? "checked" : "") + " classroomId='" + $("#classroom").val() +
+                        html += "<td class='frequency-checkbox-student frequency-checkbox-container " + (!this.available || !schedule.valid ? "disabled" : "") + "'><input class='frequency-checkbox' type='checkbox' " + (!schedule.available || !schedule.valid || student.status == 2 ? "disabled" : "") + " " + (schedule.fault ? "checked" : "") + " classroomId='" + $("#classroom").val() +
                             "' studentId='" + student.studentId + "' day='" + schedule.day + "' month='" + monthSplit[1] + "' year='" + monthSplit[0] + "' schedule='" + schedule.schedule + "' fundamentalMaior='" + fundamentalMaior + "'>" + justificationContainer + "</td>";
                     });
                     html += "</tr>";

--- a/js/classes/frequency/_initialization_instructor.js
+++ b/js/classes/frequency/_initialization_instructor.js
@@ -39,7 +39,7 @@ function generateStudentLines(data, dia, mes, ano, monthSplit, isMinor) {
         return line + `
             <div
                 class='justify-content--space-between t-padding-small--top t-padding-small--bottom'
-                style="border-bottom:1px #e8e8e8 solid;background-color:${student.status == 2 ? '#f5f7f9;' : 'initial'};"
+                style="border-bottom:1px #e8e8e8 solid;background-color:${student.status == 2 || student.status == 11 ? '#f5f7f9;' : 'initial'};"
             >
                 <div>${student.studentName}</div>
                 <div style='display:flex;'>

--- a/js/classes/frequency/_initialization_instructor.js
+++ b/js/classes/frequency/_initialization_instructor.js
@@ -15,9 +15,9 @@ function generateCheckboxItems(student, dia, mes, ano, monthSplit, isMinor) {
                         <span class='t-icon-annotation icon-color'></span>
                     </a>
                     ${isMinor == false ? schedule.schedule+'°': ''}
-                    <span class="frequency-checkbox-container" ${(!schedule.available ? "disabled" : "")}>
+                    <span class="frequency-checkbox-container" ${(!schedule.available || !schedule.valid ? "disabled" : "")}>
                         <input class='frequency-checkbox' type='checkbox'
-                            ${(!schedule.available ? "disabled" : "")}
+                            ${(!schedule.available || !schedule.valid ? "disabled" : "")}
                             ${(schedule.fault ? "checked" : "")}
                             classroomId='${$("#classroom").val()}'
                             studentId='${student.studentId}'
@@ -37,7 +37,10 @@ function generateCheckboxItems(student, dia, mes, ano, monthSplit, isMinor) {
 function generateStudentLines(data, dia, mes, ano, monthSplit, isMinor) {
     return data.students.reduce((line, student) => {
         return line + `
-            <div class='justify-content--space-between t-padding-small--top t-padding-small--bottom' style="border-bottom:1px #e8e8e8 solid;">
+            <div
+                class='justify-content--space-between t-padding-small--top t-padding-small--bottom'
+                style="border-bottom:1px #e8e8e8 solid;background-color:${student.status == 2 ? '#f5f7f9;' : 'initial'};"
+            >
                 <div>${student.studentName}</div>
                 <div style='display:flex;'>
                     ${generateCheckboxItems(student, dia, mes, ano, monthSplit, isMinor)}


### PR DESCRIPTION
## Motivação
- Na última atualização na tela de frequência, uma funcionalidade que foi adicionada anteriormente foi removida.
## Alterações Realizadas
- O status de matrícula "TRANSFERIDO" torna os campos de frequência inativos.
## Fluxo de Teste
🧪 Fluxo de Teste 01: Aluno com matrícula transferida
```
- Acessar turma com alunos matriculados
- Acessar um dos alunos com status de matrícula 'MATRICULADO'
- Acessar a tela de matrículas, selecionar a matrícula na turma selecionada e clicar no ícone de lápis ao lado para editar.
- Ao acessar, alterar o valor do select 'Situação da matrícula' para 'TRANSFERIDO'.
- Após salvar, acessar a tela de "Frequência" em diário eletrônico e verificar o seguinte:
- 1. Ao preencher os selects necessários, os campos de frequência para o aluno editado estão todos desabilitados.
- 2. Ao selecionar o primeiro botão checkbox de cada coluna, que marca falta para todos os alunos, em um primeiro momento
o checkbox do aluno transferido estará marcado, no entanto ao atualizar a página e renderizar novamente, será possível observar que os inputs para o aluno transferido estarão desmarcados, conforme pode ser visto na imagem abaixo.
``` 
![image](https://github.com/user-attachments/assets/41668128-1de9-4170-a6f8-3a3e23e76ac8)

## Migrations Utilizadas
- Sem migrations
## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
