### PR TITLE
Fix/delete classroom with grade rules

### DIFF
--- a/app/controllers/ClassroomController.php
+++ b/app/controllers/ClassroomController.php
@@ -982,6 +982,7 @@ class ClassroomController extends Controller
         if ($ableToDelete) {
             try {
                 $enrollments = StudentEnrollment::model()->findAllByAttributes(array("classroom_fk" => $classroom->id));
+                $graderules =  ClassroomVsGradeRules::model()->findAllByAttributes(array("classroom_fk"=>$classroom->id));
 
                 if (count($enrollments) > 0) {
                     throw new Exception("Não foi possível excluir a turma porque existem alunos matriculados.");
@@ -989,6 +990,10 @@ class ClassroomController extends Controller
 
                 if (count($teachingDatas) > 0) {
                     throw new Exception("Não se pode remover turma com professores vinculados.");
+                }
+
+                if(count( $graderules)  > 0){
+                    throw new Exception("Não se pode remover turma com estruturas vinculadas.");
                 }
 
                 foreach ($teachingDatas as $teachingData) {

--- a/app/modules/classdiary/controllers/DefaultController.php
+++ b/app/modules/classdiary/controllers/DefaultController.php
@@ -29,7 +29,7 @@ class DefaultController extends Controller
         $getCoursePlans = new GetCoursePlans();
         $coursePlans = $getCoursePlans->exec($discipline_fk,$stage_fk);
 
-        $getAbilities = new getAbilities();
+        $getAbilities = new GetAbilities();
         $abilities = $getAbilities->exec($discipline_fk, $stage_fk);
 
 		$this->render('classDiary', [

--- a/instance.php
+++ b/instance.php
@@ -17,7 +17,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'santaluzia1303.tag.ong.br';
+    $newdb = 'demo.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;

--- a/js/classroom/form/_initialization.js
+++ b/js/classroom/form/_initialization.js
@@ -53,6 +53,9 @@ $(function () {
             });
 
             // Adicionar opções disponíveis (não selecionadas)
+            $("#gradeRules").append(
+                `<option value="">Selecione a Regra de Avaliação</option>`
+            );
             data.available.forEach(option => {
                 $("#gradeRules").append(
                     `<option value="${option.id}">${option.name}</option>`


### PR DESCRIPTION
## 🚀 Motivação

Após a alteração para associar estruturas as turmas, não estava sendo possível excluir turma

## 🔧 Alterações Realizadas
Alterado o controller de Turma para enviar uma mensagem ao front-end indicando que não é possível excluir turmas que possuam estruturas vinculadas.

## 📌 Requisitos
estar logado no tag com perfil de admin

## 🛠️ Fluxo de Teste

1. Criar uma Turma

    Criar uma turma sem alunos ou professores.

    Certificar-se de que a turma possui uma estrutura vinculada na aba de "Configurações Pedagógicas".

2. Tentar Excluir a Turma

    Acessar a funcionalidade para excluir a turma criada.

    Resultado esperado: A exclusão da turma não deve ser permitida, e o sistema deve exibir uma mensagem indicando que a turma possui estruturas vinculadas.

3. Atualizar a Turma e Remover a Estrutura Vinculada

    Acessar a aba "Configurações Pedagógicas" da turma.

    Remover a estrutura vinculada do campo de estruturas.

4. Tentar Excluir a Turma Novamente

    Acessar novamente a funcionalidade para excluir a turma.

    Resultado esperado: A turma deve ser excluída com sucesso.

## ✨ Migrations Utilizadas

sem migrations.

## ✔️ Checklist - Padrões para PR
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?

### Documentação 
Houve alteração nos fluxo de uso? 
*(Lembrete: Em caso afirmativo, adicionar label Atualização de manual)*
- [ ] Sim   
- [x] Não
