### PR TITLE
inserido cor/raça na planilha de exportação de alunos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.86.187]
+- Inserido cor/raça na planilha de exportação de alunos
+
 ## [Versão 3.85.187]
 - Permitindo a adição de habilidades de disciplinas diferentes em planos de aula para etapas de fundamental menor
 

--- a/app/controllers/AdminController.php
+++ b/app/controllers/AdminController.php
@@ -86,6 +86,7 @@ class AdminController extends Controller
             if (si.birthday is null, '', si.birthday) data_nascimento,
             if (sdaa.cpf is null, '', sdaa.cpf) cpf,
             if (si.sex is null, '', si.sex) sexo,
+            if (si.color_race is null, '', si.color_race) cor_raca,
             if (concat(sdaa.address, \", \", sdaa.`number`, \", \", sdaa.complement) is null
                 or trim(concat(sdaa.address, \", \", sdaa.`number`, \", \", sdaa.complement)) = ', , ',
                 '',
@@ -112,6 +113,30 @@ class AdminController extends Controller
         and c.school_year = " . Yii::app()->user->year;
 
         $result = Yii::app()->db->createCommand($sql)->queryAll();
+
+        foreach($result as &$r) {
+            switch($r["cor_raca"]) {
+                case "0":
+                default:
+                    $r["cor_raca"] = "Não declarada";
+                    break;
+                case "1":
+                    $r["cor_raca"] = "Branca";
+                    break;
+                case "2":
+                    $r["cor_raca"] = "Preta";
+                    break;
+                case "3":
+                    $r["cor_raca"] = "Parda";
+                    break;
+                case "4":
+                    $r["cor_raca"] = "Amarela";
+                    break;
+                case "5":
+                    $r["cor_raca"] = "Indígena";
+                    break;
+            }
+        }
 
         $this->exportToCSV($result, $pathFile);
     }

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.85.187');
+define("TAG_VERSION", '3.86.187');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');


### PR DESCRIPTION
## Motivação

TCDA 692:

"Quando foi solicitado a criação funcionalidade Exportar Dados CSV houve um esquecimento de colocar também na formatação do cabeçalho/coluna do arquivo a cor/raça do estudante. Portanto, solicito que inclua também essa coluna no arquivo que tem os dados dos alunos."

## Alterações Realizadas

Foi inserida a coluna especificada

## Fluxo de Teste

## Migrations Utilizadas

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
