### PR TITLE
Fix/export censo without certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.2.2]
+- Permitir exportação do censo com ou sem certidões de nascimento
+
 ## [Versão 3.2.1]
 - Atividades complementares autalizadas para o Educacenso 2025
 

--- a/app/controllers/CensoController.php
+++ b/app/controllers/CensoController.php
@@ -171,8 +171,7 @@ class CensoController extends Controller
         if ($schoolIdentificationColumn['address_complement'] !== "" && $schoolIdentificationColumn["address_complement"] !== null) {
             $result = $siv->isAddressValid($schoolIdentificationColumn['address_complement'], 20, true);
             if (!$result["status"])
-                array_push($log, array("address_complement" => $result["erro"]));
-            ;
+                array_push($log, array("address_complement" => $result["erro"]));;
         }
 
         //campo 17
@@ -430,9 +429,9 @@ class CensoController extends Controller
             array_push($log, array("building_occupation_situation" => $result["erro"]));
 
         //campo 13
-//        $result = $ssv->sharedBuildingSchool($collumn["operation_location_building"],
-//            $collumn["shared_building_with_school"]);
-//        if (!$result["status"]) array_push($log, array("shared_building_with_school" => $result["erro"]));
+        //        $result = $ssv->sharedBuildingSchool($collumn["operation_location_building"],
+        //            $collumn["shared_building_with_school"]);
+        //        if (!$result["status"]) array_push($log, array("shared_building_with_school" => $result["erro"]));
 
         //campos 14 à 19
         $shared_school_inep_ids = array(
@@ -448,8 +447,8 @@ class CensoController extends Controller
             array_push($log, array("Escolas com qual e compartilhada" => $result["erro"]));
 
         //campo 20
-//        $result = $ssv->oneOfTheValues($collumn["consumed_water_type"]);
-//        if (!$result["status"]) array_push($log, array("consumed_water_type" => $result["erro"]));
+        //        $result = $ssv->oneOfTheValues($collumn["consumed_water_type"]);
+        //        if (!$result["status"]) array_push($log, array("consumed_water_type" => $result["erro"]));
 
         //campos 21 à 25
         $water_supplys = array(
@@ -573,8 +572,8 @@ class CensoController extends Controller
             array_push($log, array("classroom_count" => $result["erro"]));
 
         //        //campo 70
-//        $result = $ssv->usedClassroomCount($collumn["used_classroom_count"]);
-//        if (!$result["status"]) array_push($log, array("used_classroom_count" => $result["erro"]));
+        //        $result = $ssv->usedClassroomCount($collumn["used_classroom_count"]);
+        //        if (!$result["status"]) array_push($log, array("used_classroom_count" => $result["erro"]));
 
         //campo 86
         $internetAccess = array(
@@ -632,8 +631,8 @@ class CensoController extends Controller
             array_push($log, array("bandwidth" => $result["erro"]));
 
         //campo 88
-//        $result = $ssv->isGreaterThan($collumn["employees_count"], "0");
-//        if (!$result["status"]) array_push($log, array("employees_count" => $result["erro"]));
+        //        $result = $ssv->isGreaterThan($collumn["employees_count"], "0");
+        //        if (!$result["status"]) array_push($log, array("employees_count" => $result["erro"]));
 
         $school_inep_fk = $school['inep_id'];
         //campo 89
@@ -662,18 +661,18 @@ class CensoController extends Controller
             array_push($log, array("basic_education_cycle_organized" => $result["erro"]));
 
         //campo 97
-//        $result = $ssv->differentiatedLocation($school["inep_id"],
-//            $collumn["different_location"]);
-//        if (!$result["status"]) array_push($log, array("different_location" => $result["erro"]));
+        //        $result = $ssv->differentiatedLocation($school["inep_id"],
+        //            $collumn["different_location"]);
+        //        if (!$result["status"]) array_push($log, array("different_location" => $result["erro"]));
 
         //        //101
-//        $result = $ssv->isAllowed($collumn["native_education"], array("0", "1"));
-//        if (!$result["status"]) array_push($log, array("native_education" => $result["erro"]));
-//
-//        //104
-//        $result = $ssv->edcensoNativeLanguages($collumn["native_education_language_native"],
-//            $collumn["edcenso_native_languages_fk"]);
-//        if (!$result["status"]) array_push($log, array("edcenso_native_languages_fk" => $result["erro"]));
+        //        $result = $ssv->isAllowed($collumn["native_education"], array("0", "1"));
+        //        if (!$result["status"]) array_push($log, array("native_education" => $result["erro"]));
+        //
+        //        //104
+        //        $result = $ssv->edcensoNativeLanguages($collumn["native_education_language_native"],
+        //            $collumn["edcenso_native_languages_fk"]);
+        //        if (!$result["status"]) array_push($log, array("edcenso_native_languages_fk" => $result["erro"]));
 
         //107
         $sql = "SELECT 	COUNT(esm.id ) AS number_of
@@ -758,8 +757,8 @@ class CensoController extends Controller
         //acima: imprimir "classroom_days" no erro ou um erro pra cada um dos campos?
 
         //campo 18
-//        $result = $crv->isValidAssistanceType($schoolstructure, $column['assistance_type'], $column['pedagogical_mediation_type']);
-//        if (!$result['status']) array_push($log, array('assistance_type' => $result['erro']));
+        //        $result = $crv->isValidAssistanceType($schoolstructure, $column['assistance_type'], $column['pedagogical_mediation_type']);
+        //        if (!$result['status']) array_push($log, array('assistance_type' => $result['erro']));
 
         //campos 20 a 25
         $activities = array(
@@ -806,14 +805,14 @@ class CensoController extends Controller
             array_push($log, array('course' => $result['erro']));
 
         //campos 40 a 65
-//        $disciplinesArray = array($column['discipline_chemistry'], $column['discipline_physics'], $column['discipline_mathematics'], $column['discipline_biology'], $column['discipline_science'],
-//            $column['discipline_language_portuguese_literature'], $column['discipline_foreign_language_english'], $column['discipline_foreign_language_spanish'], $column['discipline_foreign_language_franch'], $column['discipline_foreign_language_other'],
-//            $column['discipline_arts'], $column['discipline_physical_education'], $column['discipline_history'], $column['discipline_geography'], $column['discipline_philosophy'],
-//            $column['discipline_social_study'], $column['discipline_sociology'], $column['discipline_informatics'], $column['discipline_professional_disciplines'], $column['discipline_special_education_and_inclusive_practices'],
-//            $column['discipline_sociocultural_diversity'], $column['discipline_libras'], $column['discipline_pedagogical'], $column['discipline_religious'], $column['discipline_native_language'],
-//            $column['discipline_others']);
-//        $result = $crv->isValidDiscipline($disciplinesArray, $column['pedagogical_mediation_type'], $column['assistance_type'], $column['edcenso_stage_vs_modality_fk']);
-//        if (!$result['status']) array_push($log, array('disciplines' => $result['erro']));
+        //        $disciplinesArray = array($column['discipline_chemistry'], $column['discipline_physics'], $column['discipline_mathematics'], $column['discipline_biology'], $column['discipline_science'],
+        //            $column['discipline_language_portuguese_literature'], $column['discipline_foreign_language_english'], $column['discipline_foreign_language_spanish'], $column['discipline_foreign_language_franch'], $column['discipline_foreign_language_other'],
+        //            $column['discipline_arts'], $column['discipline_physical_education'], $column['discipline_history'], $column['discipline_geography'], $column['discipline_philosophy'],
+        //            $column['discipline_social_study'], $column['discipline_sociology'], $column['discipline_informatics'], $column['discipline_professional_disciplines'], $column['discipline_special_education_and_inclusive_practices'],
+        //            $column['discipline_sociocultural_diversity'], $column['discipline_libras'], $column['discipline_pedagogical'], $column['discipline_religious'], $column['discipline_native_language'],
+        //            $column['discipline_others']);
+        //        $result = $crv->isValidDiscipline($disciplinesArray, $column['pedagogical_mediation_type'], $column['assistance_type'], $column['edcenso_stage_vs_modality_fk']);
+        //        if (!$result['status']) array_push($log, array('disciplines' => $result['erro']));
 
         $result = $crv->isValidAttendanceType($column["schooling"], $column["complementary_activity"], $column["aee"]);
         if (!$result['status'])
@@ -968,17 +967,17 @@ class CensoController extends Controller
 
         $excludingdeficiencies = array(
             $collumn['deficiency_type_blindness'] =>
-                array(
-                    $collumn['deficiency_type_low_vision'],
-                    $collumn['deficiency_type_deafness'],
-                    $collumn['deficiency_type_deafblindness']
-                ),
+            array(
+                $collumn['deficiency_type_low_vision'],
+                $collumn['deficiency_type_deafness'],
+                $collumn['deficiency_type_deafblindness']
+            ),
             $collumn['deficiency_type_low_vision'] =>
-                array($collumn['deficiency_type_deafblindness']),
+            array($collumn['deficiency_type_deafblindness']),
             $collumn['deficiency_type_deafness'] =>
-                array($collumn['deficiency_type_disability_hearing'], $collumn['deficiency_type_disability_hearing']),
+            array($collumn['deficiency_type_disability_hearing'], $collumn['deficiency_type_disability_hearing']),
             $collumn['deficiency_type_disability_hearing'] =>
-                array($collumn['deficiency_type_deafblindness'])
+            array($collumn['deficiency_type_deafblindness'])
         );
 
         if (!empty($collumn['deficiency'])) {
@@ -992,8 +991,8 @@ class CensoController extends Controller
         //if(!$result["status"]) array_push($log, array("deficiency_type_multiple_disabilities"=>$result["erro"]));
 
         $variabelData = InstructorVariableData::model()->findByPk($collumn['id']);
-        if(!isset($variabelData)){
-             array_push($log, array("Escolaridade" => "Formação educacional não foi informada"));
+        if (!isset($variabelData)) {
+            array_push($log, array("Escolaridade" => "Formação educacional não foi informada"));
         }
 
 
@@ -1095,8 +1094,7 @@ class CensoController extends Controller
         $sql = "SELECT assistance_type, pedagogical_mediation_type, edcenso_stage_vs_modality_fk
 			FROM classroom
 			WHERE id = '$classroom_fk';";
-        $check = Yii::app()->db->createCommand($sql)->queryAll();
-        ;
+        $check = Yii::app()->db->createCommand($sql)->queryAll();;
         $assistance_type = $check[0]['assistance_type'];
         $pedagogical_mediation_type = $check[0]['pedagogical_mediation_type'];
         $edcenso_svm = $check[0]['edcenso_stage_vs_modality_fk'];
@@ -1421,54 +1419,54 @@ class CensoController extends Controller
             if (!$result["status"])
                 array_push($log, array("civil_register_enrollment_number" => $result["erro"]));
             //            } else if ($collumn['civil_register_enrollment_number'] !== "") {
-//                return array("status" => false, "erro" => "Como foi preenchido o nº de matrícula da certidão nova, a nacionalidade do aluno deveria ser brasileira, nascido no exterior ou não.");
-//            }
+            //                return array("status" => false, "erro" => "Como foi preenchido o nº de matrícula da certidão nova, a nacionalidade do aluno deveria ser brasileira, nascido no exterior ou não.");
+            //            }
         }
 
         //        if (empty($collumn['cpf']) && empty($collumn['nis'])) {
-//            //campo 10
-//            $result = $sda->isCivilCertificationTypeValid($civil_certification, $field7005, $nationality, $field6006, $date);
-//            if (!$result["status"]) array_push($log, array("civil_certification_type" => $result["erro"]));
-//
-//            //campo 11
-//            $civil_certification = $collumn['civil_certification'];
-//
-//            if ($civil_certification == 1) {
-//                array_push($log, array("civil_register_enrollment_number" => $result["erro"]));
-////
-////                $result = $sda->isFieldValid(8, $collumn['civil_certification_term_number'], $nationality, $civil_certification);
-////                if (!$result["status"]) array_push($log, array("civil_certification_term_number" => $result["erro"]));
-////
-////                //campo 12
-////                $result = $sda->isFieldValid(4, $collumn['civil_certification_sheet'], $nationality, $civil_certification);
-////                if (!$result["status"]) array_push($log, array("civil_certification_sheet" => $result["erro"]));
-////
-////                //campo 13
-////                $result = $sda->isFieldValid(8, $collumn['civil_certification_book'], $nationality, $civil_certification);
-////                if (!$result["status"]) array_push($log, array("civil_certification_book" => $result["erro"]));
-////
-////                //campo 14
-////                $result = $sda->isDateValid($nationality, $collumn['civil_certification_date'], $field6006, $date, 1, 14);
-////                if (!$result["status"]) array_push($log, array("civil_certification_date" => $result["erro"]));
-////
-////                //campo 15
-////                $result = $sda->isFieldValid(2, $collumn['notary_office_uf_fk'], $nationality, $civil_certification);
-////                if (!$result["status"]) array_push($log, array("notary_office_uf_fk" => $result["erro"]));
-////
-////                //campo 16
-////                $result = $sda->isFieldValid(7, $collumn['notary_office_city_fk'], $nationality, $civil_certification);
-////                if (!$result["status"]) array_push($log, array("notary_office_city_fk" => $result["erro"]));
-////
-////                //campo 17
-////                $result = $sda->isFieldValid(6, $collumn['edcenso_notary_office_fk'], $nationality, $civil_certification);
-////                if (!$result["status"]) array_push($log, array("edcenso_notary_office_fk" => $result["erro"]));
-//
-//            } else {
-//                //campo 18
-//                $result = $sda->isCivilRegisterNumberValid($collumn['civil_register_enrollment_number'], $nationality, $civil_certification);
-//                if (!$result["status"]) array_push($log, array("civil_register_enrollment_number" => $result["erro"]));
-//            }
-//        }
+        //            //campo 10
+        //            $result = $sda->isCivilCertificationTypeValid($civil_certification, $field7005, $nationality, $field6006, $date);
+        //            if (!$result["status"]) array_push($log, array("civil_certification_type" => $result["erro"]));
+        //
+        //            //campo 11
+        //            $civil_certification = $collumn['civil_certification'];
+        //
+        //            if ($civil_certification == 1) {
+        //                array_push($log, array("civil_register_enrollment_number" => $result["erro"]));
+        ////
+        ////                $result = $sda->isFieldValid(8, $collumn['civil_certification_term_number'], $nationality, $civil_certification);
+        ////                if (!$result["status"]) array_push($log, array("civil_certification_term_number" => $result["erro"]));
+        ////
+        ////                //campo 12
+        ////                $result = $sda->isFieldValid(4, $collumn['civil_certification_sheet'], $nationality, $civil_certification);
+        ////                if (!$result["status"]) array_push($log, array("civil_certification_sheet" => $result["erro"]));
+        ////
+        ////                //campo 13
+        ////                $result = $sda->isFieldValid(8, $collumn['civil_certification_book'], $nationality, $civil_certification);
+        ////                if (!$result["status"]) array_push($log, array("civil_certification_book" => $result["erro"]));
+        ////
+        ////                //campo 14
+        ////                $result = $sda->isDateValid($nationality, $collumn['civil_certification_date'], $field6006, $date, 1, 14);
+        ////                if (!$result["status"]) array_push($log, array("civil_certification_date" => $result["erro"]));
+        ////
+        ////                //campo 15
+        ////                $result = $sda->isFieldValid(2, $collumn['notary_office_uf_fk'], $nationality, $civil_certification);
+        ////                if (!$result["status"]) array_push($log, array("notary_office_uf_fk" => $result["erro"]));
+        ////
+        ////                //campo 16
+        ////                $result = $sda->isFieldValid(7, $collumn['notary_office_city_fk'], $nationality, $civil_certification);
+        ////                if (!$result["status"]) array_push($log, array("notary_office_city_fk" => $result["erro"]));
+        ////
+        ////                //campo 17
+        ////                $result = $sda->isFieldValid(6, $collumn['edcenso_notary_office_fk'], $nationality, $civil_certification);
+        ////                if (!$result["status"]) array_push($log, array("edcenso_notary_office_fk" => $result["erro"]));
+        //
+        //            } else {
+        //                //campo 18
+        //                $result = $sda->isCivilRegisterNumberValid($collumn['civil_register_enrollment_number'], $nationality, $civil_certification);
+        //                if (!$result["status"]) array_push($log, array("civil_register_enrollment_number" => $result["erro"]));
+        //            }
+        //        }
         //campo 19
         if (!empty($collumn['cpf'])) {
             $result = $sda->isCPFValid($collumn['cpf']);
@@ -1481,10 +1479,10 @@ class CensoController extends Controller
             array_push($log, array("foreign_document_or_passport" => $result["erro"]));
 
         //campo 21
-//        if (!empty($collumn['nis'])) {
-//            $result = $sda->isNISValid($collumn['nis']);
-//            if (!$result["status"]) array_push($log, array("nis" => $result["erro"]));
-//        }
+        //        if (!empty($collumn['nis'])) {
+        //            $result = $sda->isNISValid($collumn['nis']);
+        //            if (!$result["status"]) array_push($log, array("nis" => $result["erro"]));
+        //        }
 
         $result = $sda->isAreaOfResidenceValid($collumn['residence_zone']);
         if (!$result["status"])
@@ -1867,7 +1865,7 @@ class CensoController extends Controller
             $ordens = EdcensoAlias::model()->findAllByAttributes(["register" => $register]);
             foreach ($ordens as $kord => $ord) {
                 $evalin = '$this->tmpexp["' . $pos . '"][' . $attributes['id'] . '][' . $ord->corder . '] = "' . $ord->default . '";';
-                eval ($evalin);
+                eval($evalin);
             }
         } else if ($register == 20) {
             $pos = "c";
@@ -1880,10 +1878,9 @@ class CensoController extends Controller
             if ($reg == 60) {
                 foreach ($ordens as $kord => $ord) {
                     $evalin = '$this->tmpexp["' . $pos . '"][' . $attributes['id'] . '][' . $ord->corder . '] = "' . $ord->default . '";';
-                    eval ($evalin);
+                    eval($evalin);
                 }
             }
-
         } elseif ($register == 30 || $register == 40 || $register == 50) {
             $register = 302;
             $pos = "e";
@@ -1892,7 +1889,7 @@ class CensoController extends Controller
             if ($reg == 30) {
                 foreach ($ordens as $kord => $ord) {
                     $evalin = '$this->tmpexp["' . $pos . '"][' . $attributes['id'] . '][' . $ord->corder . '] = "' . $ord->default . '";';
-                    eval ($evalin);
+                    eval($evalin);
                 }
             }
         } elseif ($register == 80) {
@@ -1906,7 +1903,7 @@ class CensoController extends Controller
             $ordens = EdcensoAlias::model()->findAllByAttributes(["register" => $register]);
             foreach ($ordens as $kord => $ord) {
                 $evalin = '$this->tmpexp["' . $pos . '"][' . $attributes['id'] . '][' . $ord->corder . '] = "' . $ord->default . '";';
-                eval ($evalin);
+                eval($evalin);
             }
         }
         //@todo $register = 40;
@@ -1916,19 +1913,16 @@ class CensoController extends Controller
             if (isset($ordem->corder)) {
                 if (($reg == 70 || $reg == 40) && $key == 'edcenso_city_fk') {
                     $eval = '$this->tmpexp["' . $pos . '"][' . $attributes['id'] . '][44] = "' . $attr . '";';
-                    eval ($eval);
+                    eval($eval);
                 } elseif (($reg == 60 || $reg == 30) && $key == 'edcenso_city_fk') {
                     $eval = '$this->tmpexp["' . $pos . '"][' . $attributes['id'] . '][15] = "' . $attr . '";';
-                    eval ($eval);
+                    eval($eval);
                 } else {
                     $eval = '$this->tmpexp["' . $pos . '"][' . $attributes['id'] . '][' . $ordem->corder . '] = "' . $attr . '";';
-                    eval ($eval);
+                    eval($eval);
                 }
-
             }
         }
-
-
     }
 
     public function normalizeFields($register, $attributes)
@@ -2034,7 +2028,6 @@ class CensoController extends Controller
         }
         $return = $digUm . $digDois;
         return $return;
-
     }
 
     public function sanitizeString($string)
@@ -2092,7 +2085,6 @@ class CensoController extends Controller
                     if (!($attributes['latitude'] >= -33.75208 && $attributes['latitude'] <= 5.271841 && $attributes['longitude'] >= -73.99045 && $attributes['longitude'] <= -32.39091)) {
                         $attributes['latitude'] = $attributes['longitude'] = '';
                     }
-
                 } else {
                     $attributes['latitude'] = $attributes['longitude'] = '';
                 }
