### PR TITLE
[TCDA-538] Report year enrollment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [Versão 3.93.210]
+- Ordem das etapas ajustada no relatório de Matrículas Anuais
 
 ## [Versão 3.93.209]
 - Trocado "Série" por "Etapa" na Ficha de Matrícula

--- a/app/controllers/ReportsController.php
+++ b/app/controllers/ReportsController.php
@@ -404,7 +404,7 @@ class ReportsController extends Controller
     {
         // Construíndo condicionais e definindo ordenação para a consulta
         $criteria = new CDbCriteria;
-        $criteria->order = 'name ASC';
+        $criteria->order = 'edcenso_stage_vs_modality_fk, name ASC';
         $criteria->condition = "school_year = :year";
         $criteria->params = array("year" => Yii::app()->user->year);
         //Consulta todas as classes abertas no ano atual

--- a/config.php
+++ b/config.php
@@ -7,7 +7,7 @@ $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 defined("SESSION_MAX_LIFETIME") or define('SESSION_MAX_LIFETIME', 3600);
 
-define("TAG_VERSION", '3.93.209');
+define("TAG_VERSION", '3.93.210');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');


### PR DESCRIPTION
## Motivação
- Corrigir exibição da ordem das etapas no relatório de matrículas no ano.
## Alterações Realizadas
- Corrigido SQL que consulta as etapas, adicionando uma regra para a ordem.
## Fluxo de Teste
```
- Acessar a tela de relatórios.
- Acessar o relatório "Matrículas do ano"
- ?r=reports/EnrollmentStatisticsByYearReport
``` 
✅ Sucesso: As colunas das etapas estão seguindo uma ordem crescente por etapa.
❌ Falha: As colunas das etapas não estão seguindo uma ordem crescente
## Migrations Utilizadas
- Sem migrations.
## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
