### PR TITLE
Fix/aee record pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.87.194]
+- Adicionando paginação nas telas de ficha AEE
+
 ## [Versão 3.87.193]
 - Consertado estrutura de notas para as etapas por conceito
 

--- a/app/modules/aeerecord/controllers/DefaultController.php
+++ b/app/modules/aeerecord/controllers/DefaultController.php
@@ -233,6 +233,7 @@ class DefaultController extends Controller
                         ),
                     ),
                 ),
+                'pagination' => false
             ));
         }
 
@@ -256,6 +257,7 @@ class DefaultController extends Controller
                     ),
                 ),
             ),
+            'pagination' => false
         ));
 
 


### PR DESCRIPTION
## Motivação
Foi observado que a paginação das fichas AEE não estava funcionando, sendo assim, só apareciam 10 fichas cadastradas de alunos. 

## Alterações Realizadas
- Adicionando paginação nas telas de ficha AEE

## Fluxo de Teste
```
- Acessar a tela de ficha AEE como administrador e verificar se existe a paginação na tela inicial
- Acessar a tela de ficha AEE como professor e verificar se existe a paginação na tela inicial
```

## Migrations Utilizadas

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