@@ -2155,7 +2147,7 @@ class CensoController extends Controller
                     'internet_access_local_wireless',
                     'internet_access_local_inexistet',
                     'equipments_computer' .
-                    'garbage_destination_throw_away',
+                        'garbage_destination_throw_away',
                     'treatment_garbage_parting_garbage',
                     'treatment_garbage_resuse',
                     'garbage_destination_recycle',
@@ -2279,7 +2271,6 @@ class CensoController extends Controller
                     $attributes['vehicle_type_waterway_boat_35'] = '';
                     $attributes['vehicle_type_metro_or_train'] = '';
                     $attributes['transport_responsable_government'] = '';
-
                 }
 
 
@@ -2398,7 +2389,6 @@ class CensoController extends Controller
                     $attributes['resource_cd_audio'] = '';
                     $attributes['resource_proof_language'] = '';
                     $attributes['resource_video_libras'] = '';
-
                 } else {
                     $existone = false;
                     foreach ($attributes as $i => $attr) {
@@ -2422,7 +2412,6 @@ class CensoController extends Controller
                                 }
                             }
                         }
-
                     }
                     if (!empty($attributes['deficiency_type_gifted'])) {
                         $attributes['resource_none'] = '';
@@ -2436,8 +2425,6 @@ class CensoController extends Controller
                         $attributes['resource_zoomed_test_24'] = '';
                         $attributes['resource_braille_test'] = '';
                     }
