### PR TITLE
Feat/increase maximum number of characters in fields aee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [Versão 3.85.181]
+- Aumentado o limite de caracteres dos campos das fichas aee
 ## [Versão 3.85.180]
 - Retirada a obrigatóriedade do campo de validade no lançamento de estoque
 - Corrigido o erro que ao adicionar um alimento, modificava o valor de uma outra escola que já tinha esse alimento salvo

--- a/app/migrations/2024-20-08_change_sudent_aee_record/sql.sql
+++ b/app/migrations/2024-20-08_change_sudent_aee_record/sql.sql
@@ -1,0 +1,5 @@
+ALTER TABLE student_aee_record
+MODIFY characterization VARCHAR(3000);
+
+ALTER TABLE student_aee_record
+MODIFY learning_needs VARCHAR(1000);

--- a/app/modules/aeerecord/models/StudentAeeRecord.php
+++ b/app/modules/aeerecord/models/StudentAeeRecord.php
@@ -39,8 +39,8 @@ class StudentAeeRecord extends CActiveRecord
 		return array(
 			array('student_fk, school_fk, classroom_fk, instructor_fk', 'required'),
 			array('student_fk, classroom_fk, instructor_fk', 'numerical', 'integerOnly'=>true),
-			array('learning_needs', 'length', 'max'=>500),
-			array('characterization', 'length', 'max'=>1000),
+			array('learning_needs', 'length', 'max'=>1000),
+			array('characterization', 'length', 'max'=>3000),
 			array('school_fk', 'length', 'max'=>8),
 			array('date', 'safe'),
 			// The following rule is used by search().

--- a/app/modules/aeerecord/views/default/_form.php
+++ b/app/modules/aeerecord/views/default/_form.php
@@ -68,14 +68,14 @@ $form=$this->beginWidget('CActiveForm', array(
     <div class="row">
         <div class="column t-field-tarea clearfix is-three-fifths">
             <?php echo CHtml::label('Necessidades de aprendizagem ', 'learning_needs', array('class' => 't-field-tarea__label')); ?>
-            <?php echo CHtml::activeTextArea($model, "learning_needs", array('id'=>"learningNeeds",'class' => "t-field-tarea__input large", 'maxlength' => 500, 'style' => 'resize: none')); ?>
+            <?php echo CHtml::activeTextArea($model, "learning_needs", array('id'=>"learningNeeds",'class' => "t-field-tarea__input large", 'maxlength' => 1000, 'style' => 'resize: none')); ?>
         </div>
     </div>
 
     <div class="row">
         <div class="column t-field-tarea clearfix is-three-fifths">
             <?php echo CHtml::label('Caracterização pedagógica ', 'characterization', array('class' => 't-field-tarea__label')); ?>
-            <?php echo CHtml::activeTextArea($model, "characterization", array('id'=>"characterization",'class' => "t-field-tarea__input large", 'maxlength' => 1000, 'style' => 'resize: none; min-height: 200px; max-height: 200px')); ?>
+            <?php echo CHtml::activeTextArea($model, "characterization", array('id'=>"characterization",'class' => "t-field-tarea__input large", 'maxlength' => 3000, 'style' => 'resize: none; min-height: 200px; max-height: 200px')); ?>
         </div>
     </div>
 

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.85.180');
+define("TAG_VERSION", '3.85.181');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');


### PR DESCRIPTION
## Motivação
Foi solicitado pelo município de boquim (TCDA-671) que os que fosse aumentado o limite de caracteres nos campos de 'Necessidades de aprendizagem' e 'Caracterização pedagógica' pois eles não estavam atendendo a demanda dos professores que necessitam escrever muito nesses campos

## Alterações Realizadas
foi alterado o limite dos campos no formulário da ficha AEE
foi alterado o limite dos campos no model StudentAeeRecord
foi alterada a tabela student_aee_record

## Fluxo de Teste
  1.0 Caso não tenha nenhuma turma AEE cadastrada crie uma ou altere em uma turma que já existe os campos  de modalidade e tipo de atendimento para atendimento educacional especializado
  ![image](https://github.com/user-attachments/assets/1512787c-a654-4703-a680-6701b0c82929)
  ![image](https://github.com/user-attachments/assets/ea0028b4-6bd8-40f9-b34a-0263bea9abb6)

  2.0 Após faça login no sistema com um professor que esteja cadastrado naquela turma
  3.0 No diário eletrônico na barra lateral selecione Ficha AEE
  4.0 Adicione uma nova ficha para testar os novos limites dos campos:
          - Necessidades de aprendizagem => 1000
          - Caracterização pedagógica => 3000
  5.0 Caso a ficha seja criada o teste foi bem sucedido

## Migrations Utilizadas
    2024-20-08_change_sudent_aee_record

## Checklist de revisão
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
