### PR TITLE
Fix/enrollment status auto update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## [Versão 3.94.214]
+- Correção na funcionalidade de atualizar situação de matrícula após calcular a nota final de aluno.
+
 ## [Versão 3.94.213]
 - Corrigindo a exibição da média de nota em turmas por conceito na ata de notas
 
@@ -8,7 +11,7 @@
 
 ## [Versão 3.94.210]
 - Permitido que se adicione casa decimal na carga horária na matriz curricular. o Valor da hora-aula é definida nas configurações gerais do município.
-- 
+-
 ## [Versão 3.93.210]
 - Ordem das etapas ajustada no relatório de Matrículas Anuais
 

--- a/app/domain/grades/usecases/ChageStudentStatusByGradeUsecase.php
+++ b/app/domain/grades/usecases/ChageStudentStatusByGradeUsecase.php
@@ -121,7 +121,7 @@ class ChageStudentStatusByGradeUsecase
         }
 
         if($this->gradeResult->save()){
-            $updateEnrollment = ChangeEnrollmentStatusUseCase($this->gradeResult->enrollment_fk);
+            $updateEnrollment = new ChangeEnrollmentStatusUsecase($this->gradeResult->enrollment_fk);
             $updateEnrollment->exec();
         }
         TLog::info("Status da matrícula", ["gradeResult" => $this->gradeResult->situation]);

--- a/app/domain/grades/usecases/ChageStudentStatusByGradeUsecase.php
+++ b/app/domain/grades/usecases/ChageStudentStatusByGradeUsecase.php
@@ -120,7 +120,10 @@ class ChageStudentStatusByGradeUsecase
 
         }
 
-        $this->gradeResult->save();
+        if($this->gradeResult->save()){
+            $updateEnrollment = ChangeEnrollmentStatusUseCase($this->gradeResult->enrollment_fk);
+            $updateEnrollment->exec();
+        }
         TLog::info("Status da matrícula", ["gradeResult" => $this->gradeResult->situation]);
     }
 

--- a/app/domain/grades/usecases/ChangeEnrollmentStatusUsecase.php
+++ b/app/domain/grades/usecases/ChangeEnrollmentStatusUsecase.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @property StudentEnrollment $enrollment
+ * @property integer $frequency
+ */
+
+class ChangeEnrollmentStatusUseCase
+{
+    private $enrollment;
+    private $frequency;
+
+    public function __construct($enrollmentId)
+    {
+        $this->enrollment = $this->getStudentEnrollment($enrollmentId);
+    }
+
+    public function exec()
+    {
+        $isAllGradesFilled = true;
+        $disciplines = $this->getDisciplines(
+            $enrollment->classroomFk->edcenso_stage_vs_modality_fk,
+            $enrollment->classroom_fk->school_year
+        );
+
+    }
+
+    public function getStudentEnrollment($enrollmentId)
+    {
+        return StudentEnrollment::model()->findByPk($enrollmentId);
+    }
+
+    public function getDisciplines($esvsm, $schoolYear){
+        $baseDisciplines = array();
+        $diversifiedDisciplines = array();
+
+        $curricularMatrixes = CurricularMatrix::model()
+        ->with("disciplineFk")
+        ->findAllByAttributes(
+            [
+                "stage_fk" => $esvsm,
+                "school_year" => $schoolYear
+            ]
+        );
+
+        return $curricularMatrixes;
+    }
+}
+
+?>

--- a/app/domain/grades/usecases/ChangeEnrollmentStatusUsecase.php
+++ b/app/domain/grades/usecases/ChangeEnrollmentStatusUsecase.php
@@ -4,7 +4,7 @@
  * @property StudentEnrollment $enrollment
  */
 
-class ChangeEnrollmentStatusUseCase
+class ChangeEnrollmentStatusUsecase
 {
     private $enrollment;
 
@@ -16,6 +16,10 @@ class ChangeEnrollmentStatusUseCase
     {
         $isAllGradesFinalMediaFilled = true;
         $isApprovedInAllGrades = true;
+        // STATUS VÁLIDOS PARA APROVAÇÃO OU REPROVAÇÃO:
+        // 1 - MATRICULADO, 13 - REINTEGRADO
+        $validStatus = [1,6,8,13];
+        $isRegistered = in_array($this->enrollment->status, $validStatus);
 
         $disciplines = $this->getDisciplines($this->enrollment->id);
 
@@ -24,26 +28,24 @@ class ChangeEnrollmentStatusUseCase
                 $isAllGradesFinalMediaFilled = false;
             }
 
-            if($discipline->situation == "REPROVADO")
-            $isApprovedInAllGrades = false;
+            if($discipline->situation == "REPROVADO"){
+                $isApprovedInAllGrades = false;
+            }
         }
 
-        if($isAllGradesFinalMediaFilled){
-            $this->enrollment->status = 1;
-        }
 
-        if($isApprovedInAllGrades){
-            $this->enrollment->status = 6;
-        }else{
-            $this->enrollment->status = 8;
+        if($isRegistered) {
+            if($isApprovedInAllGrades){
+                $this->enrollment->status = 6;
+            }else{
+                $this->enrollment->status = 8;
+            }
         }
 
         if($this->enrollment->save()){
             TLog::info(
                 "Status da matrícula",
-                [
-                    "enrollmentSituation" => $this->gradeResult->status
-                ]
+                ["enrollmentSituation" => $this->gradeResult->status]
                 );
             return;
         }

--- a/config.php
+++ b/config.php
@@ -7,7 +7,7 @@ $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 defined("SESSION_MAX_LIFETIME") or define('SESSION_MAX_LIFETIME', 3600);
 
-define("TAG_VERSION", '3.94.213');
+define("TAG_VERSION", '3.94.214');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');


### PR DESCRIPTION
## Motivação
- Usuários estavam relatando que ao o status de matrícula do aluno não estava sendo atualizando automaticamente após o preenchimento do diário das turmas.
## Alterações Realizadas
- Adicionada uma verificação adicional após atualizar a situação de matrícula dos alunos na turma.
## Fluxo de Teste
```
- Acessar a tela de notas, atribuir as notas de um aluno de tal modo que o resultado seja REPROVADO ou APROVADO.
- Certifique-se de testar pelo menos um caso em que o aluno está aprovado em todas as matérias com exceção de 
uma única matéria.
- Acessar a tela de edição da turma e verificar se o status de matrícula do aluno está de acordo com o resultado da tela de notas.
- Verifique relatórios relacionados a ficha de matrícula e situação de matrícula.
``` 
✅ Sucesso: A situação de matrícula está coerente em ambas as telas.
❌ Falha 1: A situação de matrícula não está coerente em ambas as telas.
❌ Falha 2: A situação de matrícula não está coerente em algum relatório com o resultado apresentado na tela de notas.
## Migrations Utilizadas

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
