### PR TITLE
fix: impede fusão de lançamentos no estoque da Merenda Escolar (TCDA-…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Versão 3.13.26]
+- Corrigido o Lançamento de Estoque da Merenda Escolar (TCDA-1244): lançar um produto que já tinha estoque não soma mais a quantidade nem sobrescreve fornecedor/validade do lançamento anterior. Cada lançamento agora é tratado como uma entrada independente, mantendo seu próprio fornecedor, validade e quantidade, mesmo sendo o mesmo produto — permitindo múltiplos lotes do mesmo item coexistindo (necessário para controle de validade por lote)
+- Na tela de "Movimentações" do estoque, adicionada a coluna Fornecedor, já que agora cada entrada pode vir de um fornecedor diferente. Corrigido também um bug onde essa tela não filtrava por escola, podendo misturar lançamentos de escolas diferentes que compartilham o mesmo alimento
+
 ## [Versão 3.13.25]
 - Adicionado detalhamento de Alergias Alimentares em Acompanhamento de Saúde → Doenças e Distúrbios: ao marcar "Alergias alimentares", é possível selecionar quais alimentos (Leite, Ovo, Peixe, Crustáceos e molusco, Amendoim, Abacaxi, Castanhas e outras oleaginosas, Soja, Trigo, Gergelim ou Outras, com campo de texto livre)
 - Os alimentos selecionados agora aparecem na Ficha do Aluno e no Relatório de Histórico de Saúde (entre parênteses, ao lado de "Alergias alimentares")

