### PR TITLE
Corrigido o relatório de alunos por escola (Cpg, Rg e Nis), exibindo …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [Versão 3.91.209]
+- Corrigido o relatório de alunos por escola (Cpg, Rg e Nis), exibindo somente os alunos do ano em que o relatório foi emitido
+
+## [Versão 3.91.208]
+- Permitindo o acesso dos coordenadores pedagógicos as telas de frequência de professor e a tela de notas
+- Filtrando por escola os professores que podem ser selecionados na tela de frequência de professor
+
 ## [Versão 3.91.207]
 - Feito com que o aluno rematricule numa turma que havia sido transferida
 - Aumentado fonte da ficha de notas

--- a/app/repository/ReportsRepository.php
+++ b/app/repository/ReportsRepository.php
@@ -116,11 +116,12 @@ class ReportsRepository
                 jOIN student_identification si ON se.student_fk = si.id
                 JOIN student_documents_and_address sdaa ON si.id = sdaa.id
                 JOIN classroom c ON se.classroom_fk = c.id
-                WHERE c.school_inep_fk = :school_inep_id AND ((`se`.`status` IN (1, 6, 7, 8, 9, 10) or `se`.`status` is null))
+                WHERE c.school_inep_fk = :school_inep_id AND c.school_year = :school_year AND ((`se`.`status` IN (1, 6, 7, 8, 9, 10) or `se`.`status` is null))
                 GROUP BY si.name
                 ORDER BY si.name;";
         $result = Yii::app()->db->createCommand($sql)
             ->bindParam(":school_inep_id", $school->inep_id)
+            ->bindParam(":school_year", Yii::app()->user->year)
             ->queryAll();
 
         $allClassrooms = true;

--- a/config.php
+++ b/config.php
@@ -7,7 +7,7 @@ $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 defined("SESSION_MAX_LIFETIME") or define('SESSION_MAX_LIFETIME', 3600);
 
-define("TAG_VERSION", '3.91.207');
+define("TAG_VERSION", '3.91.209');
 
 
 define("YII_VERSION", Yii::getVersion());

--- a/instance.php
+++ b/instance.php
@@ -17,7 +17,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'boquim.tag.ong.br';
+    $newdb = 'demo.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;


### PR DESCRIPTION
## Motivação
Foi observado que o relatório de alunos por escola (Cpg, Rg e Nis) estava apresentado os alunos de todos os anos, porém, o relatório deve somente exibir os alunos do ano em que o relatório foi emitido. 

## Alterações Realizadas
- Corrigido o relatório de alunos por escola (Cpg, Rg e Nis), exibindo somente os alunos do ano em que o relatório foi emitido

## Fluxo de Teste
```
- Acessar a página de relatórios do tag
- Clicar no relatório Relatório de Alunos (CPF, RG e NIS) da escola
- Verificar se os alunos exibidos são de turmas do ano de emissão do relatório
```

Observação: De preferência, teste no banco de buzios na escola municipal vereador Emigdio Goncalves Coutinho

## Migrations Utilizadas

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
