### PR TITLE
add_edcenso_associated_stage_id

### DIFF
--- a/app/controllers/ClassesController.php
+++ b/app/controllers/ClassesController.php
@@ -765,14 +765,14 @@ class ClassesController extends Controller
         echo json_encode($result);
     }
         private function checkIsStageMinorEducation($classroom) {
-            $isMinor = TagUtils::isStageMinorEducation($classroom->edcenso_stage_vs_modality_fk);
+            $isMinor = TagUtils::isStageMinorEducation($classroom->edcensoStageVsModalityFk->edcenso_associated_stage_id);
 
-            if (!$isMinor && TagUtils::isMultiStage($classroom->edcenso_stage_vs_modality_fk)) {
+            if (!$isMinor && TagUtils::isMultiStage($classroom->edcensoStageVsModalityFk->edcenso_associated_stage_id)) {
                 $enrollments = StudentEnrollment::model()->findAllByAttributes(["classroom_fk" => $classroom->id]);
 
                 foreach ($enrollments as $enrollment) {
-                    if (!$enrollment->edcenso_stage_vs_modality_fk ||
-                        !TagUtils::isStageMinorEducation($enrollment->edcenso_stage_vs_modality_fk)) {
+                    if (!$enrollment->edcensoStageVsModalityFk->edcenso_associated_stage_id ||
+                        !TagUtils::isStageMinorEducation($enrollment->edcensoStageVsModalityFk->edcenso_associated_stage_id)) {
                         return false;
                     }
                 }

--- a/app/migrations/2024-25-09_add_edcenso_associated_stage_id/sql.sql
+++ b/app/migrations/2024-25-09_add_edcenso_associated_stage_id/sql.sql
@@ -1,0 +1,44 @@
+UPDATE edcenso_stage_vs_modality
+SET edcenso_associated_stage_id = CASE name
+    WHEN 'Educação infantil - creche (0 a 3 anos)' THEN 1
+    WHEN 'Educação infantil - pré-escola (4 e 5 anos)' THEN 2
+    WHEN 'Educação infantil - unificada (0 a 5 anos)' THEN 3
+    WHEN 'Ensino fundamental de 9 anos - 1º Ano' THEN 14
+    WHEN 'Ensino fundamental de 9 anos - 2º Ano' THEN 15
+    WHEN 'Ensino fundamental de 9 anos - 3º Ano' THEN 16
+    WHEN 'Ensino fundamental de 9 anos - 4º Ano' THEN 17
+    WHEN 'Ensino fundamental de 9 anos - 5º Ano' THEN 18
+    WHEN 'Ensino fundamental de 9 anos - 6º Ano' THEN 19
+    WHEN 'Ensino fundamental de 9 anos - 7º Ano' THEN 20
+    WHEN 'Ensino fundamental de 9 anos - 8º Ano' THEN 21
+    WHEN 'Ensino fundamental de 9 anos - multi' THEN 22
+    WHEN 'Ensino fundamental de 9 anos - 9º Ano' THEN 41
+    WHEN 'Ensino fundamental de 9 anos - correção de fluxo' THEN 23
+    WHEN 'Educação infantil e ensino fundamental - multietapa' THEN 56
+    WHEN 'Ensino médio - 1ª Série' THEN 25
+    WHEN 'Ensino médio - 2ª Série' THEN 26
+    WHEN 'Ensino médio - 3ª Série' THEN 27
+    WHEN 'Ensino médio - 4ª Série' THEN 28
+    WHEN 'Ensino médio - não seriada' THEN 29
+    WHEN 'Curso técnico integrado (ensino médio integrado) 1ª Série' THEN 30
+    WHEN 'Curso técnico integrado (ensino médio integrado) 2ª Série' THEN 31
+    WHEN 'Curso técnico integrado (ensino médio integrado) 3ª Série' THEN 32
+    WHEN 'Curso técnico integrado (ensino médio integrado) 4ª Série' THEN 33
+    WHEN 'Curso técnico integrado (ensino médio integrado) não seriada' THEN 34
+    WHEN 'Curso técnico integrado na modalidade EJA (EJA integrada à educação profissional de nível médio)' THEN 74
+    WHEN 'Ensino médio - normal/magistério 1ª Série' THEN 35
+    WHEN 'Ensino médio - normal/magistério 2ª Série' THEN 36
+    WHEN 'Ensino médio - normal/magistério 3ª Série' THEN 37
+    WHEN 'Ensino médio - normal/magistério 4ª Série' THEN 38
+    WHEN 'Curso técnico - concomitante' THEN 39
+    WHEN 'Curso técnico - subsequente' THEN 40
+    WHEN 'Curso técnico misto' THEN 64
+    WHEN 'EJA - ensino fundamental - anos iniciais' THEN 69
+    WHEN 'EJA - ensino fundamental - anos finais' THEN 70
+    WHEN 'EJA - ensino fundamental - anos iniciais e anos finais' THEN 72
+    WHEN 'EJA - ensino médio' THEN 71
+    WHEN 'Curso FIC integrado na modalidade EJA - nível médio' THEN 67
+    WHEN 'Curso FIC integrado na modalidade EJA – nível fundamental (EJA integrada à educação profissional de nível fundamental)' THEN 73
+    WHEN 'Curso FIC concomitante' THEN 68
+    ELSE edcenso_associated_stage_id -- Mantém o valor original se não houver correspondência
+END;


### PR DESCRIPTION
## Motivação
Corrigir erro frequência do ensino fundamental menor em Muribeca que não estavam com a frequência unificada.


## Alterações Realizadas
alterado método de verificação de etapa de ensino no Controller de ClassesController.php agora a validação é feita levando em consideração o campo de edcenso_associated_stage_id e não mais o id da etapa.

## Fluxo de Teste
### 🧪 Teste 01
      Acessar tela de frequência
      Selecionar uma turma de ensino fundamental menor
      Salvar frequência e justificativa de falta 
      Verificar se as informações ficaram salvas

### 🧪 Teste 02
      Acessar tela de frequência
      Selecionar uma turma de ensino fundamental maior
      Salvar frequência e justificativa de falta 
      Verificar se as informações ficaram salvas

## Migrations Utilizadas

      app/migrations/2024-25-09_add_edcenso_associated_stage_id/sql.sql

## Checklist de revisão
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
