### PR TITLE
Fix/sagres food

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.1.1]
+- Ajuste no preenchimento do nome do prato da merenda no XML exportado, capturando dinamicamente o nome do componente correspondente ao dia no cardápio.
+
 ## [Versão 3.1.0]
 - Alteração no registro de data de matrícula. O campo "Data de Matrícula" do formulário de matrícula agora está diretamente relacionado
 com o valor apresentado em diferentes sessões do sistema.

--- a/app/modules/sagres/models/SagresConsultModel.php
+++ b/app/modules/sagres/models/SagresConsultModel.php
@@ -652,7 +652,7 @@ class SagresConsultModel
             $classType = new TurmaTType();
             $classId = $turma['classroomId'];
 
-            if (\TagUtils::isStageEJA( $turma["stage"]) && $turma["period"] == 0) {
+            if (\TagUtils::isStageEJA($turma["stage"]) && $turma["period"] == 0) {
                 $inconsistencyModel = new ValidationSagresModel();
                 $inconsistencyModel->enrollment = TURMA_STRONG;
 
@@ -1423,14 +1423,16 @@ class SagresConsultModel
         if ($isFoodEnabled->value) {
 
             $query = "SELECT
-                        fm.start_date as data,
-                        fm.description AS descricaoMerenda,
-                        fm.adjusted AS ajustado,
-                        fmm.turn AS turno,
-                        fmm.food_menuId
-                    FROM food_menu fm
-                        JOIN food_menu_meal fmm on fmm.food_menuId = fm.id
-                    WHERE YEAR(fm.start_date) = :year and month(fm.start_date) <= :month";
+	                    fm.start_date as data,
+	                    fmmc.description  AS descricaoMerenda,
+	                    fm.adjusted AS ajustado,
+	                    fmm.turn AS turno,
+	                    fmm.food_menuId
+                    FROM food_menu fm JOIN food_menu_meal fmm on fmm.food_menuId = fm.id
+                    JOIN food_menu_meal_component fmmc on fmmc.food_menu_mealId = fmm.id
+                    WHERE
+	                    YEAR(fm.start_date) = :year
+	                    and month(fm.start_date) <= :month;";
             $params = [
                 ':year' => $year,
                 ':month' => $month

--- a/app/modules/sagres/models/SagresConsultModel.php
+++ b/app/modules/sagres/models/SagresConsultModel.php
@@ -19,6 +19,8 @@ use GoetasWebservices\Xsd\XsdToPhpRuntime\Jms\Handler\BaseTypesHandler;
 use GoetasWebservices\Xsd\XsdToPhpRuntime\Jms\Handler\XmlSchemaDateHandler;
 use TagUtils;
 use ValidationSagresModel;
+use Classroom;
+use PeriodOptions;
 
 use Yii;
 use ZipArchive;
@@ -650,7 +652,7 @@ class SagresConsultModel
             $classType = new TurmaTType();
             $classId = $turma['classroomId'];
 
-            if (\TagUtils::isStageEJA(stage: $turma["stage"]) && $turma["period"] == \PeriodOptions::ANUALY->value) {
+            if (\TagUtils::isStageEJA( $turma["stage"]) && $turma["period"] == 0) {
                 $inconsistencyModel = new ValidationSagresModel();
                 $inconsistencyModel->enrollment = TURMA_STRONG;
 

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@ $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 defined("SESSION_MAX_LIFETIME") or define('SESSION_MAX_LIFETIME', 3600);
 
-define("TAG_VERSION", '3.1.0');
+define("TAG_VERSION", '3.1.1');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');
@@ -20,4 +20,4 @@ if (YII_DEBUG) {
 date_default_timezone_set('America/Sao_Paulo');
 ini_set('always_populate_raw_post_data', '-1');
 setlocale(LC_ALL, 'portuguese', 'pt_BR.UTF-8', 'pt_BR.UTF8', 'pt_br.UTF8', 'ptb_BRA.UTF8', "ptb", 'ptb.UTF8');
-ini_set('session.gc_maxlifetime',  SESSION_MAX_LIFETIME);
+ini_set('session.gc_maxlifetime', SESSION_MAX_LIFETIME);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     volumes:
       - .:/app
       # - ./docker/php/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini
-      - /app/docker/mysql
+      - /app/docker/mysql # commment this line if yout run project in linux ubuntu 24.0.1
       - /app/vendor
       - /app/app/vendor
       - /app/assets
@@ -55,7 +55,8 @@ services:
       MYSQL_USER: admin
       MYSQL_PASSWORD: admin
     volumes:
-      - ./docker/mysql/dbfiles:/var/lib/mysql
+      #- db-volume:/var/lib/mysql # add this line if your run the project in ubunutu 24.0.1
+       - ./docker/mysql/dbfiles:/var/lib/mysql
       # - .\dump.sql:/docker-entrypoint-initdb.d/dump.sql
       # - ./dump-data.sql:/docker-entrypoint-initdb.d/dump-data.sql
     networks:

--- a/instance.php
+++ b/instance.php
@@ -17,7 +17,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'santaluzia.tag.ong.br';
+    $newdb = 'demo.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;
@@ -29,7 +29,7 @@ $HOST = getenv("HOST_DB_TAG");
 $USER = getenv("USER_DB_TAG");
 $PWD = getenv("PWD_DB_TAG");
 
-define ("DBCONFIG", serialize (array(
+define("DBCONFIG", serialize(array(
     'connectionString' => "mysql:host=$HOST;dbname=$newdb",
     'emulatePrepare' => true,
     'enableProfiling' => YII_DEBUG,


### PR DESCRIPTION
## 🚀 Motivação
O objetivo da mudança foi ajustar o nome do prato da merenda escolar, garantindo que o nome capturado no XML corresponda exatamente ao componente definido para cada dia. 
Antes da correção, o sistema gerava o nome do prato erroa ao montar o cardápio diário, pois não atualizava corretamente o nome do prato. A solução implementada consiste em capturar dinamicamente o nome do componente do cardápio e substituir a informação no XML, assegurando que os dados apresentados estejam alinhados com a programação alimentar de cada dia.

## 🔧 Alterações Realizadas
Alterada query de busca no banco de dados  referente ao prato do dia.

## 📌 Requisitos
Nenhum

## 🛠️ Fluxo de Teste

🧪 Fluxo de Teste 1 (FT1):
```
1. Acesse o menu lateral e clique em **Interações**.
2. Selecione a opção **Sagres**.
3. Escolha o **ano** correto.
4. Selecione um **mês** desejado.
5. **Desmarque** a opção **"Excluir alunos sem CPF"**.
6. Clique em **Exportar Unidade**.
7. Aguarde a geração do documento.
8. Baixe o arquivo **ZIP** gerado.
9. **Descompacte** o arquivo ZIP.
10. Procure pelos arquivos relacionados à **"merenda"**.
11. Verifique se nos campos de descrição da merenda aparecem os nomes corretos dos pratos.

```
✅ Sucesso: Os campos de descrição da merenda exibem corretamente os nomes dos pratos.  
❌ Falha: Os campos de descrição da merenda não exibem corretamente os nomes dos pratos.

## ✨ Migrations Utilizadas
Nenhuma
## ✔️ Checklist - Padrões para PR
- [x] O número da versão foi alterado no arquivo ``` config.php ```?
- [x] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [x] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?

### Documentação 
Houve alteração nos fluxo de uso? 
*(Lembrete: Em caso afirmativo, adicionar label Atualização de manual)*
- [ ] Sim   
- [x] Não
