### PR TITLE
Fix/class contents visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Versão 3.87.195]
+- Adicionando a sessão de conteúdo de aula na tabela de visualização de aulas ministradas
+- Corrigida a duplicidade de aulas ministradas ao clicar em salvar
+
 ## [Versão 3.87.194]
 - Adicionado campo para unificar a frequencia na tela de etapa de ensino
 - Adicionando paginação nas telas de ficha AEE

--- a/app/controllers/ClassesController.php
+++ b/app/controllers/ClassesController.php
@@ -415,7 +415,6 @@ class ClassesController extends Controller
      */
     private function saveSchedule($schedule, $classContent)
     {
-
         $schedule->diary = $classContent["diary"] === "" ? null : $classContent["diary"];
         $schedule->save();
 
@@ -435,8 +434,18 @@ class ClassesController extends Controller
             ClassContents::model()->deleteAll("id IN (".implode(", ",$contentsToExclude).")");
         }
 
+
         foreach ($classContent["contents"] as $content) {
-            $this->saveClassContents($content, $schedule);
+            $existingContent = ClassContents::model()->findAll(
+                'schedule_fk = :schedule_fk and course_class_fk = :course_class_fk',
+                [
+                    'schedule_fk' => $schedule->id,
+                    'course_class_fk' => $content
+                ]
+            );
+            if(empty($existingContent)){
+                $this->saveClassContents($content, $schedule);
+            }
         }
     }
 

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.87.194');
+define("TAG_VERSION", '3.87.195');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');

--- a/instance.php
+++ b/instance.php
@@ -15,7 +15,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'boquim04/10.tag.ong.br';
+    $newdb = 'boquim23/09.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;

--- a/instance.php
+++ b/instance.php
@@ -15,7 +15,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'boquim23/09.tag.ong.br';
+    $newdb = 'demo.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;

--- a/instance.php
+++ b/instance.php
@@ -15,7 +15,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'boquim.tag.ong.br';
+    $newdb = 'boquim04/10.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;

