### PR TITLE
feat/change_batch_update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## [Versão 3.95.213]
+- Adicionando o campo de situação de matrícula na tela de atualização em lote dos alunos de uma turma
+
 ## [Versão 3.94.213]
 - Corrigindo a exibição da média de nota em turmas por conceito na ata de notas
 
@@ -8,7 +11,7 @@
 
 ## [Versão 3.94.210]
 - Permitido que se adicione casa decimal na carga horária na matriz curricular. o Valor da hora-aula é definida nas configurações gerais do município.
-- 
+-
 ## [Versão 3.93.210]
 - Ordem das etapas ajustada no relatório de Matrículas Anuais
 

--- a/app/controllers/ClassroomController.php
+++ b/app/controllers/ClassroomController.php
@@ -417,7 +417,8 @@ class ClassroomController extends Controller
             foreach ($enrollments as $id => $fields) {
                 $enro = StudentEnrollment::model()->findByPk($id);
                 $enro->edcenso_stage_vs_modality_fk = $fields['edcenso_stage_vs_modality_fk'];
-                $enro->update(array('edcenso_stage_vs_modality_fk'));
+                $enro->status = $fields['status'];
+                $enro->update(array('edcenso_stage_vs_modality_fk', 'status'));
             }
         }
 

--- a/config.php
+++ b/config.php
@@ -7,7 +7,7 @@ $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 defined("SESSION_MAX_LIFETIME") or define('SESSION_MAX_LIFETIME', 3600);
 
-define("TAG_VERSION", '3.94.213');
+define("TAG_VERSION", '3.95.213');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');

--- a/themes/default/views/classroom/batchupdatetotal.php
+++ b/themes/default/views/classroom/batchupdatetotal.php
@@ -45,17 +45,19 @@ $form = $this->beginWidget('CActiveForm', array(
                             <table id="StudentsList" class="table table-bordered table-striped" style="display: table;">
                                 <sumary>Turma <?php echo $modelClassroom->name ?></sumary>
                                 <thead>
-                                    <tr><th>Nome</th><th>Etapa Individual</th></tr>
+                                    <tr><th>Nome</th><th>Etapa Individual</th><th>Situação da matrícula</th></tr>
                                 </thead>
                                 <tbody>
                                      <?php
                                      if(isset($enrollments)){
                                         foreach ($enrollments as $enr) {
                                             $namestg = $enr->id.'[edcenso_stage_vs_modality_fk]';
+                                            $status = $enr->id.'[status]';
                                             echo "<tr><td>".$enr->studentFk->name."</a></td>";
-                                            echo "<td>".CHtml::dropDownList($namestg, $enr->edcenso_stage_vs_modality_fk, $options_stage)."</td></tr>";
+                                            echo "<td>".CHtml::dropDownList($namestg, $enr->edcenso_stage_vs_modality_fk, $options_stage)."</td>";
+                                            echo "<td>".CHtml::dropDownList($status, $enr->status, StudentEnrollment::getListStatus())."</td></tr>";
                                         }
-                                        echo "<tr><th>Total:</th><td>" . count($enrollments) . "</td></tr>";
+                                        echo "<tr><th>Total:</th><td colspan='2'>" . count($enrollments) . "</td></tr>";
                                     } else {
                                         echo "<tr><th>Não há alunos matriculados.</th></tr>";
                                     }
@@ -63,7 +65,7 @@ $form = $this->beginWidget('CActiveForm', array(
                                 </tbody>
                                 <tfooter>
                                     <?php
-                                    echo '<tr><td><input value="Atualizar Todos" type="submit" class="btn btn-icon btn-primary"><i></i></input></td></tr>';
+                                    echo '<tr><td colspan="3"><input value="Atualizar Todos" type="submit" class="btn btn-icon btn-primary"><i></i></input></td></tr>';
                                     ?>
                                 </tfooter>
                             </table>


### PR DESCRIPTION
## Motivação
Com o virar do ano, muitos municípios estão tendo dificuldades em atualizar as informações dos alunos, pois ao fazer a rematrícula para 2025, é necessário modificar a situação de matrícula do aluno no ano anterior. Para facilitar esse processo foi adicionada uma nova coluna na tela de atualização em lote, permitindo que a atualização da situação da matrícula possa ser feita para diversos alunos de uma vez. 

## Alterações Realizadas
- Adicionando o campo de situação de matrícula na tela de atualização em lote dos alunos de uma turma

## Fluxo de Teste
```
- Acessar o TAG no ano de 2024
- Escolher uma turma
- Ir na tela de atualização em lote
- Modificar a situação de matrícula de mais de um aluno e salvar
- Verificar se a situação de matrícula foi realmente atualizada
```

## Migrations Utilizadas

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
