### PR TITLE
Fix/change class contents schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.89.198]
+- Retirando a chave estrangeira de schedule em class_contents
+
 ## [Versão 3.89.197]
 - Correção de consulta de cardápio sagres versão nova
 

--- a/app/controllers/ClassesController.php
+++ b/app/controllers/ClassesController.php
@@ -454,6 +454,11 @@ class ClassesController extends Controller
         $classHasContent = new ClassContents();
         $classHasContent->schedule_fk = $schedule->id;
         $classHasContent->course_class_fk = $content;
+        $classHasContent->day = $schedule->day;
+        $classHasContent->month = $schedule->month;
+        $classHasContent->year = $schedule->year;
+        $classHasContent->classroom_fk = $schedule->classroom_fk;
+        $classHasContent->discipline_fk = $schedule->discipline_fk;
         $classHasContent->save();
     }
 

--- a/app/migrations/2024-10-23_remove_class_contents_schedule_fk/default.sql
+++ b/app/migrations/2024-10-23_remove_class_contents_schedule_fk/default.sql
@@ -1,0 +1,10 @@
+ALTER TABLE class_contents DROP FOREIGN KEY class_contents_ibfk_1;
+ALTER TABLE class_contents DROP FOREIGN KEY class_contents_ibfk_2;
+
+ALTER TABLE class_contents MODIFY schedule_fk INT(11) NULL;
+
+ALTER TABLE class_contents
+ADD CONSTRAINT class_contents_ibfk_1
+FOREIGN KEY (schedule_fk) REFERENCES schedule(id)
+ON DELETE SET NULL
+ON UPDATE CASCADE;

--- a/app/migrations/2024-10-23_remove_class_contents_schedule_fk/default.sql
+++ b/app/migrations/2024-10-23_remove_class_contents_schedule_fk/default.sql
@@ -7,10 +7,10 @@ ALTER TABLE class_contents ADD COLUMN year INT(11);
 ALTER TABLE class_contents ADD COLUMN classroom_fk INT(11);
 ALTER TABLE class_contents ADD COLUMN discipline_fk INT(11);
 
--- ALTER TABLE class_contents MODIFY schedule_fk INT(11) NULL;
-
--- ALTER TABLE class_contents
--- ADD CONSTRAINT class_contents_ibfk_1
--- FOREIGN KEY (schedule_fk) REFERENCES schedule(id)
--- ON DELETE SET NULL
--- ON UPDATE CASCADE;
+UPDATE class_contents cc
+JOIN schedule s ON cc.schedule_fk = s.id
+SET cc.day = s.day,
+    cc.month = s.month,
+    cc.year = s.year,
+    cc.classroom_fk = s.classroom_fk,
+    cc.discipline_fk = s.discipline_fk;

--- a/app/migrations/2024-10-23_remove_class_contents_schedule_fk/default.sql
+++ b/app/migrations/2024-10-23_remove_class_contents_schedule_fk/default.sql
@@ -1,10 +1,16 @@
 ALTER TABLE class_contents DROP FOREIGN KEY class_contents_ibfk_1;
 ALTER TABLE class_contents DROP FOREIGN KEY class_contents_ibfk_2;
 
-ALTER TABLE class_contents MODIFY schedule_fk INT(11) NULL;
+ALTER TABLE class_contents ADD COLUMN day INT(11);
+ALTER TABLE class_contents ADD COLUMN month INT(11);
+ALTER TABLE class_contents ADD COLUMN year INT(11);
+ALTER TABLE class_contents ADD COLUMN classroom_fk INT(11);
+ALTER TABLE class_contents ADD COLUMN discipline_fk INT(11);
 
-ALTER TABLE class_contents
-ADD CONSTRAINT class_contents_ibfk_1
-FOREIGN KEY (schedule_fk) REFERENCES schedule(id)
-ON DELETE SET NULL
-ON UPDATE CASCADE;
+-- ALTER TABLE class_contents MODIFY schedule_fk INT(11) NULL;
+
+-- ALTER TABLE class_contents
+-- ADD CONSTRAINT class_contents_ibfk_1
+-- FOREIGN KEY (schedule_fk) REFERENCES schedule(id)
+-- ON DELETE SET NULL
+-- ON UPDATE CASCADE;

--- a/app/models/ClassContents.php
+++ b/app/models/ClassContents.php
@@ -39,18 +39,19 @@ class ClassContents extends CActiveRecord
 	 * @return array validation rules for model attributes.
 	 */
 	public function rules()
