### PR TITLE
first commit

### DIFF
--- a/app/domain/grades/usecases/CalculateFinalMediaUsecase.php
+++ b/app/domain/grades/usecases/CalculateFinalMediaUsecase.php
@@ -46,6 +46,7 @@ class CalculateFinalMediaUsecase
                 $finalMedia = $this->applyCalculation($this->gradeRule->gradeCalculationFk, $grades);
             }
 
+            $this->saveFinalMedia($this->gradesResult, $finalMedia);
             if ($this->shouldApplyFinalRecovery($this->gradeRule, $finalMedia)) {
 
                 $gradeUnity = GradeUnity::model()->findByAttributes(
@@ -77,16 +78,21 @@ class CalculateFinalMediaUsecase
                 }
 
                 $finalMedia = $this->applyFinalRecovery($this->gradesResult, $gradesFinalRecovery);
+                $this->saveFinalRecoveryMedia($this->gradesResult, $finalMedia);
             }
             TLog::info("Média final calculada", ["finalMedia" => $finalMedia]);
 
-            $this->saveFinalMedia($this->gradesResult, $finalMedia);
 
     }
 
     private function saveFinalMedia($gradesResult, $finalMedia)
     {
         $gradesResult->setAttribute("final_media", $finalMedia);
+        $gradesResult->save();
+    }
+    private function saveFinalRecoveryMedia($gradesResult, $finalMedia)
+    {
+        $gradesResult->setAttribute("rec_final", $finalMedia);
         $gradesResult->save();
     }
 

--- a/app/domain/grades/usecases/ChageStudentStatusByGradeUsecase.php
+++ b/app/domain/grades/usecases/ChageStudentStatusByGradeUsecase.php
@@ -114,7 +114,7 @@ class ChageStudentStatusByGradeUsecase
             $hasRecoveryGrade = isset($recoveryMedia) && $recoveryMedia !== "";
             if (!$hasRecoveryGrade) {
                 $this->gradeResult->situation = $recoverySituation;
-            } elseif ($recoveryMedia >= $finalRecoveryMedia && $finalRecovery->gradeCalculationFk->name == "Maior") {
+            } elseif ($recoveryMedia >= $finalRecoveryMedia) {
                 $this->gradeResult->situation = $approvedSituation;
             }
 

--- a/app/domain/grades/usecases/GetStudentGradesByDisciplineUsecase.php
+++ b/app/domain/grades/usecases/GetStudentGradesByDisciplineUsecase.php
@@ -86,7 +86,8 @@ class GetStudentGradesByDisciplineUsecase
                 $unityOrder,
                 $type,
                 $semester,
-                $showSemAvarageColumn
+                $showSemAvarageColumn,
+                $rules
             );
         }
         $partialRecoveryColumns = null;
@@ -203,7 +204,7 @@ class GetStudentGradesByDisciplineUsecase
      *
      * @return StudentGradesResult
      */
-    private function getStudentGradeByDicipline($studentEnrollment, $discipline, $unitiesByDiscipline, $unityOrder,$type, $semester, $showSemAvarageColumn)
+    private function getStudentGradeByDicipline($studentEnrollment, $discipline, $unitiesByDiscipline, $unityOrder,$type, $semester, $showSemAvarageColumn, $rules)
     {
         $studentGradeResult = new StudentGradesResult($studentEnrollment->studentFk->name, $studentEnrollment->id);
 
@@ -228,8 +229,10 @@ class GetStudentGradesByDisciplineUsecase
         } else {
             $semRecPartial = "";
         }
+
+        $finalMedia  = $gradeResult->final_media == null || $gradeResult->final_media >= $rules->approvation_media ? $gradeResult->final_media : $gradeResult->rec_final;
         $studentGradeResult->setSemAvarage($semRecPartial);
-        $studentGradeResult->setFinalMedia($gradeResult->final_media);
+        $studentGradeResult->setFinalMedia($finalMedia);
         $studentGradeResult->setSituation($gradeResult->situation);
 
 

--- a/instance.php
+++ b/instance.php
@@ -17,7 +17,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'demo.tag.ong.br';
+    $newdb = 'muribeca.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;

--- a/instance.php
+++ b/instance.php
@@ -17,7 +17,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'muribeca.tag.ong.br';
+    $newdb = 'demo.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;


### PR DESCRIPTION
## Motivação
TCDA-806: No município de Poço Dantas a média de aprovação para a recuperação final (5) é diferente da média de aprovação comum (7). O sistema estava considerando apenas a média 7 por isso o status não estava sendo atualizado corretamente

## Alterações Realizadas

Foi alterado o arquivo CalculateFinalMediaUsecase.php de modo que agora a recuperação final é salva no campo "rec_final" da tabela de grades resultse não mais no "final_media" assim o usecase ChageStudentStatusByGradeUsecase.php pode verificar corretamente se a média pós recuperação final é superior a média de aprovação

## Fluxo de Teste

### Teste 1

Com um dump de Poço Dantas

Testar se um aluno que não tenha atingido a média 7, ou seja uma aluno que vai para recuperação final, ao atingir a média 5 tem o status aprovado.

### Teste 2

testar se o cálculo do status está correto para diferentes tipos de cálculo de aprovação em estrutura de unidades e avaliações distintas ("média", "soma", "média semestral", "maior", "menor")

## Migrations Utilizadas

## Checklist de revisão
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
