### PR TITLE
Corrigido erro ao atualizar status dos alunos

### DIFF
--- a/app/domain/grades/usecases/CalculateFinalMediaUsecase.php
+++ b/app/domain/grades/usecases/CalculateFinalMediaUsecase.php
@@ -47,7 +47,7 @@ class CalculateFinalMediaUsecase
             }
 
             if ($this->shouldApplyFinalRecovery($this->gradeRule, $finalMedia)) {
-
+                $this->gradesResult["final_recovery_applied"] = 1;
                 $gradeUnity = GradeUnity::model()->findByAttributes(
                     ["edcenso_stage_vs_modality_fk" => $this->gradeRule->edcenso_stage_vs_modality_fk,
                     "type" =>  "RF"]);

--- a/app/domain/grades/usecases/ChageStudentStatusByGradeUsecase.php
+++ b/app/domain/grades/usecases/ChageStudentStatusByGradeUsecase.php
@@ -98,7 +98,7 @@ class ChageStudentStatusByGradeUsecase
         $recoverySituation = self::SITUATION_RECOVERY;
 
         $finalMedia = $this->gradeResult->final_media;
-        $approvationMedia = $this->gradeRule->approvation_media;
+        $approvationMedia = $this->gradeResult->final_recovery_applied == 1 ? $this->gradeRule->final_recover_media : $this->gradeRule->approvation_media;
         $frequency = $this->frequency;
 
         $this->gradeResult->situation = $disapprovedSituation;

--- a/app/migrations/2024-13-12_add_finalRecoveryApplied_column/2024-13-12_add_finalRecoveryApplied_column.sql
+++ b/app/migrations/2024-13-12_add_finalRecoveryApplied_column/2024-13-12_add_finalRecoveryApplied_column.sql
@@ -1,0 +1,2 @@
+alter table grade_results
+add column final_recovery_applied int (2);

--- a/instance.php
+++ b/instance.php
@@ -17,7 +17,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'demo.tag.ong.br';
+    $newdb = 'muribeca.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;


### PR DESCRIPTION
## Motivação
TCDA-806: No município de Poço Dantas a média de aprovação para a recuperação final (5) é diferente da média de aprovação comum (7). O sistema estava considerando apenas a média 7 por isso o status não estava sendo atualizado corretamente

## Alterações Realizadas
**Adicionado um campo** na tabela grade_results para armazenar se a média final foi calculada com a recuperação final ou não. desse modo é possível considerar as diferentes medias de aprovação quando necessárias

## Fluxo de Teste

**Com um dump de Poço Dantas**

testar se o aluno não atinge o 7, vai para final. E aí, é preciso da recuperação final, que tem que ser igual ou superior a 5. Ou seja, a nota da recuperação final + a média dos bimestres têm que da no mínimo 5 para aprovação do mesmo.

## Migrations Utilizadas

      2024-13-12_add_finalRecoveryApplied_column.sql

## Checklist de revisão
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
