### PR TITLE
fix/class_contents_year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.99.223]
+- Adicionando o filtro de ano na listagem de aulas possíveis para adicionar em aulas ministradas
+
 ## [Versão 3.99.222]
 - Adicionado para usuário professor, através da tela de diário de classe, cadastro de aulas no plano de aula.
 - Removendo validação de espaço em branco no começo e no fim do nome do aluno, o espaço é removido automaticamente ao salvar

--- a/app/controllers/ClassesController.php
+++ b/app/controllers/ClassesController.php
@@ -168,12 +168,14 @@ class ClassesController extends Controller
                         join course_plan cp on cp.id = cc.course_plan_fk
                         join edcenso_discipline ed on cp.discipline_fk = ed.id
                         where cp.school_inep_fk = :school_inep_fk and cp.modality_fk = :modality_fk and cp.discipline_fk = :discipline_fk and cp.users_fk = :users_fk
+                        and YEAR(cp.start_date) = :year
                         order by ed.name, cp.name"
                     )
                         ->bindParam(":school_inep_fk", Yii::app()->user->school)
                         ->bindParam(":modality_fk", $schedules[0]->classroomFk->edcenso_stage_vs_modality_fk)
                         ->bindParam(":discipline_fk", $disciplineId)
                         ->bindParam(":users_fk", Yii::app()->user->loginInfos->id)
+                        ->bindParam(":year", $year)
                         ->queryAll();
                 } else {
                     $courseClasses = Yii::app()->db->createCommand(
@@ -181,11 +183,13 @@ class ClassesController extends Controller
                         join course_plan cp on cp.id = cc.course_plan_fk
                         join edcenso_discipline ed on cp.discipline_fk = ed.id
                         where cp.school_inep_fk = :school_inep_fk and cp.modality_fk = :modality_fk and cp.users_fk = :users_fk
+                        and YEAR(cp.start_date) = :year
                         order by ed.name, cp.name"
                     )
                         ->bindParam(":school_inep_fk", Yii::app()->user->school)
                         ->bindParam(":modality_fk", $schedules[0]->classroomFk->edcenso_stage_vs_modality_fk)
                         ->bindParam(":users_fk", Yii::app()->user->loginInfos->id)
+                        ->bindParam(":year", $year)
                         ->queryAll();
 
                     $additionalClasses = Yii::app()->db->createCommand(
@@ -193,11 +197,13 @@ class ClassesController extends Controller
                         from course_class cc
                         join course_plan cp on cp.id = cc.course_plan_fk
                         where cp.school_inep_fk = :school_inep_fk and cp.modality_fk = :modality_fk and cp.users_fk = :users_fk and cp.discipline_fk IS NULL
+                        and YEAR(cp.start_date) = :year
                         order by cp.name"
                     )
                         ->bindParam(":school_inep_fk", Yii::app()->user->school)
                         ->bindParam(":modality_fk", $schedules[0]->classroomFk->edcenso_stage_vs_modality_fk)
                         ->bindParam(":users_fk", Yii::app()->user->loginInfos->id)
+                        ->bindParam(":year", $year)
                         ->queryAll();
 
 
@@ -210,11 +216,13 @@ class ClassesController extends Controller
                         join course_plan cp on cp.id = cc.course_plan_fk
                         join edcenso_discipline ed on cp.discipline_fk = ed.id
                         where cp.school_inep_fk = :school_inep_fk and cp.modality_fk = :modality_fk and cp.discipline_fk = :discipline_fk
+                        and YEAR(cp.start_date) = :year
                         order by ed.name, cp.name"
                     )
                         ->bindParam(":school_inep_fk", Yii::app()->user->school)
                         ->bindParam(":modality_fk", $schedules[0]->classroomFk->edcenso_stage_vs_modality_fk)
                         ->bindParam(":discipline_fk", $disciplineId)
+                        ->bindParam(":year", $year)
                         ->queryAll();
                 } else {
                     $courseClasses = Yii::app()->db->createCommand(
@@ -222,10 +230,12 @@ class ClassesController extends Controller
                         join course_plan cp on cp.id = cc.course_plan_fk
                         join edcenso_discipline ed on cp.discipline_fk = ed.id
                         where cp.school_inep_fk = :school_inep_fk and cp.modality_fk = :modality_fk
+                        and YEAR(cp.start_date) = :year
                         order by ed.name, cp.name"
                     )
                         ->bindParam(":school_inep_fk", Yii::app()->user->school)
                         ->bindParam(":modality_fk", $schedules[0]->classroomFk->edcenso_stage_vs_modality_fk)
+                        ->bindParam(":year", $year)
                         ->queryAll();
 
                     $additionalClasses = Yii::app()->db->createCommand(
@@ -233,10 +243,12 @@ class ClassesController extends Controller
                         from course_class cc
                         join course_plan cp on cp.id = cc.course_plan_fk
                         where cp.school_inep_fk = :school_inep_fk and cp.modality_fk = :modality_fk and cp.discipline_fk IS NULL
+                        and YEAR(cp.start_date) = :year
                         order by cp.name"
                     )
                         ->bindParam(":school_inep_fk", Yii::app()->user->school)
                         ->bindParam(":modality_fk", $schedules[0]->classroomFk->edcenso_stage_vs_modality_fk)
+                        ->bindParam(":year", $year)
                         ->queryAll();
 
                     $courseClasses = array_merge($courseClasses, $additionalClasses);

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@ $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 defined("SESSION_MAX_LIFETIME") or define('SESSION_MAX_LIFETIME', 3600);
 
-define("TAG_VERSION", '3.99.222');
+define("TAG_VERSION", '3.99.223');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');


### PR DESCRIPTION
## Motivação
Com a troca do ano foi observado que a funcionalidade de listar as aulas dos planos de aulas para que sejam adicionadas em aulas ministradas não estavam sendo filtradas por ano, então ao adicionar aulas ministradas os professores estavam confusos porque estavam aparecendo aulas de planos de aula de 2024 e não somente os de 2025. Por conta disso, foi adicionado o filtro de ano nessa funcionalidade.

## Alterações Realizadas
- Adicionando o filtro de ano na listagem de aulas possíveis para adicionar em aulas ministradas

Antes da alteração
![image](https://github.com/user-attachments/assets/30348367-2f52-4c5f-a50e-201619d451c8)

Após a alteração
![image](https://github.com/user-attachments/assets/ecdd972f-ca77-4367-bb10-2ee9f540983d)

## Fluxo de Teste
###  🧪 Teste 1 - Admin
```
- Acessar a tela de aulas ministradas
- Verificar se as aulas disponíveis para selecionar são somente de planos de aula criados em 2025
- Salvar e verificar se as aulas ministradas persistem
```

###  🧪 Teste 2 - Professor
```
- Acessar a tela de aulas ministradas
- Verificar se as aulas disponíveis para selecionar são somente de planos de aula criados em 2025 e criados pelo professor logado
- Salvar e verificar se as aulas ministradas persistem
```

## Migrations Utilizadas

## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
