### PR TITLE
Fix/save instructor frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.1.1]
+- Ajuste na estrutura de dados relacionados com as faltas de um professor em uma turma. Impacto na funcionalidade de "Frequência do professor", que agora deve funcionar adequadamente.
+
 ## [Versão 3.1.0]
 - Alteração no registro de data de matrícula. O campo "Data de Matrícula" do formulário de matrícula agora está diretamente relacionado
 com o valor apresentado em diferentes sessões do sistema.

--- a/app/controllers/InstructorController.php
+++ b/app/controllers/InstructorController.php
@@ -683,7 +683,7 @@ preenchidos";
                     $array["instructorName"] = $enrollment->instructorFk->name;
                     $array["schedules"] = [];
                     foreach ($schedules as $schedule) {
-                        $instructorFault = InstructorFaults::model()->find("schedule_fk = :schedule_fk and instructor_fk = :instructor_fk", ["schedule_fk" => $schedule->id, "instructor_fk" => $enrollment->id]);
+                        $instructorFault = InstructorFaults::model()->find("schedule_fk = :schedule_fk and instructor_fk = :instructor_fk", ["schedule_fk" => $schedule->id, "instructor_fk" => $enrollment->instructor_fk]);
                         $available = date("Y-m-d") >= Yii::app()->user->year . "-" . str_pad($schedule->month, 2, "0", STR_PAD_LEFT) . "-" . str_pad($schedule->day, 2, "0", STR_PAD_LEFT);
                         array_push($array["schedules"], [
                             "available" => $available,
@@ -746,15 +746,9 @@ preenchidos";
     public function actionSaveFrequency()
     {
         if ($_POST["instructorId"] != null) {
-            $instructorId = Yii::app()->request->getPost("instructorId");
-            $classroomId = Yii::app()->request->getPost("classroomId");
-            $teachingData = InstructorTeachingData::model()->findByAttributes(array(
-                "classroom_id_fk" => $classroomId,
-                "instructor_fk" => $instructorId
-            ));
             if ($_POST["fault"] == "1") {
                 $instructorFault = new InstructorFaults();
-                $instructorFault->instructor_fk = $teachingData->id;
+                $instructorFault->instructor_fk = $_POST["instructorId"];
                 $instructorFault->schedule_fk = $_POST["schedule"];
                 $instructorFault->save();
             } else {

--- a/app/controllers/InstructorController.php
+++ b/app/controllers/InstructorController.php
@@ -683,7 +683,7 @@ preenchidos";
                     $array["instructorName"] = $enrollment->instructorFk->name;
                     $array["schedules"] = [];
                     foreach ($schedules as $schedule) {
-                        $instructorFault = InstructorFaults::model()->find("schedule_fk = :schedule_fk and instructor_fk = :instructor_fk", ["schedule_fk" => $schedule->id, "instructor_fk" => $enrollment->instructor_fk]);
+                        $instructorFault = InstructorFaults::model()->find("schedule_fk = :schedule_fk and instructor_fk = :instructor_fk", ["schedule_fk" => $schedule->id, "instructor_fk" => $enrollment->id]);
                         $available = date("Y-m-d") >= Yii::app()->user->year . "-" . str_pad($schedule->month, 2, "0", STR_PAD_LEFT) . "-" . str_pad($schedule->day, 2, "0", STR_PAD_LEFT);
                         array_push($array["schedules"], [
                             "available" => $available,
@@ -746,9 +746,15 @@ preenchidos";
     public function actionSaveFrequency()
     {
         if ($_POST["instructorId"] != null) {
+            $instructorId = Yii::app()->request->getPost("instructorId");
+            $classroomId = Yii::app()->request->getPost("classroomId");
+            $teachingData = InstructorTeachingData::model()->findByAttributes(array(
+                "classroom_id_fk" => $classroomId,
+                "instructor_fk" => $instructorId
+            ));
             if ($_POST["fault"] == "1") {
                 $instructorFault = new InstructorFaults();
-                $instructorFault->instructor_fk = $_POST["instructorId"];
+                $instructorFault->instructor_fk = $teachingData->id;
                 $instructorFault->schedule_fk = $_POST["schedule"];
                 $instructorFault->save();
             } else {

--- a/app/migrations/2025-17-04_instructor_faults/sql.sql
+++ b/app/migrations/2025-17-04_instructor_faults/sql.sql
@@ -1,0 +1,2 @@
+ALTER TABLE instructor_faults
+DROP FOREIGN KEY (instructor_faults_FK_1);

--- a/app/migrations/2025-17-04_instructor_faults/sql.sql
+++ b/app/migrations/2025-17-04_instructor_faults/sql.sql
@@ -1,2 +1,2 @@
 ALTER TABLE instructor_faults
-DROP FOREIGN KEY (instructor_faults_FK_1);
+DROP FOREIGN KEY instructor_faults_FK_1;

--- a/js/instructor/frequency.js
+++ b/js/instructor/frequency.js
@@ -24,7 +24,7 @@ $("#classesSearch").on("click", function () {
                     html += "" +
                         "<table class='t-accordion table-frequency table table-bordered table-striped table-hover'>" +
                         "<thead class='t-accordion__head'>" +
-                        "<tr><th class='table-title' colspan='" + (Object.keys(data.instructors[0].schedules).length + 1) + "'>" + ($('#disciplines').select2('data').text) + "aaaaaaa</th></tr>";
+                        "<tr><th class='table-title' colspan='" + (Object.keys(data.instructors[0].schedules).length + 1) + "'>" + ($('#disciplines').select2('data').text) + "</th></tr>";
                     var daynameRow = "";
                     var dayRow = "";
                     var scheduleRow = "";


### PR DESCRIPTION
## 🚀 Motivação
Funcionalidade de salvar professor não estava funcionando adequadamente. Foi identificado que o erro estava ocorrendo em função de um erro de constraint FK no banco de dados, que estava fazendo referência para uma tabela que não tinha a chave que estava sendo passada como parâmetro, este PR propõe um ajuste na estrutura da tabela, removendo a constraint `instructor_faults_FK_1` da tabela `instructor_faults` para a tabela de `instructor_teaching_data`.

## 🔧 Alterações Realizadas
- Migration para remover contraint FK de `instructor_faults` para `instructor_teaching_data`.

## 📌 Requisitos
- Branch atualizada.
- Dump atualizado de um dos municípios.
- Cadastro de professor atribuído a uma turma.
- Turma com quadro de horário.

## 🛠️ Fluxo de Teste

🧪 Fluxo de Teste 1 (FT1): Atribuir frequência para professor
```
1. Acessar a tela de "Professores" com um usuário de administrador.
2. Preencher o formulário com os dados do professor e da turma a qual este foi atribuído, clicar em "Pesquisar".
3. Clicar em um dos checkboxes apresentados na tela.
4. Atualize a página e verifique se o salvamento da frequência persiste após recarregar a página.
```
✅ Sucesso: A frequência persiste após a atualização.
❌ Falha: A frequência não persiste após a atualização.

## ✨ Migrations Utilizadas
```
app\migrations\2025-17-04_instructor_faults\sql.sql
``` 

## ✔️ Checklist - Padrões para PR
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?

### Documentação 
Houve alteração nos fluxo de uso? 
- [ ] Sim   
- [x] Não