-
-
                 }
                 break;
             case '30':
@@ -2484,7 +2471,6 @@ class CensoController extends Controller
                     $attributes['number'] = '';
                     $attributes['complement'] = '';
                     $attributes['neighborhood'] = '';
-
                 }
                 if (empty($attributes['cep']) && isset($attributes['edcenso_city_fk'])) {
                     $attributes['edcenso_city_fk'] = '';
@@ -2521,7 +2507,6 @@ class CensoController extends Controller
                 }
                 if (empty($attributes['civil_certification'])) {
                     $attributes['civil_certification_type'] = '';
-
                 }
 
                 if (empty($attributes['rg_number'])) {
@@ -2655,7 +2640,6 @@ class CensoController extends Controller
                     } elseif (empty($attributes['post_graduation_none'])) {
                         $attributes['post_graduation_none'] = '1';
                     }
-
                 }
                 if (
                     $attributes['high_education_situation_2'] == 2
@@ -2722,7 +2706,6 @@ class CensoController extends Controller
                         if (isset($dteacher[$dclass[$i]])) {
                             $attributes[$i] = '1';
                         }
-
                     }
                 }
                 if ($attributes['assistance_type'] != '5') {
@@ -2815,17 +2798,16 @@ class CensoController extends Controller
                 $attributes['cep'] = '';
                 $attributes['edcenso_city_fk'] = '';
                 break;
-
         }
         return $attributes;