--- a/app/modules/foods/controllers/FoodinventoryController.php
+++ b/app/modules/foods/controllers/FoodinventoryController.php
@@ -104,56 +104,38 @@ class FoodinventoryController extends Controller
 
         try {
             foreach ($foodsOnStock as $foodData) {
-                $existingFood = FoodInventory::model()->findByAttributes(['food_fk' => $foodData['id'], 'school_fk' => Yii::app()->user->school]);
                 $expirationDate = null;
                 if ($foodData['expiration_date'] != '') {
                     $expirationDate = date('Y-m-d', strtotime(str_replace('/', '-', $foodData['expiration_date'])));
                 }
 
-                if (!$existingFood) {
-                    $FoodInventory = new FoodInventory();
+                // Cada lançamento é um lote novo e independente: nunca soma/mescla
+                // num lote já existente do mesmo produto, mesmo que fornecedor e
+                // validade coincidam. Isso preserva o histórico individual de cada
+                // entrada (necessário para controle de validade por lote).
+                $FoodInventory = new FoodInventory();
 
-                    $FoodInventory->food_fk = $foodData['id'];
-                    $FoodInventory->school_fk = Yii::app()->user->school;
-                    $FoodInventory->amount = $foodData['amount'];
-                    $FoodInventory->measurementUnit = $foodData['measurementUnit'];
-                    $FoodInventory->expiration_date = $expirationDate;
-                    $FoodInventory->supplier = $foodData['supplier'] ?? null;
+                $FoodInventory->food_fk = $foodData['id'];
+                $FoodInventory->school_fk = Yii::app()->user->school;
+                $FoodInventory->amount = $foodData['amount'];
+                $FoodInventory->measurementUnit = $foodData['measurementUnit'];
+                $FoodInventory->expiration_date = $expirationDate;
+                $FoodInventory->supplier = $foodData['supplier'] ?? null;
 
-                    if (!$FoodInventory->save()) {
-                        $transaction->rollback();
-                        Yii::app()->request->sendStatusCode(400);
-                        $errors = $FoodInventory->getErrors();
-                        echo json_encode(['error' => 'Ocorreu um erro ao salvar: ' . reset($errors)[0]]);
-                        return;
-                    }
-
-                    $FoodInventoryReceived = new FoodInventoryReceived();
-                    $FoodInventoryReceived->food_fk = $foodData['id'];
-                    $FoodInventoryReceived->food_inventory_fk = $FoodInventory->id;
-                    $FoodInventoryReceived->amount = $foodData['amount'];
-
-                    $FoodInventoryReceived->save();
-                } else {
-                    $FoodInventoryReceived = new FoodInventoryReceived();
-                    $FoodInventoryReceived->food_fk = $foodData['id'];
-                    $FoodInventoryReceived->food_inventory_fk = $existingFood->id;
-                    $FoodInventoryReceived->amount = $foodData['amount'];
-
-                    $FoodInventoryReceived->save();
-
-                    if ($existingFood->measurementUnit == 'Kg' && $foodData['measurementUnit'] == 'g') {
-                        $existingFood->amount += $foodData['amount'] / 1000;
-                    } elseif ($existingFood->measurementUnit == 'g' && $foodData['measurementUnit'] == 'Kg') {
-                        $existingFood->amount += $foodData['amount'] * 1000;
-                    } else {
-                        $existingFood->amount += $foodData['amount'];
-                    }
-                    $existingFood->expiration_date = $expirationDate;
-                    $existingFood->supplier = $foodData['supplier'] ?? null;
-                    $existingFood->status = 'Disponivel';
-                    $existingFood->save();
+                if (!$FoodInventory->save()) {
+                    $transaction->rollback();
+                    Yii::app()->request->sendStatusCode(400);
+                    $errors = $FoodInventory->getErrors();
+                    echo json_encode(['error' => 'Ocorreu um erro ao salvar: ' . reset($errors)[0]]);
+                    return;
                 }
+
+                $FoodInventoryReceived = new FoodInventoryReceived();
+                $FoodInventoryReceived->food_fk = $foodData['id'];
+                $FoodInventoryReceived->food_inventory_fk = $FoodInventory->id;
+                $FoodInventoryReceived->amount = $foodData['amount'];
+
+                $FoodInventoryReceived->save();
             }
 
             $transaction->commit();
@@ -222,12 +204,16 @@ class FoodinventoryController extends Controller
     {
         $foodInventoryFoodId = Yii::app()->request->getPost('foodInventoryFoodId');
 
+        // Histórico consolidado do produto (todos os lotes/fornecedores), não só
+        // de um lote isolado — cada lançamento vira seu próprio lote, então o
+        // fornecedor de cada entrada é exibido para diferenciá-los. Filtra também
+        // pela escola do usuário, já que antes não havia esse filtro de posse.
         $criteria = new CDbCriteria();
         $criteria->select = 'amount, date';
         $criteria->with = ['foodInventoryFk'];
         $criteria->together = true;
-        $criteria->condition = 'foodInventoryFk.food_fk = :foodInventoryFoodId';
-        $criteria->params = [':foodInventoryFoodId' => $foodInventoryFoodId];
+        $criteria->condition = 'foodInventoryFk.food_fk = :foodInventoryFoodId AND foodInventoryFk.school_fk = :schoolFk';
+        $criteria->params = [':foodInventoryFoodId' => $foodInventoryFoodId, ':schoolFk' => Yii::app()->user->school];
 
         $receivedData = FoodInventoryReceived::model()->findAll($criteria);
         $spentData = FoodInventorySpent::model()->findAll($criteria);
@@ -235,10 +221,10 @@ class FoodinventoryController extends Controller
         $values = [];
 
         foreach ($receivedData as $data) {
-            array_push($values, ['type' => 'Entrada', 'amount' => $data->amount, 'date' => date('d/m/Y', strtotime($data->date)), 'measurementUnit' => $data->foodInventoryFk->measurementUnit]);
+            array_push($values, ['type' => 'Entrada', 'amount' => $data->amount, 'date' => date('d/m/Y', strtotime($data->date)), 'measurementUnit' => $data->foodInventoryFk->measurementUnit, 'supplier' => $data->foodInventoryFk->supplier]);
         }
         foreach ($spentData as $data) {
-            array_push($values, ['type' => 'Saída', 'amount' => $data->amount, 'date' => date('d/m/Y', strtotime($data->date)), 'measurementUnit' => $data->foodInventoryFk->measurementUnit]);
+            array_push($values, ['type' => 'Saída', 'amount' => $data->amount, 'date' => date('d/m/Y', strtotime($data->date)), 'measurementUnit' => $data->foodInventoryFk->measurementUnit, 'supplier' => $data->foodInventoryFk->supplier]);
         }
 
         echo json_encode($values);

--- a/app/modules/foods/resources/inventory/functions.js
+++ b/app/modules/foods/resources/inventory/functions.js
@@ -57,7 +57,7 @@ function renderStockTable(foodsOnStock, id, status) {
     let found = false;
 
     $.each(foodsOnStock, function(index, stock) {
-        if ((typeof id === 'undefined' || stock.foodId == id) && 
+        if ((typeof id === 'undefined' || stock.foodId == id) &&
             (typeof status === 'undefined' || stock.status == status)) {
             found = true;
             table.append(renderStockTableRow(stock));
@@ -111,6 +111,7 @@ function renderMovementsTable(movements, foodName) {
     let head = $('<tr>').addClass('');
     $('<th>').text('Tipo').appendTo(head);
     $('<th>').text('Item').appendTo(head);
+    $('<th>').text('Fornecedor').appendTo(head);
     $('<th>').text('Quantidade').appendTo(head);
     $('<th>').text('Data').appendTo(head);
 
@@ -123,6 +124,7 @@ function renderMovementsTable(movements, foodName) {
 
         $('<td class="' + textColor + '">').text(foodInventory.type).appendTo(row);
         $('<td>').text(foodName).appendTo(row);
+        $('<td>').text(foodInventory.supplier || '-').appendTo(row);
         $('<td>').text(foodInventory.amount + measurementUnit).appendTo(row);
         $('<td>').text(foodInventory.date).appendTo(row);
 

--- a/config.php
+++ b/config.php
@@ -8,7 +8,7 @@ defined('YII_DEBUG') or define('YII_DEBUG', $debug ?? false);
 // Sessão (1h por padrão)
 defined('SESSION_MAX_LIFETIME') or define('SESSION_MAX_LIFETIME', 3600);
 
-define("TAG_VERSION", '3.13.25');
+define("TAG_VERSION", '3.13.26');
 
 $buildConfig = require __DIR__ . '/app/config/build.php';
 defined('TAG_BUILD_COMMIT') or define('TAG_BUILD_COMMIT', isset($buildConfig['commit']) ? (string) $buildConfig['commit'] : '');


### PR DESCRIPTION
## 🚀 Motivação
No Lançamento de Estoque da Merenda Escolar, quando o mesmo produto era lançado mais de uma vez, o sistema tratava como atualização do registro anterior: somava a quantidade e sobrescrevia fornecedor/validade com os dados do lançamento mais recente. Exemplo: lançar Arroz Tipo 1 (Fornecedor A, validade 10/10/2026, 100kg) e depois Arroz Tipo 1 (Fornecedor B, validade 20/12/2026, 50kg) resultava em uma única linha de 150kg vinculada ao Fornecedor B — perdendo a informação do primeiro lançamento e inviabilizando o controle de validade por lote.

## 🔧 Alterações Realizadas
- `FoodinventoryController::actionSaveStock()`: removida a lógica de "buscar lançamento existente e mesclar". Cada item enviado agora sempre cria um novo lote (`FoodInventory`), mantendo fornecedor, validade e quantidade próprios. É permitido o mesmo produto ter múltiplos lotes simultâneos, cada um identificado separadamente — inclusive na tabela principal de estoque, que já suportava exibir múltiplas linhas do mesmo produto sem nenhuma mudança necessária.
- `FoodinventoryController::actionGetStockMovement()`: adicionada a coluna **Fornecedor** no histórico de Movimentações (consolidado por produto, mostrando entradas de todos os fornecedores/lotes). Corrigido também um bug pré-existente onde essa consulta não filtrava por escola, podendo misturar lançamentos de escolas diferentes que compartilhem o mesmo alimento.
- Não foi necessária nenhuma migration: não existe (nem nunca existiu ativamente) uma constraint de banco que force uma linha por produto+escola — o "merge" era uma decisão de aplicação.

## 📌 Requisitos
Nenhum. Não há migration nem configuração adicional.

## 🛠️ Fluxo de Teste

🧪 FT1 — Lançamentos do mesmo produto não se fundem:
```
1. Lançar um produto no estoque (ex.: Arroz Tipo 1, Fornecedor A, validade 10/10/2026, 100kg).
2. Lançar o MESMO produto novamente, com fornecedor/validade diferentes (Fornecedor B, 20/12/2026, 50kg).
3. Conferir a tabela de estoque: devem aparecer DUAS linhas de Arroz Tipo 1, cada uma com seu próprio fornecedor e validade — nenhuma quantidade somada/sobrescrita.

```
✅ Sucesso: duas linhas separadas, dados de ambos os lançamentos preservados.
❌ Falha: quantidade somada numa única linha, ou fornecedor/validade sobrescritos.

🧪 FT2 — Movimentações com fornecedor e isolado por escola:
```
Com os dois lançamentos do FT1, clicar em "Movimentações" em qualquer uma das linhas do Arroz Tipo 1.
Confirmar que aparecem as duas entradas (Fornecedor A e Fornecedor B) com a coluna Fornecedor preenchida corretamente para cada uma.
(Se possível) Repetir o mesmo alimento em outra escola e confirmar que as movimentações de uma escola não aparecem na outra.
```
✅ Sucesso: histórico mostra as duas entradas com fornecedor correto, sem misturar escolas.
❌ Falha: fornecedor ausente/errado, ou movimentações de outra escola aparecendo junto.

## ✨ Migrations Utilizadas
Nenhuma.

## ✔️ Checklist - Padrões para PR
- [x] O número da versão foi alterado no arquivo `config.php`? (3.13.25 → 3.13.26)
- [x] Foi adicionada uma descrição das alterações no arquivo de `CHANGELOG`?
- [ ] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?

### Documentação
Houve alteração nos fluxo de uso?
- [x] Sim
- [ ] Não