### PR TITLE
Fix/tcda 1237

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.13.23]
+- Corrigida a "Média da Unidade" exibida na tela de Notas, que em algumas turmas/disciplinas aparecia na linha do período errado (ex.: a média do 1º Período mostrava, na verdade, a média do 2º Período). O valor calculado e salvo sempre esteve correto; o problema era de leitura, causado pela unidade de Recuperação Final sendo contada na numeração dos períodos quando criada antes deles na estrutura de notas
+
 ## [Versão 3.13.22]
 - Corrigida duplicidade de itens no Lançamento de Estoque da Merenda Escolar: o botão "Adicionar ao estoque" agora trava durante o processamento (com indicador de carregamento sobre o modal), evitando que múltiplos cliques disparem o mesmo lançamento mais de uma vez. O salvamento no backend passou a rodar em transação e interrompe imediatamente se algum item falhar, em vez de continuar processando os demais
 

--- a/app/domain/grades/usecases/GetStudentGradesByDisciplineUsecase.php
+++ b/app/domain/grades/usecases/GetStudentGradesByDisciplineUsecase.php
@@ -58,7 +58,22 @@ class GetStudentGradesByDisciplineUsecase
         });
         $unitiesByDiscipline = array_values($unitiesByDiscipline);
 
-        $unityOrder = $this->searchUnityById($unitiesByDisciplineResult);
+        // grade_results.grade_N is written by CalculateNumericGradeUsecase using the
+        // index of this same unit within GetGradeUnitiesByDisciplineUsecase's result,
+        // which only includes TYPE_UNITY/TYPE_UNITY_BY_CONCEPT/TYPE_UNITY_WITH_RECOVERY
+        // (it excludes TYPE_FINAL_RECOVERY). getGradeUnitiesByDiscipline() below returns
+        // every unity type with no such filter, so when a TYPE_FINAL_RECOVERY unity sorts
+        // before the requested one by id, searchUnityById() returns an index one higher
+        // than the write side used — reading the next unit's cached average instead of
+        // this one's. Excluding the same types here keeps both indices in sync.
+        $unitiesForOrder = array_values(array_filter($unitiesByDisciplineResult, function ($unity) {
+            return in_array($unity->type, [
+                GradeUnity::TYPE_UNITY,
+                GradeUnity::TYPE_UNITY_BY_CONCEPT,
+                GradeUnity::TYPE_UNITY_WITH_RECOVERY,
+            ], true);
+        }));
+        $unityOrder = $this->searchUnityById($unitiesForOrder);
 
         if ($studentEnrollments == []) {
             throw new NoActiveStudentsException();

--- a/config.php
+++ b/config.php
@@ -8,7 +8,7 @@ defined('YII_DEBUG') or define('YII_DEBUG', $debug ?? false);
 // Sessão (1h por padrão)
 defined('SESSION_MAX_LIFETIME') or define('SESSION_MAX_LIFETIME', 3600);
 
-define("TAG_VERSION", '3.13.22');
+define("TAG_VERSION", '3.13.23');
 
 $buildConfig = require __DIR__ . '/app/config/build.php';
 defined('TAG_BUILD_COMMIT') or define('TAG_BUILD_COMMIT', isset($buildConfig['commit']) ? (string) $buildConfig['commit'] : '');

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1809,19 +1809,19 @@ parameters:
 		-
 			message: '#^Access to constant TYPE_UNITY on an unknown class GradeUnity\.$#'
 			identifier: class.notFound
-			count: 1
+			count: 2
 			path: app/domain/grades/usecases/GetStudentGradesByDisciplineUsecase.php
 
 		-
 			message: '#^Access to constant TYPE_UNITY_BY_CONCEPT on an unknown class GradeUnity\.$#'
 			identifier: class.notFound
-			count: 1
+			count: 2
 			path: app/domain/grades/usecases/GetStudentGradesByDisciplineUsecase.php
 
 		-
 			message: '#^Access to constant TYPE_UNITY_WITH_RECOVERY on an unknown class GradeUnity\.$#'
 			identifier: class.notFound
-			count: 2
+			count: 3
 			path: app/domain/grades/usecases/GetStudentGradesByDisciplineUsecase.php
 
 		-
@@ -1953,7 +1953,7 @@ parameters:
 		-
 			message: '#^Access to property \$type on an unknown class GradeUnity\.$#'
 			identifier: class.notFound
-			count: 3
+			count: 4
 			path: app/domain/grades/usecases/GetStudentGradesByDisciplineUsecase.php
 
 		-


### PR DESCRIPTION
## 🚀 Motivação
Em algumas turmas/disciplinas, a tela de Notas (`?r=grades/grades`) exibia a "Média da Unidade" na linha do período errado — por exemplo, a linha do 1º Período mostrava um valor que na verdade era a média do 2º Período. O valor calculado e salvo no banco sempre esteve correto (`grade_results.grade_N`); o problema era de leitura: o código que decide qual coluna `grade_N` mostrar para cada período contava a unidade de "Recuperação Final" junto com os períodos, enquanto o código que calcula e grava esses valores já a exclui dessa contagem. Quando a Recuperação Final tem `id` menor que as unidades de período (comum, já que costuma ser criada primeiro na estrutura de notas), a leitura ficava deslocada uma posição à frente.

## 🔧 Alterações Realizadas
- `GetStudentGradesByDisciplineUsecase::exec()` agora exclui a unidade de Recuperação Final (`GradeUnity::TYPE_FINAL_RECOVERY`) da lista usada para calcular o índice de leitura de `grade_results.grade_N`, alinhando com o filtro já usado por `GetGradeUnitiesByDisciplineUsecase` no lado que calcula/grava.
- Sem mudança de fórmula de cálculo — a correção é só de indexação/leitura.

## 📌 Requisitos
Nenhum. Não há migration nem alteração de configuração — a correção é puramente de leitura, então os valores já salvos aparecem certos assim que o deploy for feito, sem precisar recalcular notas.

## 🛠️ Fluxo de Teste

🧪 Fluxo de Teste 1 (FT1):
Acessar Diário Eletrônico > Notas em uma turma/disciplina cuja estrutura de notas tenha Recuperação Final configurada
Selecionar cada período (Unidade) e conferir a "Média da Unidade" exibida
Comparar manualmente com a média das notas visíveis na própria linha (considerando o modelo de cálculo configurado, ex.: média + recuperação da unidade)

✅ Sucesso: a média exibida em cada período corresponde às notas daquele mesmo período (não do período seguinte)
❌ Falha: alguma linha ainda mostra a média de outro período

## ✨ Migrations Utilizadas
Nenhuma

## ✔️ Checklist - Padrões para PR
- [x] O número da versão foi alterado no arquivo `config.php`? (3.13.22 → 3.13.23)
- [x] Foi adicionada uma descrição das alterações no arquivo de `CHANGELOG`?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?

### Documentação
Houve alteração nos fluxo de uso?
- [ ] Sim
- [x] Não (correção de bug de exibição, sem mudança de fluxo)