### PR TITLE
fix/ change https for http

### DIFF
--- a/app/modules/sagres/soap/src/sagresEdu/EducacaoTType.php
+++ b/app/modules/sagres/soap/src/sagresEdu/EducacaoTType.php
@@ -12,8 +12,8 @@ use JMS\Serializer\Annotation as Serializer;
  * XSD Type: educacao_t
  */
 
- #[Serializer\XmlRoot(name: "edu:educacao")]
- #[Serializer\XmlNamespace(uri: "https://www.tce.se.gov.br/sagres2025/xml/sagresEdu", prefix: "edu")]
+#[Serializer\XmlRoot(name: "edu:educacao")]
+#[Serializer\XmlNamespace(uri: "http://www.tce.se.gov.br/sagres2025/xml/sagresEdu", prefix: "edu")]
 class EducacaoTType
 {
     #[Serializer\SerializedName("edu:PrestacaoContas")]
@@ -91,7 +91,7 @@ class EducacaoTType
      * @return self
      * @param \SagresEdu\ProfissionalTType $profissional
      */
-    public function addToProfissional(ProfissionalTType $profissional):self
+    public function addToProfissional(ProfissionalTType $profissional): self
     {
         $this->profissional[] = $profissional;
         return $this;
@@ -103,7 +103,7 @@ class EducacaoTType
      * @param int|string $index
      * @return bool
      */
-    public function issetProfissional($index):bool
+    public function issetProfissional($index): bool
     {
         return isset($this->profissional[$index]);
     }
@@ -114,7 +114,7 @@ class EducacaoTType
      * @param int|string $index
      * @return void
      */
-    public function unsetProfissional($index):void
+    public function unsetProfissional($index): void
     {
         unset($this->profissional[$index]);
     }
@@ -135,10 +135,9 @@ class EducacaoTType
      * @param \SagresEdu\ProfissionalTType[] $profissional
      * @return self
      */
-    public function setProfissional(array $profissional = null):self
+    public function setProfissional(array $profissional = null): self
     {
         $this->profissional = $profissional;
         return $this;
     }
 }
-


### PR DESCRIPTION
## Motivação
- Erro reportado por Graccho Cardoso: não é possível submeter o documento sem movimentação, pois o schema está apontando para `https://www.tce.se.gov.br/sagres2025/xml/sagresEdu` ao invés de `http://www.tce.se.gov.br/sagres2025/xml/sagresEdu`.

## Alterações Realizadas
- Corrigido o valor da string no arquivo `app/modules/sagres/soap/src/sagresEdu/EducacaoTType.php`.

## Fluxo de Teste
1. No menu lateral vá na parte de Integrações e selecione **SAGRES**
![Captura de tela de 2025-03-24 14-28-48](https://github.com/user-attachments/assets/2ab531bf-f071-4817-98d6-add45b73afd9)
2. Selecione um mês e a opção "Sem movimentação";
![Captura de tela de 2025-03-24 14-32-27](https://github.com/user-attachments/assets/d160b23d-2be8-407e-a4a2-93e7daf67ad7)
![Captura de tela de 2025-03-24 14-33-14](https://github.com/user-attachments/assets/f394df42-ca22-4fcb-8c04-77183433696f)
3. Gere o documento ao clicar em **"Exportar Unidade"** e baixe o zip gerado.
![Captura de tela de 2025-03-24 14-34-19](https://github.com/user-attachments/assets/29e88b83-5d68-43e1-8d8d-c4c09d062739)
![Captura de tela de 2025-03-24 14-36-14](https://github.com/user-attachments/assets/46e72d15-eee0-44c9-91f3-8b7c541899cd)
4. Em um editor de texto compare a saida do documento se contem a estrutura abaixo:
```xml
<?xml version="1.0" encoding="ISO-8859-1" ?>
<edu:educacao xmlns:edu="http://www.tce.se.gov.br/sagres2025/xml/sagresEdu">
    <edu:PrestacaoContas>
        <edu:codigoUnidGestora>PREENCHER AQUI COD UG</edu:codigoUnidGestora>
        <edu:nomeUnidGestora>PREENCHER AQUI NOME UG</edu:nomeUnidGestora>
        <edu:cpfResponsavel>CPF RESPONSAVEL ENVIO</edu:cpfResponsavel>
        <edu:cpfGestor>CPF GESTOR</edu:cpfGestor>
        <edu:anoReferencia>2025</edu:anoReferencia>
        <edu:mesReferencia>1</edu:mesReferencia>
        <edu:versaoXml>0</edu:versaoXml>
        <edu:diaInicPresContas>1</edu:diaInicPresContas>
        <edu:diaFinaPresContas>31</edu:diaFinaPresContas>
    </edu:PrestacaoContas>
</edu:educacao>
```
## Migrations Utilizadas
- Nenhuma migração foi necessária.
## Aviso
- Alteração reprova no sonarcloud, mas deve ser aprovada apesar disto.
## Checklist de revisão
- [ ] O número da versão foi alterado no arquivo config.php?
- [ ] Foi adicionada uma descrição das alterações no arquivo de CHANGELOG?
- [ ] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
