### PR TITLE
[TCDA-906] Feat/experience_fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.99.223]
+- Disciplinas bases do edcenso adicionada a lista de atividades complementares no formulário de Cadastrar/Atualizar turmas.
+
 ## [Versão 3.99.222]
 - Adicionado para usuário professor, através da tela de diário de classe, cadastro de aulas no plano de aula.
 - Removendo validação de espaço em branco no começo e no fim do nome do aluno, o espaço é removido automaticamente ao salvar

--- a/app/migrations/2025-12-03_experience_fields/sql.sql
+++ b/app/migrations/2025-12-03_experience_fields/sql.sql
@@ -1,0 +1,7 @@
+INSERT INTO `edcenso_complementary_activity_type`(id, name)
+VALUES
+    (10007, 'Escuta, Fala, Pensamento e Imaginação'),
+    (10008, 'Espaço, Tempo, Quantidade, Relações e Transformações'),
+    (10009, 'Corpo, Gesto e Movimento'),
+    (10010, 'Traços, Sons, Cores e Formas'),
+    (10011, 'O Eu, O Outro e o Nós');

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@ $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 defined("SESSION_MAX_LIFETIME") or define('SESSION_MAX_LIFETIME', 3600);
 
-define("TAG_VERSION", '3.99.222');
+define("TAG_VERSION", '3.99.223');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');


### PR DESCRIPTION
## Motivação
- Usuários do TAG entraram em contato solicitando a adição de algumas opções extras relacionadas à turmas de educação infantil no formulário de turmas. Este PR inclui a adição dos campos solicitados no campo de "Atividade Complementares" do formulário.

![image](https://github.com/user-attachments/assets/4943cfeb-e412-43c8-bc90-b63479e6d4d6)


## Alterações Realizadas
- No formulário de "Cadastar/Atualizar" turma foram adicionadas novas opções ao campo de atividades complementares.

## Fluxo de Teste
```
- Rode a migration mencionada na sessão de "Migrations Utilizadas".
- Acesse a tela de turmas através do menu lateral.
- Acesse uma das turmas listadas na tabela. Caso não tenha turmas criadas, pode acessar a funcionalidade
através do botão "Adicionar Turmas".
- Na primeira aba, navegue até a sessão inferior da tela e busque pela sessão "Atendimento".
- Identifique o checkbox com a opção "Atividade Complementar ".
- Clique no checkbox e verifique se um novo campo multiselect é apresentado.
- Dentre as opções apresentadas verifique se as seguintes opções estão disponíveis:
``` 
![image](https://github.com/user-attachments/assets/355035f8-dc0f-413f-a40f-f9824d9f99c8)

✅ Sucesso: as opções apresentadas nesse PR estão condizentes com as opções visualizadas durante a realização do teste.
❌ Falha: as opções não estão condizentes.

## Migrations Utilizadas
```
app\migrations\2025-12-03_experience_fields\sql.sql
``` 

## Checklist de revisão
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