--- a/js/classes/class-contents/_initialization.js
+++ b/js/classes/class-contents/_initialization.js
@@ -18,7 +18,13 @@ function loadClassContents() {
         success: function (data) {
             data = jQuery.parseJSON(data);
             if (data.valid) {
-                createTable(data);
+                let urlIsValidate = window.location.href.includes("validateClassContents");
+                if(urlIsValidate) {
+                    createValidateTable(data);
+                } else {
+                    createTable(data);
+                }
+
                 $("#print").addClass("show").removeClass("hide");
                 $("#save").addClass("show--desktop").removeClass("hide");
                 $("#save-button-mobile").addClass("show--tablet").removeClass("hide");

--- a/js/classes/class-contents/validateFunctions.js
+++ b/js/classes/class-contents/validateFunctions.js
@@ -1,7 +1,7 @@
 function createValidateTable(data) {
     console.log(data);
     let urlIsValidate = window.location.href.includes("validateClassContents");
-    var monthSplit = $("#month").val().split("-");
+    let monthSplit = $("#month").val().split("-");
     $("#class-contents")
         .attr("classroom", $("#classroom").val())
         .attr("month", monthSplit[1])

--- a/js/classes/class-contents/validateFunctions.js
+++ b/js/classes/class-contents/validateFunctions.js
@@ -58,9 +58,11 @@ function createValidateTable(data) {
         $.each(data.courseClasses, function (index, courseClass) {
             $.each(classContent.contents, function (index, content) {
                 if(courseClass.id == content) {
-                    courseClasses += '<div class="t-badge-info column is-four-fifths">'
-                    + "Plano de aula: " + courseClass.cpname + " Aula " + courseClass.order + "<br>"
-                    + "Conteúdo: " + courseClass.content
+                    courseClasses += '<div class="t-badge-info column text-align--left t-padding-medium--x" style="width:80%">'
+                    + "<div>"
+                    + "<b>Aula:</b> " + courseClass.order + " <b>Plano de aula:</b> " + courseClass.cpname + "<br>"
+                    + "<b>Conteúdo:</b> " + courseClass.content
+                    + "</div>"
                     + '</div>';
                 }
             });
@@ -69,11 +71,10 @@ function createValidateTable(data) {
 
 
         let head = '<th class="center vmiddle contents-day ">' + ((day < 10) ? '0' : '') + day + '</th>';
-        let body = '<td class="row">'
-            + '<input type="hidden" class="classroom-diary-of-the-day" value="' + classContent.diary + '">'
+        let body = '<td class="row align-items--center">'
             + studentInputs
-            + '<span class="t-icon-annotation t-icon classroom-diary-button ' + (!classContent.available ? "disabled" : "") + '" data-toggle="tooltip" title="Diário"></span>'
-            + '<div class="mobile-row wrap" id="day[' + day + ']" name="day[' + day + '][]" class="vmiddle">'
+            + '<span style="font-size: 24px" class="t-icon t-icon-annotation t-margin-large--left classroom-diary-button' + (!classContent.available ? "disabled" : "") + '" data-toggle="tooltip" title="Diário"></span>'
+            + '<div class="column clearfix" id="day[' + day + ']" name="day[' + day + '][]">'
             + courseClasses
             + '</div>'
             + '</td>';

--- a/js/classes/class-contents/validateFunctions.js
+++ b/js/classes/class-contents/validateFunctions.js
@@ -13,15 +13,6 @@ function createValidateTable(data) {
     $('#class-contents > thead').html('<tr><th class="center">Dias</th><th style="text-align:left">Conteúdo ministrado em sala de aula</th></tr>');
     $('#class-contents > tbody').html('');
 
-    let options = "";
-    let i = 1;
-    let pivotChanger = "";
-    $.each(data.courseClasses, function () {
-        console.log(this);
-        i = pivotChanger !== this.cpid ? 1 : i;
-        pivotChanger = this.cpid;
-        options += '<div class="t-badge-info" value="' + this.id + '" disciplineid="' + this.edid + '" disciplinename="' + this.edname + '">' + this.cpname + "|" + i++ + "|" + this.content + "|" + this.edname + '</div>';
-    });
     let accordionBuilt = false;
     let accordionHtml = "";
     accordionHtml += `<div id='accordion' class='t-accordeon-primary' style='overflow: auto; height: 400px;'>`
@@ -30,17 +21,17 @@ function createValidateTable(data) {
         if (Object.keys(classContent.students).length) {
             $.each(classContent.students, function (index, studentArray) {
                 $.each(studentArray, function (index, student) {
-                    studentInputs += "<input type='hidden' class='student-diary-of-the-day' studentid='" + this.id + "' value='" + this.diary + "'>";
+                    studentInputs += "<input type='hidden' class='student-diary-of-the-day' studentid='" + student.id + "' value='" + student.diary + "'>";
                     if (!accordionBuilt) {
                         accordionHtml +=
                             `<div class='align-items--center'>
                                 <h4 class='t-title'>
                                     <span class='t-icon-person icon-color'></span>
-                                    ${this.name}
+                                    ${student.name}
                                 </h4>
                             </div>
                             <div class='ui-accordion-content js-std-classroom-diaries'>
-                                <textarea ${urlIsValidate ? 'readonly' : ''} class='t-field-tarea__input js-student-classroom-diary' studentid='${this.id}' style='resize: vertical;height: 37px;'></textarea>
+                                <textarea ${urlIsValidate ? 'readonly' : ''} class='t-field-tarea__input js-student-classroom-diary' studentid='${student.id}' style='resize: vertical;height: 37px;'></textarea>
                             </div>`
                     }
                 });
@@ -55,19 +46,30 @@ function createValidateTable(data) {
             $(".classroom-diary-no-students").show();
         }
         let courseClasses = "";
-        $.each(data.courseClasses, function (index, courseClass) {
-            $.each(classContent.contents, function (index, content) {
-                if(courseClass.id == content) {
-                    courseClasses += '<div class="t-badge-info column text-align--left t-padding-medium--x" style="width:80%">'
-                    + "<div>"
-                    + "<b>Aula:</b> " + courseClass.order + " <b>Plano de aula:</b> " + courseClass.cpname + "<br>"
-                    + "<b>Conteúdo:</b> " + courseClass.content
-                    + "</div>"
-                    + '</div>';
-                }
-            });
+        let isContentsEmpty = false;
 
+        $.each(data.courseClasses, function (index, courseClass) {
+            if (classContent.contents && Object.keys(classContent.contents).length) {
+                $.each(classContent.contents, function (index, content) {
+                    if(courseClass.id == content) {
+                        courseClasses += '<div class="t-badge-info column text-align--left t-padding-medium--x" style="width:80%">'
+                        + "<div>"
+                        + "<b>Aula:</b> " + courseClass.order + " <b>Plano de aula:</b> " + courseClass.cpname + "<br>"
+                        + "<b>Conteúdo:</b> " + courseClass.content
+                        + "</div>"
+                        + '</div>';
+                    }
+                });
+            } else {
+                isContentsEmpty =  true;
+            }
         });
+
+        if(isContentsEmpty) {
+            courseClasses += '<div class="t-badge-info column text-align--left t-padding-medium--x">'
+            + 'Nenhuma aula ministrada neste dia'
+            + '</div>';
+        }
 
 
         let head = '<th class="center vmiddle contents-day ">' + ((day < 10) ? '0' : '') + day + '</th>';

--- a/js/classes/class-contents/validateFunctions.js
+++ b/js/classes/class-contents/validateFunctions.js
@@ -1,0 +1,96 @@
+function createValidateTable(data) {
+    console.log(data);
+    let urlIsValidate = window.location.href.includes("validateClassContents");
+    var monthSplit = $("#month").val().split("-");
+    $("#class-contents")
+        .attr("classroom", $("#classroom").val())
+        .attr("month", monthSplit[1])
+        .attr("year", monthSplit[0])
+        .attr("discipline", $("#disciplines").val())
+        .attr("fundamentalmaior", $("#classroom option:selected")
+        .attr("fundamentalmaior")
+    );
+    $('#class-contents > thead').html('<tr><th class="center">Dias</th><th style="text-align:left">Conteúdo ministrado em sala de aula</th></tr>');
+    $('#class-contents > tbody').html('');
+
+    let options = "";
+    let i = 1;
+    let pivotChanger = "";
+    $.each(data.courseClasses, function () {
+        console.log(this);
+        i = pivotChanger !== this.cpid ? 1 : i;
+        pivotChanger = this.cpid;
+        options += '<div class="t-badge-info" value="' + this.id + '" disciplineid="' + this.edid + '" disciplinename="' + this.edname + '">' + this.cpname + "|" + i++ + "|" + this.content + "|" + this.edname + '</div>';
+    });
+    let accordionBuilt = false;
+    let accordionHtml = "";
+    accordionHtml += `<div id='accordion' class='t-accordeon-primary' style='overflow: auto; height: 400px;'>`
+    $.each(data.classContents, function (day, classContent) {
+        let studentInputs = "";
+        if (Object.keys(classContent.students).length) {
+            $.each(classContent.students, function (index, studentArray) {
+                $.each(studentArray, function (index, student) {
+                    studentInputs += "<input type='hidden' class='student-diary-of-the-day' studentid='" + this.id + "' value='" + this.diary + "'>";
+                    if (!accordionBuilt) {
+                        accordionHtml +=
+                            `<div class='align-items--center'>
+                                <h4 class='t-title'>
+                                    <span class='t-icon-person icon-color'></span>
+                                    ${this.name}
+                                </h4>
+                            </div>
+                            <div class='ui-accordion-content js-std-classroom-diaries'>
+                                <textarea ${urlIsValidate ? 'readonly' : ''} class='t-field-tarea__input js-student-classroom-diary' studentid='${this.id}' style='resize: vertical;height: 37px;'></textarea>
+                            </div>`
+                    }
+                });
+            });
+
+            if (!accordionBuilt) {
+                $(".accordion-students").html(accordionHtml);
+                accordionBuilt = true;
+            }
+            $(".classroom-diary-no-students").hide();
+        } else {
+            $(".classroom-diary-no-students").show();
+        }
+        let courseClasses = "";
+        $.each(data.courseClasses, function (index, courseClass) {
+            $.each(classContent.contents, function (index, content) {
+                if(courseClass.id == content) {
+                    courseClasses += '<div class="t-badge-info column is-four-fifths">'
+                    + "Plano de aula: " + courseClass.cpname + " Aula " + courseClass.order + "<br>"
+                    + "Conteúdo: " + courseClass.content
+                    + '</div>';
+                }
+            });
+
+        });
+
+
+        let head = '<th class="center vmiddle contents-day ">' + ((day < 10) ? '0' : '') + day + '</th>';
+        let body = '<td class="row">'
+            + '<input type="hidden" class="classroom-diary-of-the-day" value="' + classContent.diary + '">'
+            + studentInputs
+            + '<span class="t-icon-annotation t-icon classroom-diary-button ' + (!classContent.available ? "disabled" : "") + '" data-toggle="tooltip" title="Diário"></span>'
+            + '<div class="mobile-row wrap" id="day[' + day + ']" name="day[' + day + '][]" class="vmiddle">'
+            + courseClasses
+            + '</div>'
+            + '</td>';
+        $('#class-contents > tbody').append('<tr class="center day-row" day="' + day + '">' + head + body + '</tr>');
+    });
+    accordionHtml += `</div>`
+    $('[data-toggle="tooltip"]').tooltip({container: "body"});
+    $('#widget-class-contents').show();
+    $('#class-contents').show();
+
+    $(function () {
+        $( "#accordion" ).accordion({
+            active: false,
+            collapsible: true,
+            icons: false,
+            heightStyle: "content"
+        });
+    })
+
+}

--- a/themes/default/views/classes/validateClassContents.php
+++ b/themes/default/views/classes/validateClassContents.php
@@ -10,7 +10,7 @@ $baseUrl = Yii::app()->baseUrl;
 $themeUrl = Yii::app()->theme->baseUrl;
 $cs = Yii::app()->getClientScript();
 $cs->registerScriptFile($baseUrl . '/js/classes/class-contents/_initialization.js?v=' . TAG_VERSION, CClientScript::POS_END);
-$cs->registerScriptFile($baseUrl . '/js/classes/class-contents/functions.js?v=' . TAG_VERSION, CClientScript::POS_END);
+$cs->registerScriptFile($baseUrl . '/js/classes/class-contents/validateFunctions.js?v=' . TAG_VERSION, CClientScript::POS_END);
 
 $this->setPageTitle('TAG - ' . Yii::t('default', 'Classes Contents'));
 


### PR DESCRIPTION
## Motivação
Para facilitar a visualização das aulas ministradas no usuário de coordenador pedagógico, foi necessário realizar uma alteração na tabela. A tela de validação de aulas ministradas lista a informação completa das aulas, informando o número da aula, o plano de aula e o conteúdo. 

## Alterações Realizadas
- Adicionando a sessão de conteúdo de aula na tabela de visualização de aulas ministradas
- Corrigida a duplicidade de aulas ministradas ao clicar em salvar

## Fluxo de Teste

```
- Acessar o tag como coordenador pedagógico
- Acessar a tela de aulas ministradas
- Informar a turma e o mês
- Verificar se a listagem das aulas ministradas contém o número da aula, o plano de aula e o conteúdo. 
```
Obs: Para facilitar o processo de testes, abra em outro navegador o tag com o usuário administrador e verifique na tela de aulas ministradas se as informações naquela turma e mês são as mesmas. 

## Migrations Utilizadas

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
