### PR TITLE
Fix/showing justsemcpf with cpf

### DIFF
--- a/app/modules/sagres/models/SagresConsultModel.php
+++ b/app/modules/sagres/models/SagresConsultModel.php
@@ -1867,6 +1867,8 @@ class SagresConsultModel
                         c.edcenso_stage_vs_modality_fk,
                         c.modality,
                         se.id as numero,
+                        c.school_inep_fk as inep_id,
+                        se.classroom_fk as class_id,
                         se.student_fk,
                         se.create_date AS data_matricula,
                         se.date_cancellation_enrollment AS data_cancelamento,
@@ -1879,6 +1881,7 @@ class SagresConsultModel
                         ifnull(si.deficiency, 0) AS deficiency,
                         si.sex AS gender,
                         si.id,
+                        si2.name AS school_name,
                         CASE
                             WHEN c.edcenso_stage_vs_modality_fk IN (2, 3, 4, 5, 6, 7, 8, 9, 14, 15, 16, 17, 18, 19, 75)  THEN
                                 (SELECT if(((SELECT COUNT(schedule) FROM class_faults cf
@@ -1907,6 +1910,7 @@ class SagresConsultModel
                         join student_documents_and_address sdaa on si.id = sdaa.id
                         left join class_faults cf on cf.student_fk = si.id
                         left join schedule s on cf.schedule_fk = s.id
+                        join school_identification si2 on si2.inep_id= c.school_inep_fk
                   WHERE
                         se.classroom_fk  =  :classId AND
                         (se.status in ($strAcceptedStatus) or se.status is null) AND
@@ -1924,7 +1928,6 @@ class SagresConsultModel
 
         return $command->queryAll();
     }
-
     private function studentValidation($studentType, $schoolName, $cpf, $classId, $enrollment, $strlen): void
     {
 

--- a/app/modules/sagres/models/SagresConsultModel.php
+++ b/app/modules/sagres/models/SagresConsultModel.php
@@ -1707,7 +1707,7 @@ class SagresConsultModel
         return $attendanceList;
     }
 
-    /**
+        /**
      * Sets a new MatriculaTType
      *
      * @return MatriculaTType[] | null
@@ -1715,10 +1715,6 @@ class SagresConsultModel
     public function getEnrollments($classId, $referenceYear, $finalClass, $inepId, $withoutCpf): array|null
     {
         $enrollmentList = [];
-        $strlen = 5;
-        $school = (object) \SchoolIdentification::model()->findByAttributes(array('inep_id' => $inepId));
-        $schoolName = $school->name;
-
         $enrollments = $this->getEnrollmentsInDB($classId, $referenceYear);
 
         if (empty($enrollments)) {
@@ -1726,7 +1722,7 @@ class SagresConsultModel
         }
 
         foreach ($enrollments as $enrollment) {
-
+            $schoolName = $enrollment['school_name'];
             $convertedBirthdate = $this->convertBirthdate($enrollment['birthdate']);
 
             if ($convertedBirthdate === false) {
@@ -1745,91 +1741,7 @@ class SagresConsultModel
 
             $cpf = $this->getStudentCpf($enrollment);
 
-            $this->checkSingleStudentWithoutCpf($enrollments, $cpf, $classId, $referenceYear, $school, $inepId);
-
-            if ($withoutCpf) {
-                $studentType = new AlunoTType();
-                if (!empty($cpf)) {
-                    $birthdate = DateTime::createFromFormat(DATE_FORMAT, $convertedBirthdate);
-                    $studentType
-                        ->setNome($enrollment['name'])
-                        ->setDataNascimento($birthdate)
-                        ->setCpfAluno($cpf)
-                        ->setPcd($enrollment['deficiency'])
-                        ->setSexo($enrollment['gender']);
-
-                    $arrayStudentInfo = [
-                        "studentFk" => $enrollment['student_fk'],
-                        "classroomFk" => $classId,
-                        "schoolInepIdFk" => $inepId
-                    ];
-
-                    $modality = $enrollment['modality'];
-                    //3 - EJA
-                    if ($modality === 3) {
-                        $educationLevel = (int) $this->getStageById($enrollment['edcenso_stage_vs_modality_fk']);
-                        $age = $this->calculateAge($birthdate);
-                        $this->checkAge($age, $educationLevel, $arrayStudentInfo);
-                    }
-
-                    $this->studentValidation($studentType, $school->name, $cpf, $classId, $enrollment, $strlen);
-
-                    $this->isNullStudentType($studentType, $school, $enrollment, $classId);
-
-                } else {
-                    $birthdate = DateTime::createFromFormat(DATE_FORMAT, $convertedBirthdate);
-                    $studentType
-                        ->setNome($enrollment['name'])
-                        ->setDataNascimento($birthdate)
-                        ->setPcd($enrollment['deficiency'])
-                        ->setSexo($enrollment['gender'])
-                        ->setJustSemCpf($enrollment['cpf_reason']);
-
-                    $this->studentValidationWhioutCpf($studentType, $schoolName, $enrollment['cpf_reason'], $classId, $enrollment, $strlen);
-                    $arrayStudentInfo = [
-                        "studentFk" => $enrollment['student_fk'],
-                        "classroomFk" => $classId,
-                        "schoolInepIdFk" => $inepId
-                    ];
-
-                    $modality = $enrollment['modality'];
-                    //3 - EJA
-                    if ($modality === 3) {
-                        $educationLevel = (int) $this->getStageById($enrollment['edcenso_stage_vs_modality_fk']);
-                        $age = $this->calculateAge($birthdate);
-                        $this->checkAge($age, $educationLevel, $arrayStudentInfo);
-                    }
-
-                    $this->isNullStudentType($studentType, $school, $enrollment, $classId);
-
-                }
-            } else {
-                $studentType = new AlunoTType();
-                $convertedBirthdate = $this->convertBirthdate($enrollment['birthdate']);
-
-                if (!empty($cpf)) {
-                    $studentType
-                        ->setNome($enrollment['name'])
-                        ->setDataNascimento(DateTime::createFromFormat(DATE_FORMAT, $convertedBirthdate))
-                        ->setCpfAluno($cpf)
-                        ->setPcd($enrollment['deficiency'])
-                        ->setSexo($enrollment['gender']);
-
-                    $this->studentValidation($studentType, $schoolName, $cpf, $classId, $enrollment, $strlen);
-                } else {
-                    $studentType
-                        ->setNome($enrollment['name'])
-                        ->setDataNascimento(DateTime::createFromFormat(DATE_FORMAT, $convertedBirthdate))
-                        ->setJustSemCpf($enrollment['cpf_reason'])
-                        ->setPcd($enrollment['deficiency'])
-                        ->setSexo($enrollment['gender']);
-
-                    $this->studentValidationWhioutCpf($studentType, $schoolName, $enrollment['cpf_reason'], $classId, $enrollment, $strlen);
-                }
-
-                $this->isNullStudentType($studentType, $school, $enrollment, $classId);
-
-            }
+            $studentType = $this->generateStudentType( $withoutCpf, $convertedBirthdate,$enrollment,$cpf);
 
             $enrollmentType = new MatriculaTType();
             $enrollmentType
@@ -1839,13 +1751,88 @@ class SagresConsultModel
                 ->setAluno($studentType)
                 ->setEnrollmentStage($enrollment['enrollment_stage']);
 
-            $this->matriculaValidation($enrollment, $enrollmentType, $studentType, $school->name, $classId, $finalClass);
+            $this->matriculaValidation($enrollment, $enrollmentType, $studentType, $schoolName, $classId, $finalClass);
+            $this->checkSingleStudentWithoutCpf($enrollments, $cpf, $classId, $referenceYear, $schoolName, $inepId);
 
             $enrollmentList[] = $enrollmentType;
 
         }
 
         return $enrollmentList;
+    }
+
+    private function generateStudentType ($withoutCpf,$convertedBirthdate,$enrollment,$cpf){
+
+        return $withoutCpf
+            ? $this->studentTypeCaseWithoutCpf($convertedBirthdate, $enrollment, $cpf)
+            : $this->studentTypeCaseWithCpf($enrollment, $convertedBirthdate, $cpf);
+;
+    }
+
+    private function studentTypeCaseWithCpf($enrollment,$convertedBirthdate,$cpf){
+        $birthdate = DateTime::createFromFormat(DATE_FORMAT, $convertedBirthdate);
+        $strlen = 5;
+        $schoolName = $enrollment['school_name'];
+        $classId = $enrollment['class_id'];
+
+        $studentType = new AlunoTType();
+        $studentType
+            ->setNome($enrollment['name'])
+            ->setDataNascimento($birthdate)
+            ->setPcd($enrollment['deficiency'])
+            ->setSexo($enrollment['gender']);
+
+        if (!empty($cpf)) {
+            $studentType->setCpfAluno($cpf);
+            $this->studentValidation($studentType, $schoolName, $cpf, $classId, $enrollment, $strlen);
+        } else {
+            $studentType->setJustSemCpf($enrollment['cpf_reason']);
+            $this->studentValidationWhioutCpf($studentType, $schoolName, $enrollment['cpf_reason'], $classId, $enrollment, $strlen);
+        }
+
+        $this->checkStudentModality($enrollment, $convertedBirthdate);
+        $this->isNullStudentType($studentType, $schoolName, $enrollment, $classId);
+        return $studentType;
+    }
+    private function studentTypeCaseWithoutCpf($convertedBirthdate,$enrollment,$cpf){
+        $strlen = 5;
+        $schoolName = $enrollment['school_name'];
+        $classId = $enrollment['class_id'];
+        $birthdate = DateTime::createFromFormat(DATE_FORMAT, $convertedBirthdate);
+        $studentType = new AlunoTType();
+        $studentType
+            ->setNome($enrollment['name'])
+            ->setDataNascimento($birthdate)
+            ->setPcd($enrollment['deficiency'])
+            ->setSexo($enrollment['gender']);
+
+        if (!empty($cpf)) {
+            $studentType->setCpfAluno($cpf);
+            $this->studentValidation($studentType, $schoolName, $cpf, $classId, $enrollment, $strlen);
+        } else {
+            $studentType->setJustSemCpf($enrollment['cpf_reason']);
+            $this->studentValidationWhioutCpf($studentType, $schoolName, $enrollment['cpf_reason'], $classId, $enrollment, $strlen);
+        }
+
+        $this->checkStudentModality($enrollment, $convertedBirthdate);
+        $this->isNullStudentType($studentType, $schoolName, $enrollment, $classId);
+        return $studentType;
+    }
+
+    private function checkStudentModality ($enrollment,$birthdate){
+        $arrayStudentInfo = [
+            "studentFk" => $enrollment['student_fk'],
+            "classroomFk" =>$enrollment['class_id'],
+            "schoolInepIdFk" => $enrollment['inep_id']
+        ];
+        $modality = $enrollment['modality'];
+        //3 - EJA
+        if ($modality === 3) {
+            $educationLevel = (int) $this->getStageById($enrollment['edcenso_stage_vs_modality_fk']);
+            $age = $this->calculateAge($birthdate);
+            $this->checkAge($age, $educationLevel, $arrayStudentInfo);
+        }
+
     }
 
     private function getStudentCpf($enrollment)


### PR DESCRIPTION
## 🚀 Motivação
Muribeca relatou um problema com alunos durante a etapa de validação do status de ausência de CPF, em que estudantes com CPF estavam sendo exibidos com o campo justSemCpf igual a 0 — valor que indica ausência não justificada. Esse campo, no entanto, deveria aparecer apenas para alunos sem CPF cadastrado.
## 🔧 Alterações Realizadas
Após análise do problema, foram observados dois pontos principais:  
- A evidência enviada se referia a alunos que, de fato, não possuíam CPF cadastrado;  
- O método de montagem do documento apresentava código repetido e interações desnecessárias.

Com isso, foram realizadas as seguintes melhorias:  
- Separação da lógica de montagem do objeto do estudante em uma função dedicada;  
- Adição de uma validação extra para verificar corretamente a ausência de CPF.

## 🛠️ Fluxo de Teste

🧪 Fluxo de Teste 1 (FT1):
```
1. Vá em Sagres nas Integrações ;
2. Remova a opção de exclusão de alunos sem CPF;
3. Selecione o mês de Julho;
4. Gere o documento;
5. Baixe o zip;
6. Abra o zip em um editor de código;
7. Faça uma busca pela tag <justSemCpf> com o valor 0 Ex:"<justSemCpf>0"
8. Verifique se quando essa tag existir não exite cpf no registro do Aluno
```
✅ Sucesso: 
 - Não existe tag <justSemCpf> e <cpf> no mesmo registro de aluno
❌ Falha: 
 - Existe tag <justSemCpf> e <cpf> no mesmo registro de aluno

## ✨ Migrations Utilizadas

## ✔️ Checklist - Padrões para PR
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?

### Documentação 
Houve alteração nos fluxo de uso? 
*(Lembrete: Em caso afirmativo, adicionar label Atualização de manual)*
- [ ] Sim   
- [ ] Não