-
     }
 
-    public function actionExport()
+    public function actionExport($withoutCertificates)
     {
+
         include dirname(__DIR__) . '/libraries/Educacenso/Educacenso.php';
         $Educacenso = new Educacenso;
-        $export = $Educacenso->exportar(date("Y"));
+        $export = $Educacenso->exportar(date("Y"), $withoutCertificates);
 
         $fileDir = Yii::app()->basePath . '/export/' . date('Y_') . Yii::app()->user->school . '.TXT';
 
@@ -2844,101 +2826,101 @@ class CensoController extends Controller
         return $this->redirect(array('index'));
 
         //        $school = SchoolIdentification::model()->findByPk(Yii::app()->user->school);
-//        $this->normalizeField2019($school->register_type, $school->attributes);
-//        $schoolStructure = SchoolStructure::model()->findByPk(Yii::app()->user->school);
-//        $this->normalizeField2019($schoolStructure->register_type, $schoolStructure->attributes);
-//        $classrooms = Classroom::model()->findAllByAttributes(["school_inep_fk" => yii::app()->user->school, "school_year" => Yii::app()->user->year]);
-//        foreach ($classrooms as $iclass => $classroom) {
-//            $log['classrooms'][$iclass] = $classroom->attributes;
-//            foreach ($classroom->instructorTeachingDatas as $iteaching => $teachingData) {
-//                if (!isset($log['instructors'][$teachingData->instructor_fk])) {
-//                    //@Todo fazer o sistema atualizar automaticamente quando o o cadastro entrar na escola
-//                    $teachingData->instructorFk->documents->school_inep_id_fk = $school->inep_id;
-//                    $teachingData->instructorFk->instructorVariableData->school_inep_id_fk = $school->inep_id;
-//                    $teachingData->instructorFk->school_inep_id_fk = $school->inep_id;
-//                    $log['instructors'][$teachingData->instructor_fk]['identification'] = $teachingData->instructorFk->attributes;
-//                    $log['instructors'][$teachingData->instructor_fk]['documents'] = $teachingData->instructorFk->documents->attributes;
-//                    $instructor_inepid_id = isset($teachingData->instructorFk->inep_id) && !empty($teachingData->instructorFk->inep_id) ? $teachingData->instructorFk->inep_id : $teachingData->instructorFk->id;
-//                    if (isset($teachingData->instructorFk->inep_id) && !empty($teachingData->instructorFk->inep_id)) {
-//                        $variabledata = InstructorVariableData::model()->findByAttributes(['inep_id' => $instructor_inepid_id]);
-//                    } else {
-//                        $variabledata = InstructorVariableData::model()->findByPk($instructor_inepid_id);
-//                    }
-//                    $variabledata->id = $teachingData->instructorFk->id;
-//                    $variabledata->inep_id = $teachingData->instructorFk->inep_id;
-//                    $variabledata->school_inep_id_fk = $school->inep_id;
-//                    $log['instructors'][$teachingData->instructor_fk]['variable'] = $variabledata->attributes;
-//                } else {
-//
-//                }
-//                $teachingData->instructor_inep_id = $teachingData->instructorFk->inep_id;
-//                $teachingData->school_inep_id_fk = $school->inep_id;
-//                $log['instructors'][$teachingData->instructor_fk]['teaching'][$classroom->id] = $teachingData->attributes;
-//            }
-//            foreach ($classroom->studentEnrollments as $ienrollment => $enrollment) {
-//                if (!isset($log['students'][$enrollment->student_fk])) {
-//                    $enrollment->studentFk->school_inep_id_fk = $school->inep_id;
-//                    $enrollment->studentFk->documentsFk->school_inep_id_fk = $school->inep_id;
-//                    $log['students'][$enrollment->student_fk]['identification'] = $enrollment->studentFk->attributes;
-//                    $log['students'][$enrollment->student_fk]['documents'] = $enrollment->studentFk->documentsFk->attributes;
-//                }
-//                $enrollment->school_inep_id_fk = $school->inep_id;
-//                $log['students'][$enrollment->student_fk]['enrollments'][$ienrollment] = $enrollment->attributes;
-//            }
-//        }
-//        foreach ($log['classrooms'] as $classroom) {
-//            $this->normalizeField2019($classroom['register_type'], $classroom);
-//        }
-//        foreach ($log['instructors'] as $instructor) {
-//            $id = (String)'90' . $instructor['identification']['id'];
-//            $instructor['identification']['id'] = $id;
-//            $instructor['documents']['id'] = $id;
-//            $instructor['variable']['id'] = $id;
-//            $this->normalizeField2019($instructor['identification']['register_type'], $instructor['identification']);
-//            $this->normalizeField2019($instructor['documents']['register_type'], $instructor['documents']);
-//            $this->normalizeField2019($instructor['variable']['register_type'], $instructor['variable']);
-//            foreach ($instructor['teaching'] as $teaching) {
-//                $teaching['instructor_fk'] = $id;
-//                $this->normalizeField2019($teaching['register_type'], $teaching);
-//            }
-//        }
-//        foreach ($log['students'] as $student) {
-//            $this->normalizeField2019($student['identification']['register_type'], $student['identification']);
-//            $this->normalizeField2019($student['documents']['register_type'], $student['documents']);
-//            foreach ($student['enrollments'] as $enrollment) {
-//                $this->normalizeField2019($enrollment['register_type'], $enrollment);
-//            }
-//        }
-//        //ksort($this->tmpexp['c'][5076]);
-//        //print_r($this->tmpexp['c'][5076]);exit;
-//
-//        foreach ($this->tmpexp as $kpos => $pos) {
-//            foreach ($pos as $kline => $line) {
-//                ksort($line);
-//                $this->export[$kpos] .= implode('|', $line);
-//                $this->export[$kpos] .= "\n";
-//            }
-//        }
-//        $this->export['e'] .= '30|' . Yii::app()->user->school . '|909999|183258253160|84278560591|RUANCELI DO NASCIMENTO SANTOS|23/05/1988|1|TANIA MARIA DO NASCIMENTO||2|3|1|76|2800670|0|||||||||||||||||||||||||||||1||6||145F01|2008|3||||||||||1|0|0|0|0|0|0|1|0|0|0|0|0|0|0|0|0|0|0|1|0|RUAN@IPTI.ORG.BR' . "\n";
-//        $this->export['eb'] .= '40|' . Yii::app()->user->school . '|909999||1|2||1' . "\n";
-//        $this->export["i"] .= '99|';
-//
-//        ksort($this->export);
-//        foreach ($this->export as $key => $txtexport) {
-//            $export .= $txtexport;
-//        }
-//        $fileDir = Yii::app()->basePath . '/export/' . date('Y_') . Yii::app()->user->school . '.TXT';
-//
-//        Yii::import('ext.FileManager.fileManager');
-//        $fm = new fileManager();
-//        $result = $fm->write($fileDir, $export);
-//
-//        if ($result) {
-//            Yii::app()->user->setFlash('success', Yii::t('default', 'Exportação Concluida com Sucesso.<br><a href="?r=/censo/DownloadExportFile" class="btn btn-mini" target="_blank"><i class="icon-download-alt"></i>Clique aqui para fazer o Download do arquivo de exportação!!!</a>'));
-//        } else {
-//            Yii::app()->user->setFlash('error', Yii::t('default', 'Houve algum erro na Exportação.'));
-//        }
-//        $this->redirect(array('validate'));
+        //        $this->normalizeField2019($school->register_type, $school->attributes);
+        //        $schoolStructure = SchoolStructure::model()->findByPk(Yii::app()->user->school);
+        //        $this->normalizeField2019($schoolStructure->register_type, $schoolStructure->attributes);
+        //        $classrooms = Classroom::model()->findAllByAttributes(["school_inep_fk" => yii::app()->user->school, "school_year" => Yii::app()->user->year]);
+        //        foreach ($classrooms as $iclass => $classroom) {
+        //            $log['classrooms'][$iclass] = $classroom->attributes;
+        //            foreach ($classroom->instructorTeachingDatas as $iteaching => $teachingData) {
+        //                if (!isset($log['instructors'][$teachingData->instructor_fk])) {
+        //                    //@Todo fazer o sistema atualizar automaticamente quando o o cadastro entrar na escola
+        //                    $teachingData->instructorFk->documents->school_inep_id_fk = $school->inep_id;
+        //                    $teachingData->instructorFk->instructorVariableData->school_inep_id_fk = $school->inep_id;
+        //                    $teachingData->instructorFk->school_inep_id_fk = $school->inep_id;
+        //                    $log['instructors'][$teachingData->instructor_fk]['identification'] = $teachingData->instructorFk->attributes;
+        //                    $log['instructors'][$teachingData->instructor_fk]['documents'] = $teachingData->instructorFk->documents->attributes;
+        //                    $instructor_inepid_id = isset($teachingData->instructorFk->inep_id) && !empty($teachingData->instructorFk->inep_id) ? $teachingData->instructorFk->inep_id : $teachingData->instructorFk->id;
+        //                    if (isset($teachingData->instructorFk->inep_id) && !empty($teachingData->instructorFk->inep_id)) {
+        //                        $variabledata = InstructorVariableData::model()->findByAttributes(['inep_id' => $instructor_inepid_id]);
+        //                    } else {
+        //                        $variabledata = InstructorVariableData::model()->findByPk($instructor_inepid_id);
+        //                    }
+        //                    $variabledata->id = $teachingData->instructorFk->id;
+        //                    $variabledata->inep_id = $teachingData->instructorFk->inep_id;
+        //                    $variabledata->school_inep_id_fk = $school->inep_id;
+        //                    $log['instructors'][$teachingData->instructor_fk]['variable'] = $variabledata->attributes;
+        //                } else {
+        //
+        //                }
+        //                $teachingData->instructor_inep_id = $teachingData->instructorFk->inep_id;
+        //                $teachingData->school_inep_id_fk = $school->inep_id;
+        //                $log['instructors'][$teachingData->instructor_fk]['teaching'][$classroom->id] = $teachingData->attributes;
+        //            }
+        //            foreach ($classroom->studentEnrollments as $ienrollment => $enrollment) {
+        //                if (!isset($log['students'][$enrollment->student_fk])) {
+        //                    $enrollment->studentFk->school_inep_id_fk = $school->inep_id;
+        //                    $enrollment->studentFk->documentsFk->school_inep_id_fk = $school->inep_id;
+        //                    $log['students'][$enrollment->student_fk]['identification'] = $enrollment->studentFk->attributes;
+        //                    $log['students'][$enrollment->student_fk]['documents'] = $enrollment->studentFk->documentsFk->attributes;
+        //                }
+        //                $enrollment->school_inep_id_fk = $school->inep_id;
+        //                $log['students'][$enrollment->student_fk]['enrollments'][$ienrollment] = $enrollment->attributes;
+        //            }
+        //        }
+        //        foreach ($log['classrooms'] as $classroom) {
+        //            $this->normalizeField2019($classroom['register_type'], $classroom);
+        //        }
+        //        foreach ($log['instructors'] as $instructor) {
+        //            $id = (String)'90' . $instructor['identification']['id'];
+        //            $instructor['identification']['id'] = $id;
+        //            $instructor['documents']['id'] = $id;
+        //            $instructor['variable']['id'] = $id;
+        //            $this->normalizeField2019($instructor['identification']['register_type'], $instructor['identification']);
+        //            $this->normalizeField2019($instructor['documents']['register_type'], $instructor['documents']);
+        //            $this->normalizeField2019($instructor['variable']['register_type'], $instructor['variable']);
+        //            foreach ($instructor['teaching'] as $teaching) {
+        //                $teaching['instructor_fk'] = $id;
+        //                $this->normalizeField2019($teaching['register_type'], $teaching);
+        //            }
+        //        }
+        //        foreach ($log['students'] as $student) {
+        //            $this->normalizeField2019($student['identification']['register_type'], $student['identification']);
+        //            $this->normalizeField2019($student['documents']['register_type'], $student['documents']);
+        //            foreach ($student['enrollments'] as $enrollment) {
+        //                $this->normalizeField2019($enrollment['register_type'], $enrollment);
+        //            }
+        //        }
+        //        //ksort($this->tmpexp['c'][5076]);
+        //        //print_r($this->tmpexp['c'][5076]);exit;
+        //
+        //        foreach ($this->tmpexp as $kpos => $pos) {
+        //            foreach ($pos as $kline => $line) {
+        //                ksort($line);
+        //                $this->export[$kpos] .= implode('|', $line);
+        //                $this->export[$kpos] .= "\n";
+        //            }
+        //        }
+        //        $this->export['e'] .= '30|' . Yii::app()->user->school . '|909999|183258253160|84278560591|RUANCELI DO NASCIMENTO SANTOS|23/05/1988|1|TANIA MARIA DO NASCIMENTO||2|3|1|76|2800670|0|||||||||||||||||||||||||||||1||6||145F01|2008|3||||||||||1|0|0|0|0|0|0|1|0|0|0|0|0|0|0|0|0|0|0|1|0|RUAN@IPTI.ORG.BR' . "\n";
+        //        $this->export['eb'] .= '40|' . Yii::app()->user->school . '|909999||1|2||1' . "\n";
+        //        $this->export["i"] .= '99|';
+        //
+        //        ksort($this->export);
+        //        foreach ($this->export as $key => $txtexport) {
+        //            $export .= $txtexport;
+        //        }
+        //        $fileDir = Yii::app()->basePath . '/export/' . date('Y_') . Yii::app()->user->school . '.TXT';
+        //
+        //        Yii::import('ext.FileManager.fileManager');
+        //        $fm = new fileManager();
+        //        $result = $fm->write($fileDir, $export);
+        //
+        //        if ($result) {
+        //            Yii::app()->user->setFlash('success', Yii::t('default', 'Exportação Concluida com Sucesso.<br><a href="?r=/censo/DownloadExportFile" class="btn btn-mini" target="_blank"><i class="icon-download-alt"></i>Clique aqui para fazer o Download do arquivo de exportação!!!</a>'));
+        //        } else {
+        //            Yii::app()->user->setFlash('error', Yii::t('default', 'Houve algum erro na Exportação.'));
+        //        }
+        //        $this->redirect(array('validate'));
     }
 
     public function actionExportIdentification()
