### PR TITLE
fix/coordinator_update_courseplan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.86.191]
+- Adicionando restrição para que coordenadores pedagogicos e gestores escolares não consigam modificar planos de aula
+
 ## [Versão 3.86.190]
 - Corrigindo erros internos na impressão de documentos. Não possui impacto nas funcionalidades, apenas nos registros de erro.
 - Corrigindo alerta ao adicionar cardápio (interno)

--- a/app/modules/courseplan/views/courseplan/_form.php
+++ b/app/modules/courseplan/views/courseplan/_form.php
@@ -29,7 +29,7 @@ $school = SchoolIdentification::model()->findByPk(Yii::app()->user->school);
 <?php $readonly = Yii::app()->getAuthManager()->checkAccess('coordinator', Yii::app()->user->loginInfos->id) || $coursePlan->situation == 'APROVADO' ? 'readonly' : '' ; ?>
 
 <div class="main">
-    <?php echo ($coursePlan->situation == 'APROVADO') ? '<div id="validate-index"></div>' : '' ;  ?>
+    <?php echo ($coursePlan->situation == 'APROVADO') || Yii::app()->getAuthManager()->checkAccess('coordinator', Yii::app()->user->loginInfos->id) || Yii::app()->getAuthManager()->checkAccess('manager', Yii::app()->user->loginInfos->id) ? '<div id="validate-index"></div>' : '' ;  ?>
     <div class="tag-inner">
         <?php if (Yii::app()->user->hasFlash('success')) : ?>
             <div class="alert alert-success">

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.86.190');
+define("TAG_VERSION", '3.86.191');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');

--- a/instance.php
+++ b/instance.php
@@ -15,7 +15,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'boquim11/09.tag.ong.br';
+    $newdb = 'demo.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;

--- a/instance.php
+++ b/instance.php
@@ -15,7 +15,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'demo.tag.ong.br';
+    $newdb = 'boquim11/09.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;


### PR DESCRIPTION
## Motivação
Quando acessavam a tela de listagem de planos de aula, os coordenadores escolares e gestores conseguiam acessar a tela de update e modificar os planos que estavam com o status pendente. Essa modificação só pode ser realizada por professores ou administradores

## Alterações Realizadas
Adicionando restrição para que coordenadores pedagogicos e gestores escolares não consigam modificar planos de aula

## Fluxo de Teste

## Migrations Utilizadas

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
