### PR TITLE
fix/adjust filter on add substitute instructor view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.101.229]
+- Correção no filtro de professores na tela de "Atribuir Professor Substituto" para exibir somente professores substitutos na lista.
+
 ## [Versão 3.101.228]
 - Regra de negócio aplicada a funcionalidade de "Excluir Professor" ajustada.
 

--- a/app/modules/timesheet/controllers/TimesheetController.php
+++ b/app/modules/timesheet/controllers/TimesheetController.php
@@ -986,7 +986,11 @@ class TimesheetController extends Controller
     public function actionGetInstructors() {
         $classroom = Classroom::model()->findByPk(Yii::app()->request->getPost("classroom"));
 
-        $teachingData = InstructorTeachingData::model()->findAllByAttributes(array("classroom_id_fk" => $classroom->id));
+        $teachingData = InstructorTeachingData::model()->findAllByAttributes(
+            array(
+                "classroom_id_fk" => $classroom->id,
+                "role" => 9
+            ));
 
         $htmlOptions = CHtml::tag('option', array('value' => ""), CHtml::encode('Selecione o professor'), true);
 

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@ $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 defined("SESSION_MAX_LIFETIME") or define('SESSION_MAX_LIFETIME', 3600);
 
-define("TAG_VERSION", '3.101.227');
+define("TAG_VERSION", '3.101.229');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');


### PR DESCRIPTION
## 🚀 Motivação
Alteração no filtro de professores para registrar dias em que o professor substituto deve ministrar aulas. Foi incluído no filtro uma verificação no tipo de registro do professor na turma.

## 🔧 Alterações Realizadas
No método que faz a busca nos professores da turma, foi adicionado um filtro sobre o tipo de teaching_data registrado na turma.

## 📌 Requisitos
- Branch atualizada.
- Dump atualizado (qualquer município)
- Duas sessões diferentes.
- Selecionar uma turma que tenha quadro de horário já definido.

## 🛠️ Fluxo de Teste
🧪 Fluxo de Teste 1 (FT1): Atribuir dia de aula para professor substituto
```
COM USUÁRIO DE ADMIN
1. Acesse a tela de turmas, através do menu lateral. Selecione uma turma e acesse o formulário de atualização.
2. Navegue até a aba de professores "Professores".
3. Clique em "Adicionar Professor/Componentes curriculares", preencha o formulário e selecione
a opção "Docente Substituto" para o campo "Cargo". Clique em "Criar". Então, clique em "Salvar".
4. É importante que tenha acesso ao sistema com o usuário do professor adicionado à turma.
4.1. Para isso, acesse a tela de administração -> Gerenciar Usuários -> Busque pelo nome -> Atualize o usuário
5. Acesse a tela de "Quadro de horário", selecione a turma, clique em "Atribuir Professor Substituto".
6. Selecione a turma, verifique se APENAS os professores substitutos aparecem na lista.
7. Preencha o resto do formulário, marque algum dos dias listados.

COM USUÁRIO DE PROFESSOR
1. Acesse a tela de frequência, em Diário Eletrônico -> Frequência
2. Selecione a turma e preencha o formulário de acordo com os dias marcados com o usuário de admin.
3. Verifique se os dias disponíveis estão de acordo com as marcações realizadas na tela de atribuir dias de frequência.
```
✅ Sucesso 1: Os dias disponíveis para marcar frequência com o usuário do professor substituto está de acordo com
as marcações feitas na tela de atribuir professor substituto.
❌ Falha 1: Professores NÃO substitutos estão sendo listados na tela de atribuir professor substituto.
❌ Falha 2: Os dias disponíveis não estão de acordo com as marcações feitas na tela de atribuir professor substituto. 

## ✨ Migrations Utilizadas
- Sem migrations

## ✔️ Checklist - Padrões para PR
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?

### Documentação 
Houve alteração nos fluxo de uso? 
- [ ] Sim   
- [x] Não