@@ -2998,7 +2980,6 @@ class CensoController extends Controller
             Yii::app()->user->setFlash('error', Yii::t('default', 'Arquivo de exportação não encontrado!!! Tente exportar novamente.'));
             $this->render('index');
         }
-
     }
 
     public function actionInitialImport()
@@ -3110,7 +3091,6 @@ class CensoController extends Controller
 
                     $student->update(array('inep_id'));
                     $counterStudents++;
-
                 }
             }
             Yii::app()->user->setFlash("success", "Importação realizada com sucesso!");
@@ -3202,7 +3182,6 @@ class CensoController extends Controller
         } catch (Exception $e) {
             Yii::app()->user->setFlash("error", "Ocorreu um erro inesperado.");
         }
-
     }
 
     public function printImported($type, $register)
@@ -3324,5 +3303,3 @@ class CensoController extends Controller
         return count($result) ? current($result)->corder : null;
     }
 }
-
-?>

--- a/app/libraries/Educacenso/Educacenso.php
+++ b/app/libraries/Educacenso/Educacenso.php
@@ -31,9 +31,9 @@ class Educacenso
         $this->registers['20'] = Register20::export($year);
     }
 
-    private function register30($year)
+    private function register30($year,  $withoutCertificates)
     {
-        $this->registers['30'] = Register30::export($year);
+        $this->registers['30'] = Register30::export($year,  $withoutCertificates);
     }
 
     private function register40()
