### PR TITLE
fix: corrige inconsistências não detectadas do Sagres Edu (TCDA-1246)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.13.28]
+- Corrigidas duas inconsistências do validador do Sagres Edu que o Validador SAGRES do TCE detectava e o TAG deixava passar (TCDA-1246): turma marcada como multiseriada com apenas uma etapa de ensino agora gera inconsistência; CPF de aluno com matrícula ativa duplicada em turmas de Educação Infantil ou EJA (modalidades que não eram verificadas pela checagem de duplicidade) também passou a ser sinalizado
+
 ## [Versão 3.13.27]
 - Adicionado alerta de vencimento no Estoque da Merenda Escolar (TCDA-1244): itens cujo lote esteja a poucos dias de vencer (ou já vencido) ganham um destaque "Vence em breve" na coluna Validade, com tooltip informando quantos dias faltam (ou há quantos dias venceu); o alerta não aparece para itens marcados como "Em falta"
 - Adicionado banner no topo da tela de Estoque avisando quando há algum lote próximo do vencimento ou vencido, considerando apenas itens ainda com status "Disponível" ou "Acabando"

--- a/app/modules/sagres/models/SagresConsultModel.php
+++ b/app/modules/sagres/models/SagresConsultModel.php
@@ -395,6 +395,7 @@ class SagresConsultModel
             $infoStudent = $this->getStudentInfo($student['student_fk']);
             $count = $this->getCountOfClassrooms($student, $year);
             $this->checkStudentEnrollment($student['student_fk'], $year, infoStudent: $infoStudent);
+            $this->checkOtherModalityDuplicateEnrollment($student['student_fk'], $year, $infoStudent);
 
             if (!in_array($student['student_fk'], $processedStudents)) {
                 $this->createInconsistencyModel($student, $infoStudent, $count);
@@ -568,6 +569,70 @@ class SagresConsultModel
                 $inconsistencyModel->save();
             }
         }
+    }
+
+    /**
+     * Flags duplicate active enrollments in "regular" classes (not complementary
+     * activity, not AEE) whose modality falls outside the historically hardcoded
+     * set (1, 2, 3) checked in checkStudentEnrollment — e.g. Educação Infantil
+     * (modality 100) or EJA (modality 5). Those combinations are silently ignored
+     * by the modality-literal comparisons above, so a genuinely duplicated
+     * enrollment in those modalities was never reported, even though SAGRES
+     * itself flags it as "cpfAluno duplicado".
+     *
+     * @param int $studentfk The student ID.
+     * @param int $year The school year.
+     * @param array $infoStudent Student information.
+     */
+    private function checkOtherModalityDuplicateEnrollment($studentfk, $year, $infoStudent)
+    {
+        $knownModalities = [1, 2, 3];
+        $acceptedStatus = $this->getAcceptedEnrollmentStatus();
+        $strAcceptedStatus = implode(',', $acceptedStatus);
+
+        $sql = "SELECT c.modality, se.classroom_fk, se.school_inep_id_fk
+        FROM student_enrollment se
+        JOIN classroom c ON se.classroom_fk = c.id
+        WHERE se.student_fk = :student_fk
+        AND (se.status in ($strAcceptedStatus) or se.status is null)
+        AND c.school_year = :year
+        AND c.complementary_activity = 0
+        AND c.aee = 0";
+
+        $command = Yii::app()->db->createCommand($sql);
+        $command->bindParam(':student_fk', $studentfk);
+        $command->bindParam(':year', $year);
+        $regularEnrollments = $command->queryAll();
+
+        if (count($regularEnrollments) <= 1) {
+            return;
+        }
+
+        $hasOtherModality = false;
+        foreach ($regularEnrollments as $enrollment) {
+            if (!in_array((int) $enrollment['modality'], $knownModalities, true)) {
+                $hasOtherModality = true;
+                break;
+            }
+        }
+
+        if (!$hasOtherModality) {
+            return;
+        }
+
+        $studentData = $this->getStudentDataById($studentfk);
+        $lastEnrollment = end($regularEnrollments);
+
+        $inconsistencyModel = new ValidationSagresModel();
+        $inconsistencyModel->enrollment = '<strong>ALUNO</strong>';
+        $inconsistencyModel->school = $studentData['name'];
+        $inconsistencyModel->identifier = '9';
+        $inconsistencyModel->idStudent = $studentfk;
+        $inconsistencyModel->idClass = $lastEnrollment['classroom_fk'];
+        $inconsistencyModel->idSchool = $lastEnrollment['school_inep_id_fk'];
+        $inconsistencyModel->description = 'CPF <strong>' . $studentData['cpf'] . '</strong> do aluno <strong>' . $infoStudent['name'] . '</strong> duplicado';
+        $inconsistencyModel->action = 'Remova a matrícula do aluno de uma das turmas';
+        $inconsistencyModel->save();
     }
 
     /**
@@ -757,7 +822,7 @@ class SagresConsultModel
             }
 
             $multiserie = $this->isMulti($classId);
-            $serie = $this->getSeries2025($classId, $multiserie);
+            $serie = $this->getSeries2025($classId, $multiserie, $turma['classroomName']);
 
             $classType
                 ->setPeriodo($turma['period']) //0 - Anual
@@ -966,9 +1031,10 @@ class SagresConsultModel
      *
      * @param int $classId The class ID.
      * @param bool $isMulti Whether the class is multi-grade.
+     * @param string|null $className The class name, used for inconsistency messages.
      * @return SerieTType[]
      */
