### PR TITLE
Feat/unified frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.88.193]
+- Adicionado campo para unificar a frequencia na tela de etapa de ensino
+
 ## [Versão 3.87.193]
 - Consertado estrutura de notas para as etapas por conceito
 

--- a/app/controllers/ClassesController.php
+++ b/app/controllers/ClassesController.php
@@ -143,12 +143,12 @@ class ClassesController extends Controller
     {
         $classroomId = Yii::app()->request->getPost('classroom');
         $classroom  = Classroom::model()->findByPk($classroomId);
-        $isMinorEducation = $this->checkIsStageMinorEducation($classroom);
         $month = Yii::app()->request->getPost('month');
         $year = Yii::app()->request->getPost('year');
         $disciplineId = Yii::app()->request->getPost('discipline');
 
         $students = $this->getStudentsByClassroom($classroomId);
+        $isMinorEducation = $classroom->edcensoStageVsModalityFk->unified_frequency == 1 ? true : $this->checkIsStageMinorEducation($classroom);
 
         if (!$isMinorEducation) {
             $schedules = $this->getSchedulesFromMajorStage($classroomId, $month, $year, $disciplineId);
@@ -370,7 +370,7 @@ class ClassesController extends Controller
         $discipline = $_POST["discipline"];
 
         $modelClassroom = Classroom::model()->findByPk($classroom);
-        $isMinor = $this->checkIsStageMinorEducation($modelClassroom);
+        $isMinor = $modelClassroom->edcensoStageVsModalityFk->unified_frequency == 1 ? true : $this->checkIsStageMinorEducation($modelClassroom);
         $isMajorStage = !$isMinor;
 
         $schedules = $this->loadSchedulesByStage($isMajorStage, $classroom, $month, $year, $discipline);

--- a/app/controllers/ClassesController.php
+++ b/app/controllers/ClassesController.php
@@ -511,7 +511,7 @@ class ClassesController extends Controller
     public function actionGetFrequency()
     {
         $classroom = Classroom::model()->findByPk($_POST["classroom"]);
-        $isMinor = $this->checkIsStageMinorEducation($classroom);
+        $isMinor = $classroom->edcensoStageVsModalityFk->unified_frequency == 1 ? true : $this->checkIsStageMinorEducation($classroom);
         if ($isMinor == false) {
             $schedules = Schedule::model()->findAll(
                 "classroom_fk = :classroom_fk and year = :year and month = :month and discipline_fk = :discipline_fk and unavailable = 0 order by day, schedule",
@@ -642,7 +642,7 @@ class ClassesController extends Controller
     public function actionSaveFrequency()
     {
         $classroom = Classroom::model()->findByPk($_POST["classroomId"]);
-        $isMinor = $this->checkIsStageMinorEducation($classroom);
+        $isMinor = $classroom->edcensoStageVsModalityFk->unified_frequency == 1 ? true : $this->checkIsStageMinorEducation($classroom);
         if ($isMinor == false) {
             $schedule = Schedule::model()->find("classroom_fk = :classroom_fk and day = :day and year = :year and month = :month and schedule = :schedule", ["classroom_fk" => $_POST["classroomId"], "day" => $_POST["day"], "month" => $_POST["month"], "year" => $_POST["year"], "schedule" => $_POST["schedule"]]);
             $this->saveFrequency($schedule);
@@ -707,7 +707,7 @@ class ClassesController extends Controller
     public function actionSaveJustification()
     {
         $classroom = Classroom::model()->findByPk($_POST["classroomId"]);
-        $isMinor = $this->checkIsStageMinorEducation($classroom);
+        $isMinor = $classroom->edcensoStageVsModalityFk->unified_frequency == 1 ? true : $this->checkIsStageMinorEducation($classroom);
         if ($isMinor == false) {
             $schedule = Schedule::model()->find("classroom_fk = :classroom_fk and day = :day and month = :month and year = :year and schedule = :schedule", ["classroom_fk" => $_POST["classroomId"], "day" => $_POST["day"], "month" => $_POST["month"], "year" => $_POST["year"], "schedule" => $_POST["schedule"]]);
             $classFault = ClassFaults::model()->find("schedule_fk = :schedule_fk and student_fk = :student_fk", ["schedule_fk" => $schedule->id, "student_fk" => $_POST["studentId"]]);
@@ -730,7 +730,7 @@ class ClassesController extends Controller
     {
         $result = [];
         $classroom = Classroom::model()->findByPk($_POST["classroom"]);
-        $isMinor = $this->checkIsStageMinorEducation($classroom);
+        $isMinor = $classroom->edcensoStageVsModalityFk->unified_frequency == 1 ? true : $this->checkIsStageMinorEducation($classroom);
         if ($classroom->calendar_fk != null) {
 
             $result["months"] = [];

--- a/app/migrations/2024-04-10_add_unified_frequency_column/sql.sql
+++ b/app/migrations/2024-04-10_add_unified_frequency_column/sql.sql
@@ -1,0 +1,1 @@
+alter table edcenso_stage_vs_modality add unified_frequency INT(11);

--- a/app/migrations/2024-04-10_add_unified_frequency_column/sql.sql
+++ b/app/migrations/2024-04-10_add_unified_frequency_column/sql.sql
@@ -1,1 +1,2 @@
-alter table edcenso_stage_vs_modality add unified_frequency INT(11);
+ALTER TABLE edcenso_stage_vs_modality
+ADD COLUMN unified_frequency INT(11) DEFAULT 0;

--- a/app/models/EdcensoStageVsModality.php
+++ b/app/models/EdcensoStageVsModality.php
@@ -10,6 +10,7 @@
      * @property integer $stage
      * @property integer $edcenso_associated_stage_id
      * @property integer $is_edcenso_stage
+     * @property integer $unified_frequency
      *
      * The followings are the available model relations:
      * @property SchoolStages[] $schoolStages
@@ -128,7 +129,7 @@
                 ['name', 'length', 'max' => 100], // The following rule is used by search().
                 ['alias', 'length', 'max'=>20],
                 // Please remove those attributes that should not be searched.
-                ['id, name, alias, stage, edcenso_associated_stage_id, is_edcenso_stage', 'safe', 'on' => 'search'],
+                ['id, name, alias, stage, edcenso_associated_stage_id, is_edcenso_stage, unified_frequency', 'safe', 'on' => 'search'],
             ];
         }
 
@@ -156,6 +157,7 @@
                 'edcenso_associated_stage_id' => 'Etapa Associada ao Educacenso',
                 'is_edcenso_stage' => 'É uma Etapa do Educacenso',
                 'alias' => 'Abreviação',
+                'unified_frequency' => 'Unificar Frequência'
             ];
         }
 

--- a/app/modules/classdiary/controllers/DefaultController.php
+++ b/app/modules/classdiary/controllers/DefaultController.php
@@ -68,7 +68,7 @@ class DefaultController extends Controller
         $disciplineId = $_POST["discipline"];
         $classroom = Classroom::model()->findByPk($classroomId);
         $discipline = EdcensoDiscipline::model()->findByPk($disciplineId);
-        $isMinor = $this->checkIsStageMinorEducation($classroom);
+        $isMinor = $classroom->edcensoStageVsModalityFk->unified_frequency == 1 ? true : $this->checkIsStageMinorEducation($classroom);
         if ($isMinor == false) {
             $schedules = Schedule::model()->findAll(
                 "classroom_fk = :classroom_fk and year = :year and month = :month and discipline_fk = :discipline_fk and unavailable = 0 order by day, schedule",

--- a/app/modules/classdiary/services/StudentService.php
+++ b/app/modules/classdiary/services/StudentService.php
@@ -4,7 +4,8 @@ class StudentService
 {
     public function getFrequency($classroom_fk, $stage_fk, $discipline_fk, $date) {
         // Fundamental menor
-        $is_minor_schooling = Yii::app()->utils->isStageMinorEducation($stage_fk);
+        $classroom = Classroom::model()->findByPk($classroom_fk);
+        $is_minor_schooling = $classroom->edcensoStageVsModalityFk->unified_frequency == 1 ? true : Yii::app()->utils->isStageMinorEducation($stage_fk);
         if ($is_minor_schooling)
         {
             $schedule = Schedule::model()->find("classroom_fk = :classroom_fk and day = :day and month = :month and
@@ -106,7 +107,8 @@ class StudentService
 
     public function getSechedulesToSaveFrequency($schedule, $student_id, $fault, $stage_fk, $date, $classroom_id){
         // Fundamental menor
-        $is_minor_schooling = Yii::app()->utils->isStageMinorEducation($stage_fk);
+        $classroom = Classroom::model()->findByPk($classroom_id);
+        $is_minor_schooling = $classroom->edcensoStageVsModalityFk->unified_frequency == 1 ? true : Yii::app()->utils->isStageMinorEducation($stage_fk);
         if ($is_minor_schooling) {
             $schedules = Schedule::model()->findAll("classroom_fk = :classroom_fk and day = :day and month = :month", ["classroom_fk" => $classroom_id,
             "day" => DateTime::createFromFormat("d/m/Y", $date)->format("d"),
@@ -136,7 +138,8 @@ class StudentService
     }
     public function saveJustification($student_id, $stage_fk, $classroom_id, $schedule, $date, $justification){
          // Fundamental menor
-         $is_minor_schooling = Yii::app()->utils->isStageMinorEducation($stage_fk);
+         $classroom = Classroom::model()->findByPk($classroom_id);
+         $is_minor_schooling = $classroom->edcensoStageVsModalityFk->unified_frequency == 1 ? true : Yii::app()->utils->isStageMinorEducation($stage_fk);
         if ($is_minor_schooling) {
             $schedules = Schedule::model()->findAll("classroom_fk = :classroom_fk and day = :day and month = :month", ["classroom_fk" => $classroom_id,
             "day" => DateTime::createFromFormat("d/m/Y", $date)->format("d"),
@@ -162,7 +165,8 @@ class StudentService
     }
     public function getStudentFault($stage_fk, $classroom_fk, $discipline_fk, $date, $student_fk, $schedule){
         // Fundamental menor
-        $is_minor_schooling = Yii::app()->utils->isStageMinorEducation($stage_fk);
+        $classroom = Classroom::model()->findByPk($classroom_fk);
+        $is_minor_schooling = $classroom->edcensoStageVsModalityFk->unified_frequency == 1 ? true : Yii::app()->utils->isStageMinorEducation($stage_fk);
         if ($is_minor_schooling)
         {
             $schedule = Schedule::model()->find("classroom_fk = :classroom_fk and day = :day and month = :month and
@@ -182,7 +186,8 @@ class StudentService
     }
     public function getStudentDiary($stage_fk, $classroom_fk, $discipline_fk, $date, $student_fk) {
          // Fundamental menor
-         $is_minor_schooling = Yii::app()->utils->isStageMinorEducation($stage_fk);
+         $classroom = Classroom::model()->findByPk($classroom_fk);
+         $is_minor_schooling = $classroom->edcensoStageVsModalityFk->unified_frequency == 1 ? true : Yii::app()->utils->isStageMinorEducation($stage_fk);
         if ($is_minor_schooling == "1") {
              $schedule = Schedule::model()->find("classroom_fk = :classroom_fk and day = :day and month = :month and unavailable = 0 group by day order by day, schedule", ["classroom_fk" => $classroom_fk,
              "day" => DateTime::createFromFormat("d/m/Y", $date)->format("d"),
@@ -217,7 +222,8 @@ class StudentService
 
       public function saveStudentDiary($stage_fk, $classroom_fk, $date, $discipline_fk, $student_fk, $student_observation) {
          // Fundamental menor
-         $is_minor_schooling = Yii::app()->utils->isStageMinorEducation($stage_fk);
+         $classroom = Classroom::model()->findByPk($classroom_fk);
+         $is_minor_schooling = $classroom->edcensoStageVsModalityFk->unified_frequency == 1 ? true : Yii::app()->utils->isStageMinorEducation($stage_fk);
         if ($is_minor_schooling == "1") {
              $schedule = Schedule::model()->find("classroom_fk = :classroom_fk and day = :day and month = :month and unavailable = 0 group by day order by schedule, schedule", ["classroom_fk" => $classroom_fk,
              "day" => DateTime::createFromFormat("d/m/Y", $date)->format("d"),

--- a/app/modules/classdiary/views/default/_frequencyElementMobile.php
+++ b/app/modules/classdiary/views/default/_frequencyElementMobile.php
@@ -20,7 +20,7 @@
                 <td class='justify-content--end'>
                         <?php foreach ($f["schedule"] as $s):
                             $is_disabled = ((!$s["available"] || !$s["valid"] ) ? "disabled" : "");
-                            $url_link = yii::app()->createUrl('classdiary/default/StudentClassDiary', array('student_id' => $f["studentId"], 'stage_fk' => $stage_fk, 'classroom_id' => $classroom_fk, 'schedule' => $s["schedule"], 'date' => $date, 'discipline_fk' => $discipline_fk, "justification" => $f["schedule"]["justification"]));
+                            $url_link = yii::app()->createUrl('classdiary/default/StudentClassDiary', array('student_id' => $f["studentId"], 'stage_fk' => $stage_fk, 'classroom_id' => $classroom_fk, 'schedule' => $s["schedule"], 'date' => $date, 'discipline_fk' => $discipline_fk, "justification" => $s["justification"]));
                         ?>
                             <a class="<?='js-justification '.$is_disabled ?>" href='<?= $url_link ?>'><span class="t-icon-annotation t-icon" style="margin:0px 5px 0px 10px;"></span></a><?php  echo  $frequency["isMinorEducation"] ? '' : $s["schedule"].'°' ?> <input class='js-frequency-checkbox' id="<?php echo $f["studentId"] ?>" type='checkbox' <?= $is_disabled ?> <?php echo ( $s["fault"] ? "checked" : "") ?>
                         data-studentId='<?php echo $f["studentId"] ?>' data-classroom_id='<?php echo $classroom_fk ?>' data-stage_fk='<?php echo $stage_fk ?>' data-schedule='<?php echo $s["schedule"]?>'/>

--- a/app/modules/stages/controllers/DefaultController.php
+++ b/app/modules/stages/controllers/DefaultController.php
@@ -59,6 +59,7 @@ class DefaultController extends Controller
 
         if (isset($stageVsModality)) {
             $model->attributes = $stageVsModality;
+            $model->unified_frequency = $stageVsModality["unified_frequency"];
             $model->is_edcenso_stage = 0;
             if ($model->save()) {
                 $msg = 'O Cadastro foi criado com sucesso!';
@@ -86,6 +87,7 @@ class DefaultController extends Controller
 
         if (isset($stageVsModality)) {
             $model->attributes = $stageVsModality;
+            $model->unified_frequency = $stageVsModality["unified_frequency"];
             if ($model->save()) {
                 $msg = 'Etapa atualizada com sucesso!';
 

--- a/app/modules/stages/views/default/_form.php
+++ b/app/modules/stages/views/default/_form.php
@@ -16,7 +16,7 @@ $form = $this->beginWidget('CActiveForm', array(
 <div class="form">
     <div class="mobile-row ">
         <div class="column clearleft">
-            <h1><?php echo $model->isNewRecord ? 'Criar Etapa' : 'Atualizar Etapa ' . $model->id ?></h1>
+            <h1><?php echo $model->isNewRecord ? 'Criar Etapa' : 'Atualizar Etapa'?></h1>
         </div>
         <div class="column clearfix align-items--center justify-content--end show--desktop">
             <button id="saveStage" class="t-button-primary" type="submit">
@@ -83,6 +83,18 @@ $form = $this->beginWidget('CActiveForm', array(
                 <?php echo $form->textField($model, 'alias', array('id' => 'stageAlias', 'size' => 15, 'class' => 't-field-text__input')); ?>
                 <?php echo $form->error($model, 'alias'); ?>
             </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="column clearfix">
+        <div class="t-field-checkbox">
+            <?php echo $form->checkBox(
+                $model,
+                'unified_frequency',
+                array('value' => 1, 'uncheckValue' => 0)
+                ); ?>
+            <?php echo $form->label($model, 'unified_frequency', array('class' => 't-field-text__label')); ?>
+        </div>
         </div>
     </div>
 

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.87.194');
+define("TAG_VERSION", '3.88.193');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');

--- a/js/classes/class-contents/_initialization.js
+++ b/js/classes/class-contents/_initialization.js
@@ -125,6 +125,7 @@ $("#save, #save-button-mobile").on('click', function () {
                 diary: $(this).val()
             })
         });
+        console.log($(this).find("input.classroom-diary-of-the-day"),  $(this).find("input.classroom-diary-of-the-day").val(), "aaaa")
         classContents.push({
             day: $(this).attr("day"),
             diary: $(this).find(".classroom-diary-of-the-day").val(),
@@ -164,7 +165,7 @@ $('.heading-buttons').css('width', $('#content').width());
 $(document).on("click", ".classroom-diary-button", function () {
     let button = this;
     $(".classroom-diary-day").val($(button).closest("tr").attr("day"));
-    $(".js-classroom-diary").val($(button).parent().find(".classroom-diary-of-the-day").val());
+    $(".classroom-diary-textarea").val($(button).parent().find(".classroom-diary-of-the-day").val());
     $(".js-std-classroom-diaries").each(function () {
         let value = $(button).parent().find(".student-diary-of-the-day[studentid=" + $(this).find(".js-student-classroom-diary").attr("studentid") + "]").val();
         $(this).find(".js-student-classroom-diary").val(value);
@@ -177,8 +178,7 @@ $(document).on("click", ".classroom-diary-button", function () {
 
 $(document).on("click", ".js-add-classroom-diary", function () {
     let tr = $("#class-contents tbody").find("tr[day=" + $(".classroom-diary-day").val() + "]");
-
-    tr.find(".classroom-diary-of-the-day").val($(".js-classroom-diary").val());
+    tr.find(".classroom-diary-of-the-day").val($(".classroom-diary-textarea").val());
     $(".js-student-classroom-diary").each(function () {
         tr.find(".student-diary-of-the-day[studentid=" + $(this).attr("studentid") + "]").val($(this).val())
     });

--- a/js/classes/class-contents/functions.js
+++ b/js/classes/class-contents/functions.js
@@ -16,7 +16,6 @@ function createTable(data) {
     let i = 1;
     let pivotChanger = "";
     $.each(data.courseClasses, function () {
-        console.log(this);
         i = pivotChanger !== this.cpid ? 1 : i;
         pivotChanger = this.cpid;
         options += '<option value="' + this.id + '" disciplineid="' + this.edid + '" disciplinename="' + this.edname + '">' + this.cpname + "|" + i++ + "|" + this.content + "|" + this.edname + '</option>';


### PR DESCRIPTION
## Motivação
A fim de adaptar o sistema as diferentes regras de negócio utilizadas em cada município foi adicionada a funcionalidade de unificar frequência por etapa. Agora cada municio pode decidir se uma determinada etapa de ensino tem a frequência polivalente sem afetar os outros município que utilizam a ferramenta.

## Alterações Realizadas

-- Adicionada a unified_frequency coluna na tabela edcenso_stage_vs_modality que será responsável por armazenar o valor que indica se a frequência daquela etapa é ou não unificada.
-- A checagem feita nos controllers para verificar se a etapa é do ensino fundamental menor também foi alterada, no tocante a frequência e a aulas ministradas
-- Durante a realização da tarefa foi consertado alguns bugs encontrados:
- Removido console.log do arquivo js/classes/class-contents/functions.js
- Alterado classes js na arquivo js/classes/class-contents/_initialization.js que não estava salvando a informação do diário pois o seletor estava com a classe errada na tela de Aulas Ministradas
- Retirado o id da Etapa que aparecia no título da tela de edição de etapa de ensino no arquivo app/modules/stages/views/default/_form.php

### :rotating_light: Importante destacar que as alterações feitas refletem mudanças em partes sensíveis do sistema:  
  **- Aulas Ministradas**
  **- Frequência**
  **- Diário de Classe (módulo do professor)**
**Por isso é necessário verificar se as funcionalidades continuam funcionando como esperado**

## Fluxo de Teste
**OBS: para realizar os testes é necessário uma turma que não tenha uma etapa cuja frequência seja unificada, como as turmas eja por exemplo. Além disso é necessário o acesso de um professor que de aula nessa turma**

### :alembic: Teste 1
1 - Acessar a tela de administração  no _sidebar_ do tag e selecionar o card de gerenciar etapas
2 - Escolher uma etapa de ensino e na tela de edição e marcar o campo "Unificar Frequência"
3 - Ir para tela de Frequência e verificar se a frequência foi unificada:
- Marcar frequências de alunos e salvar justificativas e conferir se ao sair da tela e voltar elas permanecem salvas e sendo exibidas na tabela de frequência

### :alembic: Teste 2
1 - Acessar a tela de Aulas ministradas e verificar se a mudança foi refletida lá também:
- Como a frequência passa a ser polivalente nas aulas ministradas não deve aparecer o select de componente curricular para a turma com a etapa de ensino que foi unificada
- Salve planos de aulas de componentes diferentes
- Salve observações de aula e de alunos
- Verifique se os valores salvos continuam lá ao sair da tela e entrar de novo

###  :alembic: Teste 3
1 - Acessar o TAG com o acesso do professor que da aula na turma com a etapa de ensino que foi escolhida para ser unificada
2 - Acessar a tela de diário de classe no _sidebar_
3 - verificar se as alterações feitas nos testes de frequência e aulas ministradas estão refletidas nesse módulo também:
- Veja se os planos de aula e as observações salvas aparecem nos mesmos dias.
- Verifique se a frequência salva também aparece nessa tela
4 - Repita o passo 3 do Teste 1 e o Passo 1 do teste 2 para esse módulo

## Migrations Utilizadas

app/migrations/2024-04-10_add_unified_frequency_column/sql.sql

## Checklist de revisão
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
