### PR TITLE
Fix/individual record no filled final media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.95.214]
+- Correção no relatório "Ficha de Notas", disciplinas sem nota não afetam mais a situação final de matrícula.
+
 ## [Versão 3.95.213]
 - Adicionado usuário de leitura
 

--- a/config.php
+++ b/config.php
@@ -7,7 +7,7 @@ $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 defined("SESSION_MAX_LIFETIME") or define('SESSION_MAX_LIFETIME', 3600);
 
-define("TAG_VERSION", '3.95.213');
+define("TAG_VERSION", '3.95.214');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');

--- a/themes/default/views/forms/IndividualRecord.php
+++ b/themes/default/views/forms/IndividualRecord.php
@@ -395,7 +395,7 @@ $rTwoDisciplinesCount = $mathematicsCount + $sciencesCount;
                             ?>
                         </td>
                         <?php
-                        if($d['final_media'] < $gradeRules->approvation_media) {
+                        if($d['final_media'] < $gradeRules->approvation_media && $d['final_media'] !== null) {
                             $reprovado = true;
                         }
                         ?>


### PR DESCRIPTION
## Motivação
- Alunos com situação de matrícula "Aprovado" estavam sendo apresentados como "Reprovados" no relatório de ficha individual.
## Alterações Realizadas

## Fluxo de Teste
```
- Selecione uma turma e um aluno.
- Verifique em estrutura de notas qual a média de aprovação para a etapa da turma selecionada.
- Acesse a tela de notas, preencha as notas de uma disciplina, de modo que o aluno seja aprovado.
- Basta que preencha as notas de uma única disciplina, e então acesse de matrículas do aluno e gere o relatório "Ficha Individual"
- Verifique a situação de matrícula do aluno apresentado no relatório.
``` 
✅ Sucesso: Status APROVADO, quando os aluno tiver média final maior do que a média de aprovação em todas as disciplinas com notas preenchidas.
❌ Falha 1: Status APROVADO, quando o aluno tiver média final MENOR do que a média de aprovação em alguma das disciplinas.
❌ Falha 2: Status REPROVADO, quando os aluno tiver média final maior do que a média de aprovação em todas as disciplinas com notas preenchidas.
## Migrations Utilizadas

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