@@ -61,12 +61,12 @@ class Educacenso
         return  RegisterIdentification::export();
     }
 
-    public function exportar($year)
+    public function exportar($year, $withoutCertificates)
     {
         $this->register00($year);
         $this->register10($year);
         $this->register20($year);
-        $this->register30($year);
+        $this->register30($year,  $withoutCertificates);
         $this->register40();
         $this->register50($year);
         $this->register60($year);

--- a/app/libraries/Educacenso/Register30.php
+++ b/app/libraries/Educacenso/Register30.php
@@ -254,7 +254,7 @@ class Register30
         return $register;
     }
 
-    private static function exportStudentDocuments($student, $register, $school, $aliases)
+    private static function exportStudentDocuments($student, $register, $school, $aliases,  $withoutCertificates)
     {
         $student['register_type'] = '30';
 
@@ -264,7 +264,7 @@ class Register30
         }
 
 
-        if ($student['civil_certification'] != 2) {
+        if ($student['civil_certification'] != 2 || $withoutCertificates == true) {
             $student['civil_register_enrollment_number'] = '';
         }
 
@@ -536,7 +536,7 @@ class Register30
         return $highEducationCourses[$found_key]['cine_id'];
     }
 
-    public static function export($year)
+    public static function export($year,  $withoutCertificates)
     {
         $registers = [];
 
@@ -560,7 +560,7 @@ class Register30
             $register = [];
 
             $register = self::exportStudentIdentification($student['identification'], $register, $school, $aliasesStudent);
-            $register = self::exportStudentDocuments($student['documents'], $register, $school, $aliasesStudent);
+            $register = self::exportStudentDocuments($student['documents'], $register, $school, $aliasesStudent,  $withoutCertificates);
             $register = self::exportStudentDisorders($student['disorders'], $register, $aliasesStudent);
 
             ksort($register);

--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@ $debug = getenv("YII_DEBUG");
 defined('YII_DEBUG') or define('YII_DEBUG', $debug);
 defined("SESSION_MAX_LIFETIME") or define('SESSION_MAX_LIFETIME', 3600);
 
-define("TAG_VERSION", '3.2.1');
+define("TAG_VERSION", '3.2.2');
 
 define("YII_VERSION", Yii::getVersion());
 define("BOARD_MSG", '<div class="alert alert-success">Novas atualizações no TAG. Confira clicando <a class="changelog-link" href="?r=admin/changelog">aqui</a>.</div>');

--- a/instance.php
+++ b/instance.php
@@ -17,7 +17,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'demo.tag.ong.br';
+    $newdb = 'nossasenhoradagloria.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;

--- a/instance.php
+++ b/instance.php
@@ -17,7 +17,7 @@ $domain = array_shift($host_array);
 $newdb = $domain . '.tag.ong.br';
 
 if ($domain == "localhost") {
-    $newdb = 'nossasenhoradagloria.tag.ong.br';
+    $newdb = 'demo.tag.ong.br';
 }
 
 $_GLOBALGROUP = 0;

--- a/js/censo/functions.js
+++ b/js/censo/functions.js
@@ -1,0 +1,12 @@
+
+
+$('.js-withoutCertificates').on('change', function () {
+    const isChecked = $(this).is(':checked');
+    const value = isChecked ? 'true' : 'false';
+
+    const baseUrl = $('.js-export-link').attr('href').split('?')[0]; // remove parâmetros antigos
+
+    const newUrl = baseUrl + '?withoutCertificates=' + value;
+
+    $('.js-export-link').attr('href', newUrl);
+})

--- a/js/censo/functions.js
+++ b/js/censo/functions.js
@@ -1,12 +1,18 @@
-
-
 $('.js-withoutCertificates').on('change', function () {
-    const isChecked = $(this).is(':checked');
-    const value = isChecked ? 'true' : 'false';
+  const checkbox = this;
+  const exportLink = $('.js-export-link');
 
-    const baseUrl = $('.js-export-link').attr('href').split('?')[0]; // remove parâmetros antigos
+  if (!exportLink.length) return;
 
-    const newUrl = baseUrl + '?withoutCertificates=' + value;
+  // Pega o valor atual do href
+  const currentHref = exportLink.attr('href');
 
-    $('.js-export-link').attr('href', newUrl);
-})
+  // Cria objeto de URL com base no href atual
+  const url = new URL(currentHref, window.location.origin);
+
+  // Atualiza o parâmetro
+  url.searchParams.set('withoutCertificates', checkbox.checked); // true ou false
+
+  // Atualiza o href do link
+  exportLink.attr('href', url.toString());
+});

