### PR TITLE
fix no select da estrutura de unidades, "Forma de Cálculo" da rec. final

### DIFF
--- a/js/admin/grades-structure.js
+++ b/js/admin/grades-structure.js
@@ -498,7 +498,7 @@ function saveUnities(reply) {
                 id: $(".final-recovery-unity-id").val(),
                 name: $(".final-recovery-unity-name").val(),
                 type: $(".final-recovery-unity-type").val(),
-                grade_calculation_fk: $(".calculation-final-media").select2(
+                grade_calculation_fk: $(".final-recovery-unity-calculation").select2(
                     "val"
                 ),
                 operation: $(".final-recovery-unity-operation").val(),


### PR DESCRIPTION
## Motivação

Descrição do problema no JIRA:

Venho por meio deste relatar um problema persistente na Estrutura de Unidades e Avaliações. O campo Recuperação Final não está sendo salvo corretamente. Estamos editando as informações referentes ao Nome e à Forma de Cálculo, e ambas não estão sendo salvas, o que resulta na não exibição dessas informações na aba Notas.

## Alterações Realizadas

Foi corrigido um equívoco em uma linha do código.

## Fluxo de Teste

Ver se o campo "Fórmula de Cálculo" da recuperação final tá mudando depois do save.

## Migrations Utilizadas

Não.

## Checklist de revisão
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
