### PR TITLE
Fix/final recovery modality

### DIFF
--- a/app/controllers/AdminController.php
+++ b/app/controllers/AdminController.php
@@ -559,13 +559,6 @@ class AdminController extends Controller
 
                 $recoveryUnity = GradeUnity::model()->find('id = :id', array(':id' => $finalRecovery["id"]));
 
-                if ($finalRecovery["operation"] === "delete") {
-                    $recoveryUnity->delete();
-                    GradeUnityModality::model()->deleteByAttributes(["grade_unity_fk"=>$recoveryUnity]);
-                    echo json_encode(["valid" => true]);
-                    Yii::app()->end();
-                }
-
                 if ($recoveryUnity === null) {
                     $recoveryUnity = new GradeUnity();
                 }
@@ -587,7 +580,7 @@ class AdminController extends Controller
                     if ($modalityModel == null) {
                         $modalityModel = new GradeUnityModality();
                     }
-                    $modalityModel->name = "prova";
+                    $modalityModel->name = "Avaliação/Prova";
                     $modalityModel->type = "R";
                     $modalityModel->weight = null;
                     $modalityModel->grade_unity_fk = $recoveryUnity->id;
@@ -598,7 +591,13 @@ class AdminController extends Controller
 
                     $modalityModel->save();
 
+            } elseif ($hasFinalRecovery === false && $finalRecovery["operation"] === "delete") {
+                $recoveryUnity = GradeUnity::model()->find('id = :id', array(':id' => $finalRecovery["id"]));
+                $recoveryUnity->delete();
+                echo json_encode(["valid" => true]);
+                Yii::app()->end();
             }
+
 
             echo json_encode(["valid" => true]);
         } catch (\Throwable $th) {

--- a/app/controllers/AdminController.php
+++ b/app/controllers/AdminController.php
@@ -561,6 +561,7 @@ class AdminController extends Controller
 
                 if ($finalRecovery["operation"] === "delete") {
                     $recoveryUnity->delete();
+                    GradeUnityModality::model()->deleteByAttributes(["grade_unity_fk"=>$recoveryUnity]);
                     echo json_encode(["valid" => true]);
                     Yii::app()->end();
                 }
@@ -580,6 +581,23 @@ class AdminController extends Controller
                 }
 
                 $recoveryUnity->save();
+
+
+                    $modalityModel = GradeUnityModality::model()->findByAttributes(["grade_unity_fk"=>$recoveryUnity->id]);
+                    if ($modalityModel == null) {
+                        $modalityModel = new GradeUnityModality();
+                    }
+                    $modalityModel->name = "prova";
+                    $modalityModel->type = "R";
+                    $modalityModel->weight = null;
+                    $modalityModel->grade_unity_fk = $recoveryUnity->id;
+
+                    if (!$modalityModel->validate()) {
+                        throw new CantSaveGradeUnityModalityException($modalityModel);
+                    }
+
+                    $modalityModel->save();
+
             }
 
             echo json_encode(["valid" => true]);

--- a/app/domain/grades/usecases/CalculateNumericGradeUsecase.php
+++ b/app/domain/grades/usecases/CalculateNumericGradeUsecase.php
@@ -103,7 +103,7 @@ class CalculateNumericGradeUsecase
 
     private function calculateFinalRecovery($gradeResult, $studentEnrollment, $discipline, $unity)
     {
-        $unityMedia = $this->calculateUnityMedia($studentEnrollment, $discipline, $unity);
+        $unityMedia = $this->calculateFinalRecoveryMedia($studentEnrollment, $discipline, $unity);
         $gradeResult->setAttribute("rec_final", is_nan($unityMedia) ? "" : $unityMedia);
 
         return $gradeResult;
@@ -255,6 +255,18 @@ class CalculateNumericGradeUsecase
         );
         $isRecovery = false;
         return $this->applyStrategyComputeGradesByFormula($unity->gradeCalculationFk->name, $unity, array_column($grades, "grade"), $isRecovery);
+    }
+
+    private function calculateFinalRecoveryMedia($enrollment, $disciplineId, $unity)
+    {
+
+        $grades = $this->getRecoveryGradeFromUnity(
+            $enrollment->id,
+            $disciplineId,
+            $unity->id
+        );
+        $isRecovery = false;
+        return $this->applyStrategyComputeGradesByFormula($unity->gradeCalculationFk->name, $unity, [$grades->grade], $isRecovery);
     }
 
     /**

--- a/instance.php
+++ b/instance.php
@@ -15,7 +15,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'boquim.tag.ong.br';
+    $newdb = 'demo.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;


### PR DESCRIPTION
## Motivação
As recuperações finais não estavam sendo carregadas na tela de notas. Por que não tinham nenhuma modalidade associada a elas. Além disso, as recuperações finais não estavam sendo apagadas quando deviam

## Alterações Realizadas
-- foi adicionado no código a criação de uma modalidade para a recuperação final
-- Foi alterado também o método de cálculo de média final
## Fluxo de Teste
- Na tela de estrutura, salvar uma estrutura com recuperação final (mesmo se ela já aparecer é necessário clicar em salvar)
- Na tela de notas verificar se a recuperação final abre quando selecionada no select de Unidades
- VERIFICAR OS CÁLCULOS das unidades e da recuperação final, para estruturas como tipo de aprovação por:
   - Média
   - Soma
   - Média Semestral
   - Maior
   - Menor
   - Peso
   
  
![image](https://github.com/user-attachments/assets/d8518d2d-967c-4a25-836f-afc251141a90)

- Verificar também se a recuperação final está sendo apagada quando o usuário desmarca o checkbox "incluir recuperação final" na tela de estrutura

## Migrations Utilizadas

## Checklist de revisão
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