--- a/themes/default/views/censo/validate.php
+++ b/themes/default/views/censo/validate.php
@@ -13,6 +13,7 @@
     );
     $themeUrl = Yii::app()->theme->baseUrl;
     $cs = Yii::app()->getClientScript();
+    $cs->registerScriptFile($baseUrl . '/js/censo/functions.js?v=' . TAG_VERSION, CClientScript::POS_END);
 
     ?>
     <style type="text/css">
@@ -111,24 +112,33 @@
                 <?php echo Yii::app()->user->getFlash('success') ?>
             </div>
         <?php } else if (Yii::app()->user->hasFlash('error')) { ?>
-                <div class="alert alert-error">
+            <div class="alert alert-error">
                 <?php echo Yii::app()->user->getFlash('success') ?>
-                </div>
+            </div>
         <?php } ?>
         <div class="row  t-buttons-container">
-            <a href="<?= CHtml::normalizeUrl(array('censo/export')) ?>" class="t-button-primary" style="margin:0;">
+            <a href="<?= CHtml::normalizeUrl(array('censo/export', 'withoutCertificates' => 0)) ?>" class="t-button-primary js-export-link" style="margin:0;">
                 <?= Yii::t('default', 'Exportar arquivo de migração') ?>
             </a>
+            <!-- <button class="t-button-primary js-export-censo" style="margin:0;">
+                <?= Yii::t('default', 'Exportar arquivo de migração') ?>
+            </button> -->
             <?php if (Yii::app()->getAuthManager()->checkAccess('admin', Yii::app()->user->loginInfos->id)): ?>
                 <a href="<?= CHtml::normalizeUrl(array('censo/exportidentification')) ?>" class="t-button-secondary"
                     style="margin:0;">
                     <?= Yii::t('default', 'Exportar arquivo de identificação') ?>
                 </a>
