### PR TITLE
Feat/tcda 1238

### DIFF
--- a/app/migrations/3.14.22/add_macete_lesson_plan_code.sql
+++ b/app/migrations/3.14.22/add_macete_lesson_plan_code.sql
@@ -1,0 +1,22 @@
+-- =============================================================================
+-- TAG Migration v3.14.22 - MACETE lesson plan code
+-- =============================================================================
+-- Adds an alphanumeric code to macete_lesson_plan so a plan/template can be
+-- searched by code from the listing screen (same idea as the BNCC code search).
+-- Idempotent: safe to run on installations where the column already exists.
+
+SET @macete_lesson_plan_code_exists := (
+    SELECT COUNT(*)
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'macete_lesson_plan'
+        AND COLUMN_NAME = 'code'
+);
+SET @macete_lesson_plan_code_sql := IF(
+    @macete_lesson_plan_code_exists = 0,
+    'ALTER TABLE `macete_lesson_plan` ADD COLUMN `code` VARCHAR(50) NULL AFTER `name`, ADD KEY `idx_macete_lesson_plan_code` (`code`)',
+    'SELECT 1'
+);
+PREPARE macete_lesson_plan_code_statement FROM @macete_lesson_plan_code_sql;
+EXECUTE macete_lesson_plan_code_statement;
+DEALLOCATE PREPARE macete_lesson_plan_code_statement;

--- a/app/migrations/3.14.22/add_macete_lesson_plan_code.sql
+++ b/app/migrations/3.14.22/add_macete_lesson_plan_code.sql
@@ -19,4 +19,7 @@ SET @macete_lesson_plan_code_sql := IF(
 );
 PREPARE macete_lesson_plan_code_statement FROM @macete_lesson_plan_code_sql;
 EXECUTE macete_lesson_plan_code_statement;
-DEALLOCATE PREPARE macete_lesson_plan_code_statement;
+-- No DEALLOCATE PREPARE: MySQL releases it automatically when the session ends,
+-- and explicitly deallocating here fails with "Unknown prepared statement handler"
+-- on tools/pools that don't guarantee PREPARE and this statement run on the same
+-- connection (observed when running this script manually against production).

--- a/app/modules/macete/models/MaceteLessonPlan.php
+++ b/app/modules/macete/models/MaceteLessonPlan.php
@@ -5,6 +5,7 @@
  *
  * @property integer $id
  * @property string $name
+ * @property string $code
  * @property string $theme
  * @property string $school_inep_fk
  * @property integer $classroom_fk
@@ -52,12 +53,13 @@ class MaceteLessonPlan extends TagModel
             ['name, theme, school_inep_fk, edcenso_stage_vs_modality_fk, users_fk, school_year, status', 'required'],
             ['classroom_fk, edcenso_stage_vs_modality_fk, edcenso_discipline_fk, users_fk, school_year', 'numerical', 'integerOnly' => true],
             ['name', 'length', 'max' => 150],
+            ['code', 'length', 'max' => 50],
             ['theme', 'length', 'max' => 255],
             ['school_inep_fk', 'length', 'max' => 8],
             ['unit', 'length', 'max' => 50],
             ['status', 'length', 'max' => 20],
-            ['territory_context, knowledge_object, evaluation, references_text, created_at, updated_at', 'safe'],
-            ['id, name, theme, school_inep_fk, classroom_fk, edcenso_stage_vs_modality_fk, edcenso_discipline_fk, users_fk, school_year, unit, territory_context, knowledge_object, evaluation, references_text, status, created_at, updated_at', 'safe', 'on' => 'search'],
+            ['code, territory_context, knowledge_object, evaluation, references_text, created_at, updated_at', 'safe'],
+            ['id, name, code, theme, school_inep_fk, classroom_fk, edcenso_stage_vs_modality_fk, edcenso_discipline_fk, users_fk, school_year, unit, territory_context, knowledge_object, evaluation, references_text, status, created_at, updated_at', 'safe', 'on' => 'search'],
         ];
     }
 
@@ -82,7 +84,8 @@ class MaceteLessonPlan extends TagModel
     {
         return [
             'id' => 'ID',
-            'name' => 'Nome',
+            'name' => 'Título do Plano',
+            'code' => 'Código do plano',
             'theme' => 'Tema da aula',
             'school_inep_fk' => 'Escola',
             'classroom_fk' => 'Turma',
@@ -107,6 +110,7 @@ class MaceteLessonPlan extends TagModel
 
         $criteria->compare('id', $this->id);
         $criteria->compare('name', $this->name, true);
+        $criteria->compare('code', $this->code, true);
         $criteria->compare('theme', $this->theme, true);
         $criteria->compare('school_inep_fk', $this->school_inep_fk, true);
         $criteria->compare('classroom_fk', $this->classroom_fk);

--- a/app/modules/macete/models/MaceteLessonPlanResource.php
+++ b/app/modules/macete/models/MaceteLessonPlanResource.php
@@ -68,6 +68,40 @@ class MaceteLessonPlanResource extends TagModel
         ];
     }
 
