### PR TITLE
Fix/tcda 1241

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.13.24]
+- Corrigido falso positivo na inconsistência "Turmas multiseriadas apenas aceitam 3 etapas de ensino diferentes" do Sagres: turmas AEE contavam a Etapa Individual de matrículas CANCELADO/TRANSFERIDO (e outros status não ativos) ao verificar a quantidade de etapas da turma, gerando erro mesmo quando os alunos com matrícula ativa respeitavam o limite de 3 etapas
+
 ## [Versão 3.13.23]
 - Corrigida a "Média da Unidade" exibida na tela de Notas, que em algumas turmas/disciplinas aparecia na linha do período errado (ex.: a média do 1º Período mostrava, na verdade, a média do 2º Período). O valor calculado e salvo sempre esteve correto; o problema era de leitura, causado pela unidade de Recuperação Final sendo contada na numeração dos períodos quando criada antes deles na estrutura de notas
 

--- a/app/modules/sagres/models/SagresConsultModel.php
+++ b/app/modules/sagres/models/SagresConsultModel.php
@@ -1096,6 +1096,7 @@ class SagresConsultModel
         JOIN  edcenso_stage_vs_modality esvm on esvm.id = se.edcenso_stage_vs_modality_fk
         WHERE
             c.id = :id
+        And (se.status = 1 or se.status is null)
         And esvm.edcenso_associated_stage_id is not NULL
         GROUP by se.edcenso_stage_vs_modality_fk'
             :

--- a/config.php
+++ b/config.php
@@ -8,7 +8,7 @@ defined('YII_DEBUG') or define('YII_DEBUG', $debug ?? false);
 // Sessão (1h por padrão)
 defined('SESSION_MAX_LIFETIME') or define('SESSION_MAX_LIFETIME', 3600);
 
-define("TAG_VERSION", '3.13.23');
+define("TAG_VERSION", '3.13.24');
 
 $buildConfig = require __DIR__ . '/app/config/build.php';
 defined('TAG_BUILD_COMMIT') or define('TAG_BUILD_COMMIT', isset($buildConfig['commit']) ? (string) $buildConfig['commit'] : '');


### PR DESCRIPTION
## 🚀 Motivação
Foi relatado que o Sagres reporta a inconsistência "Turmas multiseriadas apenas aceitam 3 etapas de ensino diferentes" em turmas AEE mesmo quando a turma tem, de fato, no máximo 3 etapas entre os alunos com matrícula ativa. O erro aparecia porque alunos com matrícula CANCELADA (ou outros status não-ativos) continuavam sendo contados na verificação da quantidade de etapas, inflando o total.

## 🔧 Alterações Realizadas
- Ajustada a query de `getSeriesQuery()` (ramo de turmas multisseriadas/AEE) em `SagresConsultModel.php` para considerar apenas matrículas com `status = 1` (MATRICULADO) ou `status IS NULL` ao contar etapas de ensino distintas na turma — mesmo critério já usado em `getCountOfClassrooms()` no mesmo arquivo.
- Nenhuma mudança de schema; só lógica de consulta.

## 📌 Requisitos
Nenhum. Não há migration nem configuração adicional.

## 🛠️ Fluxo de Teste

🧪 Fluxo de Teste 1 (FT1):
```

1. Localizar (ou montar) uma turma AEE/multisseriada com alunos ativos em até 3 etapas de ensino diferentes, e mais um aluno com matrícula CANCELADA (ou TRANSFERIDO) em uma 4ª etapa distinta.
2. Rodar a consulta/validação do Sagres para essa turma (tela de Inconsistências do módulo Sagres).
3. Confirmar que a inconsistência "Turmas multiseriadas apenas aceitam 3 etapas de ensino diferentes" NÃO é mais gerada para essa turma.
4. Alterar a matrícula cancelada de volta para MATRICULADO e confirmar que a inconsistência volta a aparecer (validando que turmas com >3 etapas ativas continuam sendo corretamente sinalizadas).

```
✅ Sucesso: inconsistência não aparece quando a 4ª etapa pertence só a uma matrícula inativa; volta a aparecer se a matrícula for reativada.
❌ Falha: inconsistência continua aparecendo com a matrícula cancelada, ou deixa de aparecer mesmo com 4+ etapas ativas.

## ✨ Migrations Utilizadas
Nenhuma.

## ✔️ Checklist - Padrões para PR
- [x] O número da versão foi alterado no arquivo `config.php`? (3.13.23 → 3.13.24)
- [ ] Foi adicionada uma descrição das alterações no arquivo de `CHANGELOG`?
- [ ] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?

### Documentação
Houve alteração nos fluxo de uso?
- [ ] Sim
- [x] Não