-                 <a href="<?= CHtml::normalizeUrl(array('censo/inepImport')) ?>" class="t-button-secondary"
+                <a href="<?= CHtml::normalizeUrl(array('censo/inepImport')) ?>" class="t-button-secondary"
                     style="margin:0;">
                     <?= Yii::t('default', 'Importar INEP ID') ?>
                 </a>
             <?php endif; ?>
+        </div>
+        <div class="t-field-checkbox">
+            <label class="t-field-checkbox__label">
+                <input type="checkbox" class="t-field-checkbox__input js-withoutCertificates" name="withoutCertificates">
+                Exportar sem certidões de nascimento
+            </label>
         </div>
         <!-- Widget Heading END -->
         <?php
@@ -155,10 +165,10 @@
                 </div>
             </div>
             <script type="text/javascript">
-                $(function () {
+                $(function() {
                     $.ajax({
                         url: '<?= $this->createUrl('censo/validate') ?>',
-                        success: function (data) {
+                        success: function(data) {
                             $('#filterUsersTab').html(data);
                             $(".itens-censo li").parents('div').css("display", "block");
                             if ($(".list-timeline").find(".ellipsis").length) {
@@ -174,7 +184,6 @@
                     });
 
                 });
-
             </script>
         </div>
 


### PR DESCRIPTION
## 🚀 Motivação

Usuários relataram a ausência da opção de exportar o arquivo do censo escolar sem o campo de certidão de nascimento, uma vez que esse campo não é obrigatório

## 🔧 Alterações Realizadas
Adicionando um campo checkbox para permitir que o usuário escolha se quer exportar o arquivo com as certidões ou não

## 📌 Requisitos
nenhum

## 🛠️ Fluxo de Teste

🧪 Fluxo de Teste 1 (FT1):
```
1. No menu lateral do TAG escolher  Integrações > Censo
2. Marcar o checkbox "Exportar sem certidões de nascimento"
3. Clicar em "Exportar arquivo de migração"
4. Verificar se no arquivo o campo 50 (certidão de nascimento) veio não preenchido
```
✅ Sucesso: O campo 50 (certidão de nascimento) veio não preenchido
❌ Falha: O campo 50 (certidão de nascimento) veio preenchido

## ✨ Migrations Utilizadas

Nenhuma

## ✔️ Checklist - Padrões para PR
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?

### Documentação 
Houve alteração nos fluxo de uso? 
*(Lembrete: Em caso afirmativo, adicionar label Atualização de manual)*
- [ ] Sim   
- [ ] Não
