### PR TITLE
fix/trim-name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.2.2]
+- Adicionado tratamento automático para remoção de espaços em branco no início e fim do valor do campo nome nos formulários de professor e aluno
+
 ## [Versão 3.2.1]
 - Atividades complementares autalizadas para o Educacenso 2025
 

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@ $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 defined("SESSION_MAX_LIFETIME") or define('SESSION_MAX_LIFETIME', 3600);
 
-define("TAG_VERSION", '3.2.1');
+define("TAG_VERSION", '3.2.2');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');

--- a/js/instructor/form/functions.js
+++ b/js/instructor/form/functions.js
@@ -122,3 +122,8 @@ function renderClasroomsCards(){
  }
 
  renderClasroomsCards();
+
+$('.js-trim-name').on('focusout', function () {
+    let name = $(this).val();
+    $(this).val(name.trim());
+});

--- a/js/student/form/functions.js
+++ b/js/student/form/functions.js
@@ -33,5 +33,9 @@ $(document).on("click", ".js-remove-enrollment", function () {
         }
     });
 });
+$('.js-trim-name').on('focusout', function () {
+    let name = $(this).val();
+    $(this).val(name.trim());
+});
 
 

--- a/themes/default/views/instructor/_form.php
+++ b/themes/default/views/instructor/_form.php
@@ -130,6 +130,7 @@ $isModel = isset($modelInstructorIdentification->id);
                                         array(
                                             'size' => 60,
                                             'maxlength' => 100,
+                                            'class'=>'js-trim-name',
                                             'placeholder' => 'Digite o Nome de Apresentação'
                                         )
                                     );
@@ -163,6 +164,7 @@ $isModel = isset($modelInstructorIdentification->id);
                                         array(
                                             'size' => 60,
                                             'maxlength' => 100,
+                                            'class'=>'js-trim-name',
                                             'placeholder' => 'Digite o Nome Civil'
                                         )
                                     );

--- a/themes/default/views/student/_form.php
+++ b/themes/default/views/student/_form.php
@@ -167,7 +167,7 @@ $form = $this->beginWidget(
                   array(
                     'size' => 60,
                     'maxlength' => 100,
-                    'class' => 't-field-text__input',
+                    'class' => 't-field-text__input js-trim-name',
                     'placeholder' => 'Digite o Nome de Apresentação'
                   )
                 ); ?>
@@ -196,7 +196,7 @@ $form = $this->beginWidget(
                   array(
                     'size' => 60,
                     'maxlength' => 100,
-                    'class' => 't-field-text__input',
+                    'class' => 't-field-text__input js-trim-name',
                     'placeholder' => 'Digite o Nome Civil'
                   )
                 ); ?>


### PR DESCRIPTION
## 🚀 Motivação
Remover espaços em branco antes e no fim do valor do campo nome  nos formulários de professor e de aluno para corrigir incosistência no censo

## 🔧 Alterações Realizadas
Adicionado tratamento automático para remoção de espaços em branco no início e fim do valor do campo nome nos formulários de professor e aluno

## 📌 Requisitos
Nenhum 

## 🛠️ Fluxo de Teste

🧪 Fluxo de Teste 1 (FT1):
```
1. No menu lateral do TAG escolher a opção alunos
2. Selecionar um aluno
3. Tentar adicionar um espaço em branco no fim o no inicio do nome do aluno
4. verificar se o espaço em branco persiste após salvar
5. repetir o processo para o professor
```
✅ Sucesso:  Espaço em branco persiste
❌ Falha:  Espaço em branco não persiste

## ✨ Migrations Utilizadas

## ✔️ Checklist - Padrões para PR
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?

### Documentação 
Houve alteração nos fluxo de uso? 
*(Lembrete: Em caso afirmativo, adicionar label Atualização de manual)*
- [ ] Sim   
- [ ] Não