-    private function getSeries2025($classId, $isMulti)
+    private function getSeries2025($classId, $isMulti, $className = null)
     {
         $seriesList = [];
 
@@ -976,7 +1042,7 @@ class SagresConsultModel
         $series = Yii::app()->db->createCommand($query)->bindValue(':id', $classId)->queryAll();
 
         $seriesList = $this->seriesAssembly($series, $classId, $isMulti);
-        $this->seriesNumberValidation($series, $classId);
+        $this->seriesNumberValidation($series, $classId, $isMulti, $className);
 
         return $seriesList;
     }
@@ -1190,15 +1256,20 @@ class SagresConsultModel
     }
 
     /**
-     * Validates the number of series in a multi-grade class (limit: 3).
+     * Validates the number of series in a multi-grade class (limit: 3, minimum: 2).
      *
      * @param array $series The series found.
      * @param int $idClass The class ID.
+     * @param bool $isMulti Whether the class is flagged as multi-grade (multiseriada).
+     * @param string|null $className The class name, used for inconsistency messages.
      */
-    private function seriesNumberValidation($series, $idClass): void
+    private function seriesNumberValidation($series, $idClass, $isMulti = false, $className = null): void
     {
         $maxNumber = 3;
+        $minMultiNumber = 2;
         $schoolName = $this->schoolName;
+        $inepId = $this->inepId;
+
         if (count($series) > $maxNumber) {
             $inconsistencyModel = new ValidationSagresModel();
             $inconsistencyModel->enrollment = TURMA_STRONG;
@@ -1208,6 +1279,19 @@ class SagresConsultModel
             $inconsistencyModel->identifier = '13';
 
             $inconsistencyModel->idClass = $idClass;
+            $inconsistencyModel->insert();
+        }
+
+        if ($isMulti && count($series) < $minMultiNumber) {
+            $inconsistencyModel = new ValidationSagresModel();
+            $inconsistencyModel->enrollment = TURMA_STRONG;
+            $inconsistencyModel->school = $schoolName;
+            $inconsistencyModel->description = 'A turma <strong>' . $className . '</strong> está marcada como multiseriada, mas possui apenas uma etapa de ensino';
+            $inconsistencyModel->action = 'Desmarque a turma como multiseriada ou adicione alunos de outra etapa de ensino: ' . $className;
+            $inconsistencyModel->identifier = '13';
+
+            $inconsistencyModel->idClass = $idClass;
+            $inconsistencyModel->idSchool = $inepId;
             $inconsistencyModel->insert();
         }
     }

--- a/config.php
+++ b/config.php
@@ -8,7 +8,7 @@ defined('YII_DEBUG') or define('YII_DEBUG', $debug ?? false);
 // Sessão (1h por padrão)
 defined('SESSION_MAX_LIFETIME') or define('SESSION_MAX_LIFETIME', 3600);
 
-define("TAG_VERSION", '3.13.27');
+define("TAG_VERSION", '3.13.28');
 
 $buildConfig = require __DIR__ . '/app/config/build.php';
 defined('TAG_BUILD_COMMIT') or define('TAG_BUILD_COMMIT', isset($buildConfig['commit']) ? (string) $buildConfig['commit'] : '');


### PR DESCRIPTION
Turma marcada como multiseriada com apenas uma etapa de ensino e CPF de aluno com matrícula duplicada em turmas de Educação Infantil/EJA (modalidades fora do conjunto historicamente verificado) passavam sem alerta no TAG, mas eram rejeitados pelo Validador SAGRES do TCE.

## 🚀 Motivação
_Descreva o problema que será resolvido e como a solução foi implementada._

## 🔧 Alterações Realizadas
_Descreva em alto nível as principais mudanças feitas no código._  

## 📌 Requisitos
_Descreva alterações ou configurações que devem ser feitas antes de testar a funcionalidade._  

## 🛠️ Fluxo de Teste

🧪 Fluxo de Teste 1 (FT1):
```
1. ...  
2. ...  
3. ...
```
✅ Sucesso: 
❌ Falha: 

## ✨ Migrations Utilizadas

## ✔️ Checklist - Padrões para PR
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?

### Documentação 
Houve alteração nos fluxo de uso? 
*(Lembrete: Em caso afirmativo, adicionar label Atualização de manual)*
- [ ] Sim   
- [ ] Não
