### PR TITLE
[TCDA-921, TCDA-928 & TCDA-932] Fix/student frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## [Versão 3.100.225]
+- Correção na funcionalidade de salvar data de matrícula: agora deve ser considerado
+o valor do campo "Data de Matrícula" para fins de frequência em turmas
 
-## [Versão 3.99.224]
+## [Versão 3.100.224]
 - Adicionando o filtro de ano na listagem de aulas possíveis para adicionar em aulas ministradas
 
 ## [Versão 3.100.223]

--- a/app/controllers/EnrollmentController.php
+++ b/app/controllers/EnrollmentController.php
@@ -206,6 +206,8 @@ class EnrollmentController extends Controller implements AuthenticateSEDTokenInt
     {
         $model = $this->loadModel($id);
 
+        $model->school_admission_date = DateTime::createFromFormat("Y-m-d", $model->school_admission_date)->format('d/m/Y');
+
         $class = Classroom::model()->findByPk($model->classroom_fk);
         $oldClass = $class->gov_id === null ? $class->inep_id : $class->gov_id;
 

--- a/app/controllers/EnrollmentController.php
+++ b/app/controllers/EnrollmentController.php
@@ -206,7 +206,13 @@ class EnrollmentController extends Controller implements AuthenticateSEDTokenInt
     {
         $model = $this->loadModel($id);
 
-        $model->school_admission_date = DateTime::createFromFormat("Y-m-d", $model->school_admission_date)->format('d/m/Y');
+        $rawDate = $model->school_admission_date ?? '';
+
+        $date = (!empty($rawDate) && $rawDate !== '0000-00-00')
+            ? DateTime::createFromFormat("Y-m-d", $rawDate) ?: new DateTime()
+            : new DateTime();
+
+        $model->school_admission_date = $date->format('d/m/Y');
 
         $class = Classroom::model()->findByPk($model->classroom_fk);
         $oldClass = $class->gov_id === null ? $class->inep_id : $class->gov_id;
@@ -239,6 +245,9 @@ class EnrollmentController extends Controller implements AuthenticateSEDTokenInt
         if (isset($_POST['StudentEnrollment'])) {
             if ($model->validate()) {
                 $model->attributes = $_POST['StudentEnrollment'];
+                $model->school_admission_date = DateTime::createFromFormat("d/m/Y", $model->school_admission_date);
+                $model->school_admission_date = $model->school_admission_date->format('Y-m-d');
+                $model->enrollment_date = $model->school_admission_date;
                 $model->school_inep_id_fk = Classroom::model()->findByPk([$_POST['StudentEnrollment']["classroom_fk"]])->school_inep_fk;
                 if ($model->validate()) {
 
@@ -254,6 +263,8 @@ class EnrollmentController extends Controller implements AuthenticateSEDTokenInt
                     }
 
                     if ($model->save()) {
+                        $model->school_admission_date = DateTime::createFromFormat("Y-m-d", $model->school_admission_date);
+                        $model->school_admission_date = $model->school_admission_date->format('d/m/Y');
                         $message = "";
                         if (Yii::app()->features->isEnable("FEAT_SEDSP")) {
                             $this->authenticateSedToken();

--- a/app/controllers/StudentController.php
+++ b/app/controllers/StudentController.php
@@ -564,6 +564,8 @@ class StudentController extends Controller implements AuthenticateSEDTokenInterf
                         ) {
                             $modelEnrollment = new StudentEnrollment;
                             $modelEnrollment->attributes = $_POST[$this->STUDENT_ENROLLMENT];
+                            $modelEnrollment->school_admission_date = DateTime::createFromFormat("d/m/Y", $modelEnrollment->school_admission_date);
+                            $modelEnrollment->school_admission_date = $modelEnrollment->school_admission_date->format('Y-m-d');
                             $modelEnrollment->school_inep_id_fk = $modelStudentIdentification->school_inep_id_fk;
                             $modelEnrollment->student_fk = $modelStudentIdentification->id;
                             $modelEnrollment->student_inep_id = $modelStudentIdentification->inep_id;

--- a/app/controllers/StudentController.php
+++ b/app/controllers/StudentController.php
@@ -721,6 +721,7 @@ class StudentController extends Controller implements AuthenticateSEDTokenInterf
             $modelEnrollment->create_date = date('Y-m-d');
             $modelEnrollment->daily_order = $modelEnrollment->getDailyOrder();
             $modelEnrollment->enrollment_date = $currentEnrollment->transfer_date;
+            $modelEnrollment->school_admission_date = $currentEnrollment->transfer_date;
             $modelEnrollment->current_enrollment = 1;
 
             if ($modelEnrollment->validate()) {

--- a/app/controllers/StudentController.php
+++ b/app/controllers/StudentController.php
@@ -564,7 +564,11 @@ class StudentController extends Controller implements AuthenticateSEDTokenInterf
                         ) {
                             $modelEnrollment = new StudentEnrollment;
                             $modelEnrollment->attributes = $_POST[$this->STUDENT_ENROLLMENT];
-                            $modelEnrollment->school_admission_date = DateTime::createFromFormat("d/m/Y", $modelEnrollment->school_admission_date);
+                            if ($modelEnrollment->school_admission_date !== "") {
+                                $modelEnrollment->school_admission_date = DateTime::createFromFormat("d/m/Y", $modelEnrollment->school_admission_date);
+                            }else {
+                                $modelEnrollment->school_admission_date = new DateTime();
+                            }
                             $modelEnrollment->school_admission_date = $modelEnrollment->school_admission_date->format('Y-m-d');
                             $modelEnrollment->school_inep_id_fk = $modelStudentIdentification->school_inep_id_fk;
                             $modelEnrollment->student_fk = $modelStudentIdentification->id;

--- a/app/controllers/StudentController.php
+++ b/app/controllers/StudentController.php
@@ -569,7 +569,7 @@ class StudentController extends Controller implements AuthenticateSEDTokenInterf
                             $modelEnrollment->student_inep_id = $modelStudentIdentification->inep_id;
                             $modelEnrollment->create_date = date('Y-m-d');
                             if ($modelEnrollment->status == 1) {
-                                $modelEnrollment->enrollment_date = date('Y-m-d');
+                                $modelEnrollment->enrollment_date = $modelEnrollment->school_admission_date;
                             }
                             $modelEnrollment->daily_order = $modelEnrollment->getDailyOrder();
                             $saved = false;

--- a/app/messages/pt_br/default.php
+++ b/app/messages/pt_br/default.php
@@ -581,7 +581,7 @@ return array(
     'Student Entry Form' => 'Forma de ingresso (apenas para escolas federais)',
     'Current stage situation' => 'Situação na série/etapa atual',
     'Previous stage situation' => 'Situação no ano anterior',
-    'School admission date' => 'Data de ingresso na escola',
+    'School admission date' => 'Data de matrícula',
     'Admission type' => 'Tipo de ingresso',
     'Status' => 'Situação da matrícula',
     'The student is already enrolled this year' => 'O aluno já está matrículado no corrente ano',

--- a/app/migrations/2025-19-03_merge_column_student_enrollment/sql.sql
+++ b/app/migrations/2025-19-03_merge_column_student_enrollment/sql.sql
@@ -1,0 +1,3 @@
+SELECT school_admission_date, enrollment_date
+FROM student_enrollment
+WHERE school_admission_date IS NOT NULL;

--- a/app/migrations/2025-19-03_merge_column_student_enrollment/sql.sql
+++ b/app/migrations/2025-19-03_merge_column_student_enrollment/sql.sql
@@ -1,9 +1,10 @@
-UPDATE student_enrollment SET
-enrollment_date = school_admission_date
-WHERE school_admission_date IS NOT NULL;
 
 UPDATE student_enrollment
 SET school_admission_date = STR_TO_DATE(school_admission_date, '%d/%m/%Y')
 WHERE school_admission_date IS NOT NULL;
 
 ALTER TABLE student_enrollment MODIFY COLUMN school_admission_date DATE NULL;
+
+UPDATE student_enrollment SET
+enrollment_date = school_admission_date
+WHERE school_admission_date IS NOT NULL;

--- a/app/migrations/2025-19-03_merge_column_student_enrollment/sql.sql
+++ b/app/migrations/2025-19-03_merge_column_student_enrollment/sql.sql
@@ -1,3 +1,9 @@
-SELECT school_admission_date, enrollment_date
-FROM student_enrollment
+UPDATE student_enrollment SET
+enrollment_date = school_admission_date
 WHERE school_admission_date IS NOT NULL;
+
+UPDATE student_enrollment
+SET school_admission_date = STR_TO_DATE(school_admission_date, '%d/%m/%Y')
+WHERE school_admission_date IS NOT NULL;
+
+ALTER TABLE student_enrollment MODIFY COLUMN school_admission_date DATE NULL;

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@ $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 defined("SESSION_MAX_LIFETIME") or define('SESSION_MAX_LIFETIME', 3600);
 
-define("TAG_VERSION", '3.101.224');
+define("TAG_VERSION", '3.100.225');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');

--- a/themes/default/views/enrollment/_form.php
+++ b/themes/default/views/enrollment/_form.php
@@ -228,9 +228,11 @@ $form = $this->beginWidget('CActiveForm', array(
                         </div>
                         <div class="column">
                             <div class="t-field-text">
-                                    <?php echo $form->labelEx($model, 'school_admission_date', array('class' => 't-field-text__label')); ?>
-                                    <?php echo $form->textField($model, 'school_admission_date', array('size' => 10, 'maxlength' => 10, 'class'=>'t-field-text__input')); ?>
-                                    <?php echo $form->error($model, 'school_admission_date'); ?>
+                                <?php echo $form->label($model, 'school_admission_date', array('class' => 't-field-text__label--required')); ?>
+                                <?php
+                                    $this->widget('zii.widgets.jui.CJuiDatePicker', DatePickerWidget::renderDatePicker($model, 'school_admission_date'));
+                                    echo $form->error($model, 'school_admission_date');
+                                ?>
                             </div>
 
                             <!--  Data de transferência externa na escola -->

--- a/themes/default/views/student/_form.php
+++ b/themes/default/views/student/_form.php
@@ -1844,7 +1844,7 @@ $form = $this->beginWidget(
           <div class="row new-enrollment-form" style="display: none;">
             <!--  Data de ingresso na escola -->
             <div class="column clearleft is-two-fifths">
-              <div class="t-field-text js-hide-not-required" id="ticketDate">
+            <div class="t-field-text js-hide-not-required" id="ticketDate">
                 <?php echo $form->label($modelEnrollment, 'school_admission_date', array('class' => 't-field-text__label')); ?>
                 <?php echo $form->textField($modelEnrollment, 'school_admission_date', array('size' => 10, 'maxlength' => 10, 'class' => 't-field-text__input')); ?>
                 <?php echo $form->error($modelEnrollment, 'school_admission_date'); ?>


### PR DESCRIPTION
## Motivação
- Usuários entraram em contato informando que não estavam conseguindo atribuir a frequência de alunos adequadamente, visto que dias que deviam estar disponíveis para marcação de frequência estavam indisponíveis. Foi identificado que o erro se dava por conta do uso incorreto de um campo disponível no formulário de matrícula "Data de Ingresso na escola", que no entendimento dos usuários seria a data na qual os alunos começaram a frequentar as aulas da turma. A solução proposta para esse problema se dá em mapear a data inserida para o campo de "school_admission_date" para "enrollment_date" esse segundo que é utilizado para verificação de disponibilidade de frequência.

Chamados do Jira associados:
- https://tagbr.atlassian.net/jira/servicedesk/projects/TCDA/queues/custom/44/TCDA-921
- https://tagbr.atlassian.net/jira/servicedesk/projects/TCDA/queues/custom/44/TCDA-932
- https://tagbr.atlassian.net/jira/servicedesk/projects/TCDA/queues/custom/44/TCDA-928

Exemplificação do erro que estava acontecendo:
![image](https://github.com/user-attachments/assets/d127a981-084a-45cd-9021-1f5849092067)
![image](https://github.com/user-attachments/assets/0e47ad2c-65bc-4fda-933c-24fc32c6e087)
![image](https://github.com/user-attachments/assets/7fab6cd9-6827-4ee3-ac21-49d7cc018992)

As imagens apresentadas foram retiradas no ambiente de cristalia.tag.ong.br, na tela de matrículas de aluno.
Escola: LAR DA ESPERANÇA (CEMEI)
Aluno: MARIA JULIA PEREIRA ELOI
Turma: 03 ANOS MATUTINO FERNANDA 2025

## Alterações Realizadas
- Mapeamento da coluna "school_admission_date" para "enrollment_date", bem como alteração do tipo do valor em "school_admission_date".
- Funcionalidades de transferir matrícula e atualizar matrícula agora atualizam o campo "enrollment_date" de acordo com o valor do campo "school_admission_date".

## Fluxo de Teste
```
- Sugiro que inicialmente faça um dump do município exemplo apresentado acima, pois ficará mais fácil de encontrar
um cenário onde o problema acontece.
- Alterado o dump, verifique as informações salvas atualmente nas telas de matrícula e frequência e sugiro que 
deixe salvo para comparação posteriormente.
- SOMENTE APÓS ISSO RODE AS MIGRATIONS, senão é possível que não identifique as mudanças.
- Após rodar as migrations, acesse novamente a tela de matrícula de aluno e de frequência.
- A "Data de Matrícula" apresentada no acordeon de matrícula deve ser igual a data do campo "Data de Matrícula"
presente no formulário de matrícula.
- Verifique principalmente a data de matrícula apresentada no label ao lado do nome da turma e os dias disponíveis 
para marcar frequência.
``` 
Label ao lado do nome da turma:
![image](https://github.com/user-attachments/assets/cc865496-c2a5-4836-b9c8-a6a6750aee1a)

✅ Sucesso: A data de matrícula no label está de acordo com a data marcada no campo "Data de Matrícula" no formulário,
bem como os dias disponíveis para marcar frequência estão de acordo com a data de matrícula.
❌ Falha 1: A data de matrícula no label é diferente da data de matrícula marcada no formulário.
❌ Falha 2: Os dias de frequência disponíveis não estão de acordo com a data de matrícula do formulário.
## Migrations Utilizadas
```
app\migrations\2025-19-03_merge_column_student_enrollment\sql.sql
``` 
## Checklist de revisão
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
