### PR TITLE
Fix/print button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [Versão 3.94.214]
+- Corrigida a funcionalidade de imprimir aulas ministradas.
 
 ## [Versão 3.94.213]
 - Corrigindo a exibição da média de nota em turmas por conceito na ata de notas
@@ -8,7 +10,7 @@
 
 ## [Versão 3.94.210]
 - Permitido que se adicione casa decimal na carga horária na matriz curricular. o Valor da hora-aula é definida nas configurações gerais do município.
-- 
+-
 ## [Versão 3.93.210]
 - Ordem das etapas ajustada no relatório de Matrículas Anuais
 

--- a/config.php
+++ b/config.php
@@ -7,7 +7,7 @@ $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 defined("SESSION_MAX_LIFETIME") or define('SESSION_MAX_LIFETIME', 3600);
 
-define("TAG_VERSION", '3.94.213');
+define("TAG_VERSION", '3.94.214');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');

--- a/js/classes/class-contents/_initialization.js
+++ b/js/classes/class-contents/_initialization.js
@@ -25,7 +25,7 @@ function loadClassContents() {
                     createTable(data);
                 }
 
-                $("#print").addClass("show").removeClass("hide");
+                $("#print-button").addClass("show").removeClass("hide");
                 $("#save").addClass("show--desktop").removeClass("hide");
                 $("#save-button-mobile").addClass("show--tablet").removeClass("hide");
                 $('#error-badge').html('')
@@ -108,7 +108,7 @@ $("#month, #disciplines").on("change", function () {
         $("#classroomValue").text($("#classroom option:selected").text());
     } else {
         $("#widget-class-contents").hide();
-        $("#print, #save, #save-button-mobile").addClass("hide");
+        $("#print-button, #save, #save-button-mobile").addClass("hide");
     }
 });
 
@@ -116,7 +116,8 @@ $(document).ready(function () {
     $('#class-contents').hide();
 });
 
-$(document).on("click", "#print", function () {
+$(document).on("click", "#print-button", function (e) {
+    e.preventDefault();
     let  monthSplit = $("#month").val().split("-");
 
     let classroomId = $("#classroom").val();
@@ -126,7 +127,8 @@ $(document).on("click", "#print", function () {
 
     let url = `?r=reports/ClassContentsReport&classroomId=${classroomId}&month=${month}&year=${year}&disciplineId=${disciplineId}`;
 
-    window.open(url, "_blank")
+    window.open(url, "_blank");
+
 });
 
 $("#save, #save-button-mobile").on('click', function () {

--- a/themes/default/views/classes/classContents.php
+++ b/themes/default/views/classes/classContents.php
@@ -29,7 +29,7 @@ $school = SchoolIdentification::model()->findByPk(Yii::app()->user->school);
     </div>
     <div class="mobile-row justify-content--space-between">
         <div class="t-buttons-container auto-width">
-            <a id="print" class='t-button-secondary hide printButton'>
+            <a id="print-button" class='t-button-secondary hide printButton'>
                 <span class="t-icon-printer"></span>
                 <?php echo Yii::t('default', 'Print') ?>
             </a>


### PR DESCRIPTION
## Motivação
- Professores relataram que não conseguiam acessar o relatório de aulas ministradas através do botão imprimir presente na tela. Pop-up de impressão padrão estava sendo exibido, o que dificultava o acesso dos usuários ao relatório.

## Alterações Realizadas
- Identificador do botão de impressão foi alterado, visto que outro event-handler estava "assumindo" o controle do evento de "onclick" no botão.
## Fluxo de Teste
```
- Acesse a tela de aulas ministradas
- Após preencher os campos obrigatórios, clique no botão de impressão.
``` 
✅ Sucesso: Após clicar no botão, uma nova aba foi aberta com o relatório.
❌ Falha: Após clicar no botão, o pop-up de impressão padrão foi aberto, realizando o redirecionamento para a nova aba com o relatório somente após fechar o pop-up.

## Migrations Utilizadas
- Sem migrations utilizadas.
## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