-	{
-		// NOTE: you should only define rules for those attributes that
-		// will receive user inputs.
-		return array(
-			array('schedule_fk, course_class_fk', 'required'),
-			array('schedule_fk, course_class_fk', 'numerical', 'integerOnly'=>true),
-			array('fkid', 'length', 'max'=>40),
-			// The following rule is used by search().
-			// @todo Please remove those attributes that should not be searched.
-			array('id, schedule_fk, course_class_fk, fkid', 'safe', 'on'=>'search'),
-		);
-	}
+    {
+        // NOTE: you should only define rules for those attributes that
+        // will receive user inputs.
+        return array(
+            array('schedule_fk, course_class_fk', 'required'),
+            array('schedule_fk, course_class_fk, day, month, year, classroom_fk, discipline_fk', 'numerical', 'integerOnly'=>true),
+            array('fkid', 'length', 'max'=>40),
+            array('created_at, updated_at', 'safe'),
+            // The following rule is used by search().
+            // @todo Please remove those attributes that should not be searched.
+            array('id, schedule_fk, course_class_fk, fkid, created_at, updated_at, day, month, year, classroom_fk, discipline_fk', 'safe', 'on'=>'search'),
+        );
+    }
 
 	/**
 	 * @return array relational rules.
@@ -60,7 +61,6 @@ class ClassContents extends CActiveRecord
 		// NOTE: you may need to adjust the relation name and the related
 		// class name for the relations automatically generated below.
 		return array(
-			'scheduleFk' => array(self::BELONGS_TO, Schedule::class, 'schedule_fk'),
 			'courseClassFk' => array(self::BELONGS_TO, CourseClass::class, 'course_class_fk'),
 		);
 	}
@@ -69,14 +69,21 @@ class ClassContents extends CActiveRecord
 	 * @return array customized attribute labels (name=>label)
 	 */
 	public function attributeLabels()
-	{
-		return array(
-			'id' => 'ID',
-			'schedule_fk' => 'Schedule Fk',
-			'course_class_fk' => 'Course Class Fk',
-			'fkid' => 'Fkid',
-		);
-	}
+    {
+        return array(
+            'id' => 'ID',
+            'schedule_fk' => 'Schedule Fk',
+            'course_class_fk' => 'Course Class Fk',
+            'fkid' => 'Fkid',
+            'created_at' => 'Created At',
+            'updated_at' => 'Updated At',
+            'day' => 'Day',
+            'month' => 'Month',
+            'year' => 'Year',
+            'classroom_fk' => 'Classroom Fk',
+            'discipline_fk' => 'Discipline Fk',
+        );
+    }
 
 	/**
 	 * Retrieves a list of models based on the current search/filter conditions.
@@ -91,20 +98,26 @@ class ClassContents extends CActiveRecord
 	 * based on the search/filter conditions.
 	 */
 	public function search()