+    public static function maceteBoxItems(): array
+    {
+        return [
+            'Giz de cera',
+            'Lápis de cor',
+            'Tinta guache',
+            'Barbante',
+            'Fita adesiva colorida',
+            'Fita adesiva transparente',
+            'Fita crepe',
+            'Grampo',
+            'Papel fotográfico',
+            'Papel Opaline',
+            'Apontador',
+            'Borracha',
+            'Caixa de lápis',
+            'Cortador circular',
+            'Estilete',
+            'Kit escolar de réguas',
+            'Piloto de quadro',
+            'Pincel fino',
+            'Régua 30 cm',
+            'Tesoura',
+            'Balança',
+            'Cola branca',
+            'Cola de isopor',
+            'Lupa',
+            'Pistola de cola quente',
+            'Régua geométrica',
+            'Saco de elástico',
+            'Pranchet',
+        ];
+    }
+
     public static function model($className = __CLASS__)
     {
         return parent::model($className);

--- a/app/modules/macete/resources/macete.js
+++ b/app/modules/macete/resources/macete.js
@@ -6,16 +6,54 @@
     };
 
     window.Macete.initTabs = function () {
-        $(document).on("click", ".js-macete-tab-link", function (event) {
-            event.preventDefault();
+        var tabOrder = $(".js-macete-tab-link").map(function () {
+            return $(this).attr("href");
+        }).get();
 
-            var target = $(this).attr("href");
+        function currentTab() {
+            return $(".js-macete-tab-link").closest(".t-tabs__item.active").find(".js-macete-tab-link").attr("href");
+        }
+
+        function activateTab(target) {
+            var link = $(".js-macete-tab-link[href='" + target + "']");
             $(".js-macete-tab-link").closest(".t-tabs__item").removeClass("active");
-            $(this).closest(".t-tabs__item").addClass("active");
+            link.closest(".t-tabs__item").addClass("active");
 
             $(".js-macete-tab-panel").addClass("hide");
             $(target).removeClass("hide");
+
+            var index = tabOrder.indexOf(target);
+            var isFirstTab = index === 0;
+            var isLastTab = index === tabOrder.length - 1;
+            $(".js-macete-prev").toggleClass("hide", isFirstTab);
+            $(".js-macete-next").toggleClass("hide", isLastTab);
+            $(".js-macete-save").toggleClass("hide", !isLastTab);
+        }
+
+        $(document).on("click", ".js-macete-tab-link", function (event) {
+            event.preventDefault();
+            activateTab($(this).attr("href"));
         });
+
+        $(document).on("click", ".js-macete-next", function (event) {
+            event.preventDefault();
+            var index = tabOrder.indexOf(currentTab());
+            if (index > -1 && index < tabOrder.length - 1) {
+                activateTab(tabOrder[index + 1]);
+            }
+        });
+
+        $(document).on("click", ".js-macete-prev", function (event) {
+            event.preventDefault();
+            var index = tabOrder.indexOf(currentTab());
+            if (index > 0) {
+                activateTab(tabOrder[index - 1]);
+            }
+        });
+
+        if (tabOrder.length) {
+            activateTab(tabOrder[0]);
+        }
     };
 
     window.Macete.initAbilitySelector = function () {

--- a/app/modules/macete/services/MaceteLessonPlanService.php
+++ b/app/modules/macete/services/MaceteLessonPlanService.php
@@ -266,6 +266,7 @@ class MaceteLessonPlanService
     {
         $allowedAttributes = [
             'name',
+            'code',
             'theme',
             'classroom_fk',
             'unit',
@@ -426,6 +427,10 @@ class MaceteLessonPlanService
         );
 
         foreach ($resources as $type => $description) {
+            if (is_array($description)) {
+                $description = implode(', ', array_filter(array_map('trim', $description), static fn (string $item): bool => $item !== ''));
+            }
+
             $description = MaceteRichTextSanitizer::sanitize((string) $description);
             if ($description === '') {
                 continue;

--- a/app/modules/macete/views/lessonsplan/_form.php
+++ b/app/modules/macete/views/lessonsplan/_form.php
@@ -52,15 +52,15 @@ $selectedAbilitiesCount = count($selectedAbilities);
             <h1><?php echo $lessonPlan->isNewRecord ? 'Novo Plano MACETE' : 'Editar Plano MACETE'; ?></h1>
         </div>
         <div class="column clearfix align-items--center justify-content--end show--desktop">
-            <a class="t-button-secondary"
-                href="<?php echo MaceteRoutes::url(MaceteRoutes::LESSONSPLAN_INDEX); ?>">Voltar</a>
+            <button type="button" class="t-button-secondary js-macete-prev hide">Voltar</button>
             <?php if (!$lessonPlan->isNewRecord): ?>
                 <a class="t-button-secondary"
                     href="<?php echo MaceteRoutes::url(MaceteRoutes::LESSONSRECORD_CREATE, ['lessonPlanId' => $lessonPlan->id]); ?>">
                     Registrar aula
                 </a>
             <?php endif; ?>
-            <button class="t-button-primary" type="submit">Salvar</button>
+            <button type="button" class="t-button-primary js-macete-next">Próximo</button>
+            <button class="t-button-primary js-macete-save hide" type="submit">Salvar</button>
         </div>
     </div>
 
@@ -104,7 +104,7 @@ $selectedAbilitiesCount = count($selectedAbilities);
                 <div id="macete-identification" class="js-macete-tab-panel">
 
                     <div class="row">
-                        <div class="column is-two-fifths">
+                        <div class="column is-half clearleft">
                             <div class="t-field-text">
                                 <?php echo $form->label($lessonPlan, 'name', ['class' => 't-field-text__label--required']); ?>
                                 <?php echo $form->textField($lessonPlan, 'name', [
@@ -115,7 +115,21 @@ $selectedAbilitiesCount = count($selectedAbilities);
                                 <?php echo $form->error($lessonPlan, 'name'); ?>
                             </div>
                         </div>
-                        <div class="column is-two-fifths">
+                        <div class="column is-half">
+                            <div class="t-field-text">
+                                <?php echo $form->label($lessonPlan, 'code', ['class' => 't-field-text__label']); ?>
+                                <?php echo $form->textField($lessonPlan, 'code', [
+                                    'class' => 't-field-text__input',
+                                    'maxlength' => 50,
+                                    'placeholder' => 'Ex.: MAT-001',
+                                ]); ?>
+                                <?php echo $form->error($lessonPlan, 'code'); ?>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="column is-half clearleft">
                             <div class="t-field-text">
                                 <?php echo $form->labelEx($lessonPlan, 'unit', ['class' => 't-field-text__label']); ?>
                                 <?php echo $form->textField($lessonPlan, 'unit', [
@@ -126,7 +140,7 @@ $selectedAbilitiesCount = count($selectedAbilities);
                                 <?php echo $form->error($lessonPlan, 'unit'); ?>
                             </div>
                         </div>
-                        <div class="column is-one-fifth">
+                        <div class="column is-half">
                             <div class="t-field-select">
                                 <?php echo $form->label($lessonPlan, 'status', ['class' => 't-field-select__label--required']); ?>
                                 <?php echo $form->dropDownList(
@@ -367,12 +381,21 @@ $selectedAbilitiesCount = count($selectedAbilities);
                     </div>
                     <div class="row">
                         <div class="column">
-                            <div class="t-field-tarea">
-                                <label class="t-field-tarea__label">Caixa MACETE</label>
-                                <?php echo CHtml::textArea(
-                                    'resources[' . MaceteLessonPlanResource::TYPE_MACETE_BOX . ']',
-                                    $resourceValue(MaceteLessonPlanResource::TYPE_MACETE_BOX),
-                                    ['class' => 't-field-tarea__input', 'rows' => 6, 'placeholder' => 'Liste os materiais da caixa MACETE usados na aula.']
+                            <div class="t-field-select">
+                                <label class="t-field-select__label">Caixa MACETE</label>
+                                <?php
+                                $maceteBoxValue = $resourceValue(MaceteLessonPlanResource::TYPE_MACETE_BOX);
+                                $maceteBoxSelected = $maceteBoxValue !== '' ? array_map('trim', explode(',', $maceteBoxValue)) : [];
+                                ?>
+                                <?php echo CHtml::dropDownList(
+                                    'resources[' . MaceteLessonPlanResource::TYPE_MACETE_BOX . '][]',
+                                    $maceteBoxSelected,
+                                    array_combine(MaceteLessonPlanResource::maceteBoxItems(), MaceteLessonPlanResource::maceteBoxItems()),
+                                    [
+                                        'class' => 'select-search-on t-multiselect t-field-select__input select2-container',
+                                        'multiple' => 'multiple',
+                                        'placeholder' => 'Selecione os materiais usados na aula',
+                                    ]
                                 ); ?>
                             </div>
                         </div>
@@ -570,9 +593,9 @@ $selectedAbilitiesCount = count($selectedAbilities);
 
     <div class="row reverse show--tablet">
         <div class="t-buttons-container">
-            <a class="t-button-secondary"
-                href="<?php echo MaceteRoutes::url(MaceteRoutes::LESSONSPLAN_INDEX); ?>">Voltar</a>
-            <button class="t-button-primary" type="submit">Salvar</button>
+            <button type="button" class="t-button-secondary js-macete-prev hide">Voltar</button>
+            <button type="button" class="t-button-primary js-macete-next">Próximo</button>
+            <button class="t-button-primary js-macete-save hide" type="submit">Salvar</button>
         </div>
     </div>
 </div>

--- a/app/modules/macete/views/lessonsplan/index.php
+++ b/app/modules/macete/views/lessonsplan/index.php
@@ -89,13 +89,19 @@ $this->setPageTitle('TAG - Planos MACETE');
                             'name' => 'name',
                             'type' => 'raw',
                             'value' => 'CHtml::link(CHtml::encode($data->name), MaceteRoutes::url(MaceteRoutes::LESSONSPLAN_UPDATE, ["id" => $data->id]))',
-                            'htmlOptions' => ['width' => '20%', 'class' => 'link-update-grid-view'],
+                            'htmlOptions' => ['width' => '18%', 'class' => 'link-update-grid-view'],
+                        ],
+                        [
+                            'header' => 'Código',
+                            'name' => 'code',
+                            'value' => 'CHtml::encode($data->code)',
+                            'htmlOptions' => ['width' => '8%'],
                         ],
                         [
                             'header' => 'Tema',
                             'name' => 'theme',
                             'value' => '$data->theme',
-                            'htmlOptions' => ['width' => '22%'],
+                            'htmlOptions' => ['width' => '18%'],
                         ],
                         [
                             'header' => 'Professor',


### PR DESCRIPTION
## 🚀 Motivação
Ajustes solicitados após revisão do formulário de plano de aula MACETE: a navegação entre abas não seguia o padrão de wizard já usado em outros formulários do TAG (Voltar/Próximo/Salvar), a "Caixa MACETE" era um campo de texto livre sem lista padronizada, faltava um jeito de localizar planos/modelos por código, e havia desalinhamento nos campos da aba Identificação.

## 🔧 Alterações Realizadas
- Voltar/Próximo agora navegam entre as abas do formulário (Identificação → Metodologia → Complementar), como nos demais wizards do TAG; "Salvar" só aparece na última aba; "Voltar" fica oculto na primeira aba (não há para onde voltar).
- Novo campo alfanumérico "Código do plano", para localizar modelos de plano (mesma lógica da busca de habilidades BNCC). Coluna "Código" adicionada na listagem.
- Campo "Nome" renomeado para "Título do Plano".
- "Caixa MACETE" agora é um multi-select com a lista fixa de 28 materiais, usando a classe `t-multiselect` do design system (chips azuis, padrão TAG) em vez de texto livre.
- Campos da aba Identificação reorganizados em duas colunas (Título do Plano + Código; Unidade + Status).
- Removido o filtro dedicado de "Código" na listagem — a tabela já tem busca nativa (DataTables), então bastava manter a coluna visível.

## 📌 Requisitos
- Rodar a migration `app/migrations/3.14.22/add_macete_lesson_plan_code.sql` em qualquer banco onde o módulo MACETE já esteja instalado.

## 🛠️ Fluxo de Teste

🧪 Fluxo de Teste 1 (FT1) — Navegação por abas:
```
1. Acessar "Novo Plano MACETE".
2. Na aba 1 (Identificação), confirmar que só aparece "Próximo".
3. Clicar em "Próximo" até a aba 3 (Complementar) e confirmar que só aparecem "Voltar" e "Salvar".
4. Clicar em "Voltar" e confirmar que retorna para a aba 2 (Metodologia).
```
✅ Sucesso: navegação segue o padrão wizard, sem sair do formulário.
❌ Falha: algum botão aparece fora da aba esperada, ou "Voltar" navega para a listagem.

🧪 Fluxo de Teste 2 (FT2) — Caixa MACETE e código do plano:
```
1. Na aba Complementar, selecionar 2-3 itens da Caixa MACETE.
2. Confirmar que os itens selecionados aparecem como chips azuis (padrão TAG), não como tags genéricas do select2.
3. Preencher "Código do plano" na aba Identificação e salvar.
4. Reabrir o plano e confirmar que o código e os itens da Caixa MACETE persistiram.
```
✅ Sucesso: chips com estilo TAG e dados persistidos corretamente.
❌ Falha: estilo genérico do select2 ou dados não salvos/recuperados.

## ✨ Migrations Utilizadas
- `app/migrations/3.14.22/add_macete_lesson_plan_code.sql`

## ✔️ Checklist - Padrões para PR
- [ ] O número da versão foi alterado no arquivo `config.php`?
- [ ] Foi adicionada uma descrição das alterações no arquivo de `CHANGELOG`?
- [ ] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?

### Documentação
Houve alteração nos fluxo de uso?
- [x] Sim
- [ ] Não