### PR TITLE
Corrigindo error no tamanho do nome do aluno ao gerar o sagres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.89.203]
+- Corrigindo error no tamanho do nome do aluno ao gerar o sagres
+
 ## [Versão 3.89.202]
 - Modificando o tempo de sessão
 - Corrigindo errors relacionados a comparação de variáveis

--- a/app/modules/sagres/models/SagresConsultModel.php
+++ b/app/modules/sagres/models/SagresConsultModel.php
@@ -1778,7 +1778,7 @@ class SagresConsultModel
                         $inconsistencyModel->insert();
                     }
 
-                    if ($studentType->getNome() > $strMaxLength) {
+                    if (strlen($studentType->getNome()) > $strMaxLength) {
                         $inconsistencyModel = new ValidationSagresModel();
                         $inconsistencyModel->enrollment = '<strong>ESTUDANTE<strong>';
                         $inconsistencyModel->school = $school->name;

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@
 $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 
-define("TAG_VERSION", '3.89.202');
+define("TAG_VERSION", '3.89.203');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');


### PR DESCRIPTION
## Motivação
O município de japaratuba relatou um error ao gerar o sagres, aparecia nas inconsistências que o nome do aluno estava maior que 200 caracteres, porém, os nomes dos alunos estavam normais.

## Alterações Realizadas
- Corrigindo error no tamanho do nome do aluno ao gerar o sagres

## Fluxo de Teste
```
- Utilizar um dump de japaratuba
- Gerar o arquivo do sagres e virificar se nas inconsistências esse error no nome dos alunos aparece
```

## Migrations Utilizadas

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