-	{
-		// @todo Please modify the following code to remove attributes that should not be searched.
+    {
 
-		$criteria=new CDbCriteria;
+        $criteria=new CDbCriteria;
 
-		$criteria->compare('id',$this->id);
-		$criteria->compare('schedule_fk',$this->schedule_fk);
-		$criteria->compare('course_class_fk',$this->course_class_fk);
-		$criteria->compare('fkid',$this->fkid,true);
+        $criteria->compare('id',$this->id);
+        $criteria->compare('schedule_fk',$this->schedule_fk);
+        $criteria->compare('course_class_fk',$this->course_class_fk);
+        $criteria->compare('fkid',$this->fkid,true);
+        $criteria->compare('created_at',$this->created_at,true);
+        $criteria->compare('updated_at',$this->updated_at,true);
+        $criteria->compare('day',$this->day);
+        $criteria->compare('month',$this->month);
+        $criteria->compare('year',$this->year);
+        $criteria->compare('classroom_fk',$this->classroom_fk);
+        $criteria->compare('discipline_fk',$this->discipline_fk);
 
-		return new CActiveDataProvider($this, array(
-			'criteria'=>$criteria,
-		));
-	}
+        return new CActiveDataProvider($this, array(
+            'criteria'=>$criteria,
+        ));
+    }
 
 	/**
 	 * Returns the static model of the specified AR class.

--- a/app/modules/calendar/controllers/DefaultController.php
+++ b/app/modules/calendar/controllers/DefaultController.php
@@ -102,8 +102,8 @@ class DefaultController extends Controller
         $event = CalendarEvent::model()->findByPk($_POST["id"]);
         if (Yii::app()->getAuthManager()->checkAccess('admin', Yii::app()->user->loginInfos->id) || $event == null || $event->school_fk != null) {
             $result = Yii::app()->db->createCommand("
-            select count(s.id) as qtd from schedule s 
-            join classroom cr on s.classroom_fk = cr.id 
+            select count(s.id) as qtd from schedule s
+            join classroom cr on s.classroom_fk = cr.id
             join calendar c on cr.calendar_fk = c.id
             where c.id = :id")->bindParam(":id", $_POST["calendarFk"])->queryRow();
             $isHardUnavailableEvent = $_POST["eventTypeFk"] == 102;
@@ -159,8 +159,8 @@ class DefaultController extends Controller
                 $period = new DatePeriod($start, $interval, $end);
                 foreach ($period as $dt) {
                     $schedulesToAdjust = Yii::app()->db->createCommand("
-                            select s.id from schedule s 
-                            join classroom cr on s.classroom_fk = cr.id 
+                            select s.id from schedule s
+                            join classroom cr on s.classroom_fk = cr.id
                             join calendar c on cr.calendar_fk = c.id
                             where c.id = :id and s.day = :day and s.month = :month and s.year = :year")->bindParam(":id", $_POST["calendarFk"])->bindParam(":day", $dt->format("j"))->bindParam(":month", $dt->format("n"))->bindParam(":year", $dt->format("Y"))->queryAll();
                     foreach ($schedulesToAdjust as $scheduleToAdjust) {
@@ -169,7 +169,6 @@ class DefaultController extends Controller
                         } else if ($isSoftUnavailableEvent) {
                             Schedule::model()->updateAll(["unavailable" => 1], "id = :id", [":id" => $scheduleToAdjust["id"]]);
                             ClassFaults::model()->deleteAll("schedule_fk = :schedule_fk", [":schedule_fk" => $scheduleToAdjust["id"]]);
-                            ClassContents::model()->deleteAll("schedule_fk = :schedule_fk", [":schedule_fk" => $scheduleToAdjust["id"]]);
                             ClassDiaries::model()->deleteAll("schedule_fk = :schedule_fk", [":schedule_fk" => $scheduleToAdjust["id"]]);
                         } else {
                             Schedule::model()->updateAll(["unavailable" => 0], "id = :id", [":id" => $scheduleToAdjust["id"]]);
@@ -201,8 +200,8 @@ class DefaultController extends Controller
         $event = CalendarEvent::model()->findByPk($_POST["id"]);
         if (Yii::app()->getAuthManager()->checkAccess('admin', Yii::app()->user->loginInfos->id) || $event->school_fk != null) {
             $result = Yii::app()->db->createCommand("
-            select count(s.id) as qtd from schedule s 
-            join classroom cr on s.classroom_fk = cr.id 
+            select count(s.id) as qtd from schedule s
+            join classroom cr on s.classroom_fk = cr.id
             join calendar c on cr.calendar_fk = c.id
             where c.id = :id")->bindParam(":id", $_POST["calendarId"])->queryRow();
             $isHardUnavailableEvent = $event->calendar_event_type_fk == 102;
@@ -222,8 +221,8 @@ class DefaultController extends Controller
                 foreach ($period as $dt) {
                     if ($isSoftUnavailableEvent) {
                         $schedulesToAdjust = Yii::app()->db->createCommand("
-                            select s.id from schedule s 
-                            join classroom cr on s.classroom_fk = cr.id 
+                            select s.id from schedule s
+                            join classroom cr on s.classroom_fk = cr.id
                             join calendar c on cr.calendar_fk = c.id
                             where c.id = :id and s.day = :day and s.month = :month and s.year = :year")->bindParam(":id", $_POST["calendarId"])->bindParam(":day", $dt->format("j"))->bindParam(":month", $dt->format("n"))->bindParam(":year", $dt->format("Y"))->queryAll();
                         foreach ($schedulesToAdjust as $scheduleToAdjust) {
@@ -279,8 +278,8 @@ class DefaultController extends Controller
             $calendar = Calendar::model()->findByPk($_POST["id"]);
             if ($_POST["confirm"] === "false" && ($calendar->start_date != $_POST["startDate"] || $calendar->end_date != $_POST["endDate"])) {
                 $result = Yii::app()->db->createCommand("
-                    select count(s.id) as qtd from schedule s 
-                    join classroom cr on s.classroom_fk = cr.id 
+                    select count(s.id) as qtd from schedule s
+                    join classroom cr on s.classroom_fk = cr.id
                     join calendar c on cr.calendar_fk = c.id
                     where c.id = :id")->bindParam(":id", $calendar->id)->queryRow();
                 if ((int)$result["qtd"] > 0) {
@@ -310,10 +309,10 @@ class DefaultController extends Controller
 
 
                 Yii::app()->db->createCommand("
-                            delete from schedule s 
-                            join classroom cr on s.classroom_fk = cr.id 
+                            delete from schedule s
+                            join classroom cr on s.classroom_fk = cr.id
                             join calendar c on c.id = cr.calendar_fk
-                            where c.id = :id and 
+                            where c.id = :id and
                             (CONCAT(s.year, '-', LPAD(s.month, 2, '0'), '-', LPAD(s.day, 2, '0')) < :start_date or CONCAT(s.year, '-', LPAD(s.month, 2, '0'), '-', LPAD(s.day, 2, '0')) > :end_date)"
                 )->bindParam(":id", $calendar->id)->bindParam(":start_date", $calendar->start_date)->bindParam(":end_date", $calendar->end_date);
 
@@ -329,9 +328,9 @@ class DefaultController extends Controller
     public function actionShowStages()
     {
         $result = Yii::app()->db->createCommand("
-            select edcenso_stage_vs_modality.id, edcenso_stage_vs_modality.name 
-            from calendar_stages 
-            inner join edcenso_stage_vs_modality on calendar_stages.stage_fk = edcenso_stage_vs_modality.id 
+            select edcenso_stage_vs_modality.id, edcenso_stage_vs_modality.name
+            from calendar_stages
+            inner join edcenso_stage_vs_modality on calendar_stages.stage_fk = edcenso_stage_vs_modality.id
             where calendar_fk = :id order by edcenso_stage_vs_modality.name"
         )->bindParam(":id", $_POST["id"])->queryAll();
         foreach ($result as &$stage) {
@@ -436,9 +435,9 @@ class DefaultController extends Controller
         $result = [];
 
         $gradeUnityPeriods = Yii::app()->db->createCommand("
-            select gup.initial_date, gu.name 
-            from grade_unity_periods gup 
-            inner join grade_unity gu on gup.grade_unity_fk = gu.id 
+            select gup.initial_date, gu.name
+            from grade_unity_periods gup
+            inner join grade_unity gu on gup.grade_unity_fk = gu.id
             where gu.edcenso_stage_vs_modality_fk = :stageId and calendar_fk = :calendar_fk
             order by initial_date"
         )->bindParam(":stageId", $_POST["stageId"])->bindParam(":calendar_fk", $_POST["calendarId"])->queryAll();

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.89.197');
+define("TAG_VERSION", '3.89.198');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');

--- a/instance.php
+++ b/instance.php
@@ -17,7 +17,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'boquim22/10.tag.ong.br';
+    $newdb = 'boquim24/10.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;

--- a/instance.php
+++ b/instance.php
@@ -17,7 +17,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'demo.tag.ong.br';
+    $newdb = 'boquim22/10.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;

--- a/instance.php
+++ b/instance.php
@@ -17,7 +17,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'boquim24/10.tag.ong.br';
+    $newdb = 'demo.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;


### PR DESCRIPTION
## Motivação
Para evitar que as aulas ministradas sejam excluídas do banco de dados ao modificar o quadro de horário ou o calendário escolar, foi necessário retirar a relação de chave estrangeira do campo "schedule_fk" na tabela class_contents no banco de dados. Sendo assim, o valor permanece lá, mas a exclusão automática de aulas ministradas não acontece mais. Também foram adicionados campos referentes a data da aula ministrada na tabela de class_contents.

## Alterações Realizadas
- Retirando a chave estrangeira de schedule em class_contents
- Adicionando campos de data na tabela de class_contents

## Fluxo de Teste
```
- Rodar a migration
- Excluir as aulas em um dia do quadro de horário e verificar se esse dia desaparece das aulas ministradas
- Verificar no banco de dados se as aulas ministradas referentes ao dia excluído permanecem salvas
- Modificar o dia (que tenha uma aula) no calendário escolar, para um dia que não deveria ter aula (ex: feriado) e verificar se esse dia desaparece de aulas ministradas
- Verificar no banco de dados se as aulas ministradas referentes ao dia sem aula permanecem salvas
```

Obs: Para facilitar na verificação do banco de dados, podem utilizar esse sql
```
select cc.* from class_contents cc
where cc.classroom_fk = :classroom and cc.year = :year and cc.month = :month and cc.discipline_fk = :discipline
```

## Migrations Utilizadas
- 2024-10-23_remove_class_contents_schedule_fk

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
