### PR TITLE
Fix/Adjust on timesheet view

### DIFF
--- a/themes/default/views/timesheet/timesheet/index.php
+++ b/themes/default/views/timesheet/timesheet/index.php
@@ -69,9 +69,9 @@ $this->setPageTitle('TAG - ' . Yii::t('timesheetModule.timesheet', 'Timesheet'))
                     </button>
                 </div>
             </div>
-            <div style="margin-bottom: 2px;">
-                <a href="<?php echo Yii::app()->createUrl('timesheet/timesheet/substituteInstructor')?>">
-                    <button class="t-button-primary">
+            <div class="schedule-info display-hide">
+                <a style="margin-bottom: 2px;" href="<?php echo Yii::app()->createUrl('timesheet/timesheet/substituteInstructor')?>">
+                    <button class="t-button-primary t-button-secondary">
                         <i></i><?= yii::t('timesheetModule.timesheet', "Assign Substitute Instructor") ?>
                     </button>
                 </a>


### PR DESCRIPTION
## Motivação
- Em razão de melhorar o entendimento da interface na view do módulo de timesheet (quadro de horário) algumas correções nos estilos e fluxo de tela foram realizadas.

## Alterações Realizadas
- Cor do botão que leva o usuário a funcionalidade de "Atribuir dias letivos de professor substituto" alterada.
- Botão mencionado acima, será apresentado somente após o usuário selecionar uma turma.
## Fluxo de Teste
### 🧪 Fluxo de Teste: Acessar funcionalidade de "Atribuir dias letivos para professor substituto".
```
- Acesse a tela de quadro de horário a partir do botão no menu lateral "Quadro de horário".
- Selecione uma turma.
- Verifique se os botões são exibidos.
``` 
✅ Sucesso: O botão "Atribuir Professor Substituto" é exibido somente após selecionar uma turma, e a cor do botão corresponde ao estilo de botão secundário(cinza).
❌ Falha: O botão é exibido antes de selecionar uma turma.
❌ Falha: O botão é exibido com o estilo de botão primário (azul)
## Migrations Utilizadas
- Sem migrations utilizadas
## Checklist de revisão
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
