### PR TITLE
fix/classdiary-getAbilities

### DIFF
--- a/app/modules/classdiary/controllers/DefaultController.php
+++ b/app/modules/classdiary/controllers/DefaultController.php
@@ -29,7 +29,7 @@ class DefaultController extends Controller
         $getCoursePlans = new GetCoursePlans();
         $coursePlans = $getCoursePlans->exec($discipline_fk,$stage_fk);
 
-        $getAbilities = new getAbilities();
+        $getAbilities = new GetAbilities();
         $abilities = $getAbilities->exec($discipline_fk, $stage_fk);
 
 		$this->render('classDiary', [


### PR DESCRIPTION
## Motivação

Alguns professores de Nossa Senhora da Glória relataram que não estão conseguindo acessar a tela do Diário de Classe no módulo classDiary
![image](https://github.com/user-attachments/assets/0cec9e08-87fa-4e3a-8d80-9a4a23132a67)


## Alterações Realizadas

Alterado o nome da classe no defaultController para ficar em conformidade com o nome da classe, assim como as outras classes usadas nesse controller.
![image](https://github.com/user-attachments/assets/b1fd427c-0f7c-4fee-9b26-dfb53a53a092)

## Fluxo de Teste

- Acessar o módulo Diário de Classe com o login de professor.

## Migrations Utilizadas

## Checklist de revisão
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
