### PR TITLE
Feat/tcda 1248

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.14.23]
+- Ajustes no MACETE (TCDA-1248): a Contextualização do território deixou de ser um campo do Plano de Aula e passou a ser um campo opcional fixo da própria escola, exibido no formulário de escola apenas quando o MACETE está habilitado para o município e mostrado como referência no resumo do plano, logo abaixo do nome da escola; a Contextualização por etapa foi mantida como estava. O quadrante "Jogo Pedagógico" do item Complementar passou a se chamar "Material pedagógico". Na tela de Registrar Aula MACETE, os campos de registro foram unificados em uma única caixa de texto, renomeada de "Conteúdo executado" para "Anotações de Aula"
+
 ## [Versão 3.14.21]
 - Adicionado o módulo MACETE ao Diário Eletrônico para criação de planos e registros de aula vinculados a etapas, componentes curriculares e habilidades BNCC
 - Os textos pedagógicos dos planos e registros agora possuem editor rico Quill com formatação segura

--- a/app/migrations/3.14.23/add_school_territory_context.sql
+++ b/app/migrations/3.14.23/add_school_territory_context.sql
@@ -1,0 +1,28 @@
+-- =============================================================================
+-- TAG Migration v3.14.23 - Contextualização por território na Escola (TCDA-1248)
+-- =============================================================================
+-- A contextualização por território deixa de ser um campo do Plano de Aula
+-- MACETE e passa a ser um campo opcional fixo vinculado à própria escola,
+-- funcionando como um "subtítulo" do nome da escola. O campo só é exibido no
+-- formulário de escola quando a feature do MACETE (Plano de Aula ou Aulas
+-- Ministradas) está habilitada para o município.
+-- Idempotente: seguro rodar em instalações onde a coluna já existe.
+
+SET @school_territory_context_exists := (
+    SELECT COUNT(*)
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'school_identification'
+        AND COLUMN_NAME = 'territory_context'
+);
+SET @school_territory_context_sql := IF(
+    @school_territory_context_exists = 0,
+    'ALTER TABLE `school_identification` ADD COLUMN `territory_context` TEXT NULL AFTER `name`',
+    'SELECT 1'
+);
+PREPARE school_territory_context_statement FROM @school_territory_context_sql;
+EXECUTE school_territory_context_statement;
+-- No DEALLOCATE PREPARE: MySQL releases it automatically when the session ends,
+-- and explicitly deallocating here fails with "Unknown prepared statement handler"
+-- on tools/pools that don't guarantee PREPARE and this statement run on the same
+-- connection (observed when running this script manually against production).

--- a/app/models/SchoolIdentification.php
+++ b/app/models/SchoolIdentification.php
@@ -14,6 +14,7 @@
  * @property string $initial_date
  * @property string $final_date
  * @property string $name
+ * @property string $territory_context
  * @property string $latitude
  * @property string $longitude
  * @property string $cep
@@ -115,8 +116,8 @@ class SchoolIdentification extends AltActiveRecord
             ['phone_number, other_phone_number', 'length', 'max' => 9],
             ['edcenso_regional_education_organ_fk', 'length', 'max' => 5],
             ['private_school_maintainer_cnpj, private_school_cnpj, ies_code', 'length', 'max' => 14],
-            ['logo_file_content, act_of_acknowledgement', 'safe'],
-            ['register_type, inep_id, manager_cpf, number_ato, manager_name, manager_role, manager_email, situation, initial_date, final_date, name, latitude, longitude, cep, address, address_number, address_complement, address_neighborhood, edcenso_uf_fk, edcenso_city_fk, edcenso_district_fk, ddd, phone_number, public_phone_number, other_phone_number, fax_number, email, edcenso_regional_education_organ_fk, administrative_dependence, location, private_school_category, public_contract, private_school_business_or_individual, private_school_syndicate_or_association, private_school_ong_or_oscip, private_school_non_profit_institutions, private_school_s_system, private_school_maintainer_cnpj, private_school_cnpj, offer_or_linked_unity, inep_head_school, ies_code, regulation, logo_file_name, logo_file_type, logo_file_content, act_of_acknowledgement', 'safe', 'on' => 'search'],
+            ['logo_file_content, act_of_acknowledgement, territory_context', 'safe'],
+            ['register_type, inep_id, manager_cpf, number_ato, manager_name, manager_role, manager_email, situation, initial_date, final_date, name, territory_context, latitude, longitude, cep, address, address_number, address_complement, address_neighborhood, edcenso_uf_fk, edcenso_city_fk, edcenso_district_fk, ddd, phone_number, public_phone_number, other_phone_number, fax_number, email, edcenso_regional_education_organ_fk, administrative_dependence, location, private_school_category, public_contract, private_school_business_or_individual, private_school_syndicate_or_association, private_school_ong_or_oscip, private_school_non_profit_institutions, private_school_s_system, private_school_maintainer_cnpj, private_school_cnpj, offer_or_linked_unity, inep_head_school, ies_code, regulation, logo_file_name, logo_file_type, logo_file_content, act_of_acknowledgement', 'safe', 'on' => 'search'],
         ];
     }
 
@@ -159,6 +160,7 @@ class SchoolIdentification extends AltActiveRecord
             'initial_date' => Yii::t('default', 'Initial Date'),
             'final_date' => Yii::t('default', 'Final Date'),
             'name' => Yii::t('default', 'Name'),
+            'territory_context' => 'Contextualização do território',
             'latitude' => Yii::t('default', 'Latitude'),
             'longitude' => Yii::t('default', 'Longitude'),
             'cep' => Yii::t('default', 'Cep'),

--- a/app/modules/macete/controllers/LessonsplanController.php
+++ b/app/modules/macete/controllers/LessonsplanController.php
@@ -196,6 +196,7 @@ class LessonsplanController extends Controller
             'materialValues' => $this->lessonPlanService()->getMaterialValues($lessonPlan),
             'selectedAbilities' => $this->abilityService()->getByIds($abilityIds),
             'schoolName' => $school !== null ? (string) $school->name : '',
+            'territoryContext' => $school !== null ? (string) $school->territory_context : '',
             'professorName' => $loginInfos !== null ? (string) $loginInfos->name : '',
         ];
     }

--- a/app/modules/macete/controllers/LessonsplanController.php
+++ b/app/modules/macete/controllers/LessonsplanController.php
@@ -146,6 +146,7 @@ class LessonsplanController extends Controller
     {
         $this->accessService()->requireLessonPlanFeature();
         $lessonPlan = $this->loadModel($id);
+        $abilityIds = $this->lessonPlanService()->getAbilityIds($lessonPlan);
 
         echo CJSON::encode([
             'id' => (int) $lessonPlan->id,
@@ -155,6 +156,7 @@ class LessonsplanController extends Controller
             'discipline' => $lessonPlan->getDisciplineNames(),
             'classroom' => $lessonPlan->classroomFk !== null ? $lessonPlan->classroomFk->name : '',
             'abilities' => $lessonPlan->getAbilityCodes(),
+            'abilityList' => $this->abilityService()->getByIds($abilityIds),
         ]);
         Yii::app()->end();
     }

--- a/app/modules/macete/controllers/LessonsrecordController.php
+++ b/app/modules/macete/controllers/LessonsrecordController.php
@@ -130,11 +130,14 @@ class LessonsrecordController extends Controller
             }
         }
 
+        $school = SchoolIdentification::model()->findByPk(Yii::app()->user->school);
+
         return [
             'lessonRecord' => $lessonRecord,
             'plans' => $this->lessonRecordService()->getPlans(),
             'classrooms' => $this->lessonPlanService()->getClassrooms(),
             'selectedAbilities' => $this->abilityService()->getByIds($abilityIds),
+            'territoryContext' => $school !== null ? (string) $school->territory_context : '',
         ];
     }
 

--- a/app/modules/macete/models/MaceteLessonMaterial.php
+++ b/app/modules/macete/models/MaceteLessonMaterial.php
@@ -65,7 +65,7 @@ class MaceteLessonMaterial extends TagModel
     {
         return [
             self::TYPE_ACTIVITY_SHEET => 'Ficha de atividade',
-            self::TYPE_GAME => 'Jogo pedagógico',
+            self::TYPE_GAME => 'Material pedagógico',
             self::TYPE_SUPPORT_MATERIAL => 'Material de apoio',
         ];
     }

--- a/app/modules/macete/models/MaceteLessonPlan.php
+++ b/app/modules/macete/models/MaceteLessonPlan.php
@@ -84,7 +84,7 @@ class MaceteLessonPlan extends TagModel
     {
         return [
             'id' => 'ID',
-            'name' => 'Título do Plano',
+            'name' => 'Tema da aula',
             'code' => 'Código do plano',
             'theme' => 'Tema da aula',
             'school_inep_fk' => 'Escola',

--- a/app/modules/macete/models/MaceteLessonRecord.php
+++ b/app/modules/macete/models/MaceteLessonRecord.php
@@ -62,7 +62,7 @@ class MaceteLessonRecord extends TagModel
             'edcenso_discipline_fk' => 'Componente curricular',
             'users_fk' => 'Professor',
             'lesson_date' => 'Data da aula',
-            'executed_content' => 'Conteúdo executado',
+            'executed_content' => 'Anotações de Aula',
             'methodology_notes' => 'Aplicação da metodologia',
             'evaluation_notes' => 'Evidências/observações',
             'adaptation_notes' => 'Adaptações realizadas',

--- a/app/modules/macete/resources/lesson-record.js
+++ b/app/modules/macete/resources/lesson-record.js
@@ -1,7 +1,20 @@
 (function ($) {
-    function updatePlanSummary(planId) {
+    // O campo "Turma" do resumo reflete a turma escolhida aqui no próprio
+    // registro (classroom_fk do registro), não a turma do plano MACETE
+    // selecionado — o plano pode nem ter turma vinculada.
+    function updateClassroomSummary() {
+        var data = $(".js-macete-record-classroom").select2("data");
+        $(".js-macete-plan-summary [data-summary-field='classroom']").text(data ? data.text : "");
+    }
+
+    // syncAbilities só deve ser true quando o professor troca o plano à
+    // mão: no carregamento inicial da edição de um registro já existente,
+    // as habilidades marcadas são as do próprio registro (podem já ter
+    // sido ajustadas pelo professor) e não devem ser substituídas pelas
+    // do plano só porque a tela abriu com um plano pré-selecionado.
+    function updatePlanSummary(planId, syncAbilities) {
         if (!planId) {
-            $(".js-macete-plan-summary [data-summary-field]").text("");
+            $(".js-macete-plan-summary [data-summary-field]").not("[data-summary-field='classroom']").text("");
             return;
         }
 
@@ -13,14 +26,22 @@
             $(".js-macete-plan-summary [data-summary-field='theme']").text(data.theme || "");
             $(".js-macete-plan-summary [data-summary-field='stage']").text(data.stage || "");
             $(".js-macete-plan-summary [data-summary-field='discipline']").text(data.discipline || "");
-            $(".js-macete-plan-summary [data-summary-field='classroom']").text(data.classroom || "");
             $(".js-macete-plan-summary [data-summary-field='abilities']").text(data.abilities || "");
+
+            if (syncAbilities) {
+                $(".js-macete-abilities-selected").empty();
+                (data.abilityList || []).forEach(function (ability) {
+                    window.Macete.addAbility(ability);
+                });
+            }
         });
     }
 
     $(document).on("change", ".js-macete-plan-select", function () {
-        updatePlanSummary($(this).val());
+        updatePlanSummary($(this).val(), true);
     });
+
+    $(document).on("change", ".js-macete-record-classroom", updateClassroomSummary);
 
     $(document).ready(function () {
         if (typeof $(".js-macete-date").mask === "function") {
@@ -29,8 +50,10 @@
 
         var selectedPlan = $(".js-macete-plan-select").val();
         if (selectedPlan) {
-            updatePlanSummary(selectedPlan);
+            updatePlanSummary(selectedPlan, false);
         }
+
+        updateClassroomSummary();
     });
 })(jQuery);
 

--- a/app/modules/macete/services/MaceteLessonPlanService.php
+++ b/app/modules/macete/services/MaceteLessonPlanService.php
@@ -24,6 +24,11 @@ class MaceteLessonPlanService
             }
 
             $lessonPlan->attributes = $this->editablePlanData($planData);
+            // O campo "theme" não é mais preenchido pelo usuário (a tela
+            // de metodologia removeu o campo duplicado "Tema da aula"),
+            // mas continua existindo para não quebrar telas/relatórios
+            // que já dependem dele, então espelha sempre o valor de "name".
+            $lessonPlan->theme = $lessonPlan->name;
             $lessonPlan->edcenso_stage_vs_modality_fk = $stageComponents[0]['stage_id'];
             $lessonPlan->edcenso_discipline_fk = $stageComponents[0]['discipline_id'];
 
@@ -267,7 +272,6 @@ class MaceteLessonPlanService
         $allowedAttributes = [
             'name',
             'code',
-            'theme',
             'classroom_fk',
             'unit',
             'territory_context',

--- a/app/modules/macete/views/lessonsplan/_form.php
+++ b/app/modules/macete/views/lessonsplan/_form.php
@@ -10,6 +10,7 @@
  *  @var $materialValues array
  *  @var $selectedAbilities CourseClassAbilities[]
  *  @var $schoolName string
+ *  @var $territoryContext string
  *  @var $professorName string
  */
 
@@ -159,20 +160,20 @@ $selectedAbilitiesCount = count($selectedAbilities);
                     <div class="row">
                         <div class="column">
                             <div class="t-field-select macete-stage-repeater">
-                                <label class="t-field-select__label--required">Etapas e componentes curriculares</label>
+                                <label class="t-field-select__label--required">Anos/Séries e componentes curriculares</label>
                                 <div class="js-macete-stage-components">
                                     <?php foreach ($stageComponents as $index => $stageComponent): ?>
                                         <div class="row align-items--end js-macete-stage-component-row">
                                             <div class="column is-two-fifths clearleft">
                                                 <div class="t-field-select">
-                                                    <label class="t-field-select__label">Etapa</label>
+                                                    <label class="t-field-select__label">Ano/Série</label>
                                                     <?php echo CHtml::dropDownList(
                                     'stage_components[' . $index . '][stage_id]',
                                     $stageComponent['stage_id'],
                                     CHtml::listData($stages, 'id', 'name'),
                                     [
                                         'class' => 'select-search-on t-field-select__input js-macete-stage-component-stage',
-                                        'prompt' => 'Selecione a etapa',
+                                        'prompt' => 'Selecione o Ano/Série',
                                     ]
                                 ); ?>
                                                 </div>
@@ -199,7 +200,7 @@ $selectedAbilitiesCount = count($selectedAbilities);
                                     <?php endforeach; ?>
                                 </div>
                                 <button type="button" class="t-button-secondary js-macete-add-stage-component">Adicionar
-                                    etapa</button>
+                                    Ano/Série</button>
                                 <?php echo $form->error($lessonPlan, 'edcenso_stage_vs_modality_fk'); ?>
                             </div>
                         </div>
@@ -207,8 +208,8 @@ $selectedAbilitiesCount = count($selectedAbilities);
 
                     <script type="text/template" id="macete-stage-component-template">
                         <div class="row align-items--end js-macete-stage-component-row">
-                            <div class="column is-two-fifths clearleft"><div class="t-field-select"><label class="t-field-select__label">Etapa</label><select class="select-search-on t-field-select__input js-macete-stage-component-stage" name="stage_components[__index__][stage_id]"><option value="">Selecione a etapa</option><?php foreach ($stages as $stage): ?><option value="<?php echo (int) $stage['id']; ?>"><?php echo CHtml::encode($stage['name']); ?></option><?php endforeach; ?></select></div></div>
-                            <div class="column is-two-fifths"><div class="t-field-select"><label class="t-field-select__label">Componente curricular</label><select class="select-search-on t-field-select__input js-macete-stage-component-discipline" name="stage_components[__index__][discipline_id]"><option value="">Selecione a etapa primeiro</option></select></div></div>
+                            <div class="column is-two-fifths clearleft"><div class="t-field-select"><label class="t-field-select__label">Ano/Série</label><select class="select-search-on t-field-select__input js-macete-stage-component-stage" name="stage_components[__index__][stage_id]"><option value="">Selecione o Ano/Série</option><?php foreach ($stages as $stage): ?><option value="<?php echo (int) $stage['id']; ?>"><?php echo CHtml::encode($stage['name']); ?></option><?php endforeach; ?></select></div></div>
+                            <div class="column is-two-fifths"><div class="t-field-select"><label class="t-field-select__label">Componente curricular</label><select class="select-search-on t-field-select__input js-macete-stage-component-discipline" name="stage_components[__index__][discipline_id]"><option value="">Selecione o Ano/Série primeiro</option></select></div></div>
                             <div class="column is-one-fifth"><button type="button" class="t-button-secondary js-macete-remove-stage-component">Remover</button></div>
                         </div>
                     </script>
@@ -247,15 +248,6 @@ $selectedAbilitiesCount = count($selectedAbilities);
                             </div>
                         </div>
                         <div class="column">
-                            <div class="t-field-tarea">
-                                <?php echo $form->labelEx($lessonPlan, 'territory_context', ['class' => 't-field-tarea__label']); ?>
-                                <?php echo $form->textArea($lessonPlan, 'territory_context', [
-                                    'class' => 't-field-tarea__input',
-                                    'rows' => 4,
-                                    'placeholder' => 'Contextualize a escola, comunidade e território.',
-                                ]); ?>
-                                <?php echo $form->error($lessonPlan, 'territory_context'); ?>
-                            </div>
                         </div>
                     </div>
 
@@ -299,7 +291,7 @@ $selectedAbilitiesCount = count($selectedAbilities);
                                 <div class="macete-phase-card__body">
                                     <div
                                         class="js-macete-stage-empty <?php echo empty($selectedStageIds) ? '' : 'hide'; ?>">
-                                        Selecione etapas na aba Identificação.
+                                        Selecione Anos/Séries na aba Identificação.
                                     </div>
                                     <?php foreach ($stages as $stage): ?>
                                         <?php
@@ -326,12 +318,12 @@ $selectedAbilitiesCount = count($selectedAbilities);
                         <?php endforeach; ?>
                     </div>
                     <div class="column">
-                        <h3>Contextualização por etapa</h3>
+                        <h3>Contextualização por Ano/Série</h3>
                     </div>
                     <div class="row">
                         <div
                             class="column is-full js-macete-stage-empty <?php echo empty($selectedStageIds) ? '' : 'hide'; ?>">
-                            <p>Selecione etapas na aba Identificação para preencher os textos por etapa.</p>
+                            <p>Selecione Anos/Séries na aba Identificação para preencher os textos por Ano/Série.</p>
                         </div>
                     </div>
                     <?php foreach ($stages as $stage): ?>
@@ -556,13 +548,17 @@ $selectedAbilitiesCount = count($selectedAbilities);
                         <p><b>Escola:</b> <?php echo CHtml::encode($schoolName); ?></p>
                     <?php endif; ?>
 
+                    <?php if ($territoryContext !== ''): ?>
+                        <p><b>Contextualização do território:</b> <?php echo nl2br(CHtml::encode($territoryContext)); ?></p>
+                    <?php endif; ?>
+
                     <?php if ($professorName !== ''): ?>
                         <p><b>Professor(a):</b> <?php echo CHtml::encode($professorName); ?></p>
                     <?php endif; ?>
 
                     <p><b>Componente curricular:</b> <span class="js-macete-summary-discipline">—</span></p>
 
-                    <p><b>Etapa / Ano:</b> <span class="js-macete-summary-stage">—</span></p>
+                    <p><b>Ano/Série:</b> <span class="js-macete-summary-stage">—</span></p>
 
                     <p><b>Unidade:</b> <span class="js-macete-summary-unit">—</span></p>
 

--- a/app/modules/macete/views/lessonsplan/_form.php
+++ b/app/modules/macete/views/lessonsplan/_form.php
@@ -219,22 +219,6 @@ $selectedAbilitiesCount = count($selectedAbilities);
                 <!-- Tab 2: Metodologia -->
                 <div id="macete-methodology" class="js-macete-tab-panel hide">
 
-                    <div class="row align-items--start">
-                        <div class="column">
-                            <div class="t-field-text">
-                                <?php echo $form->label($lessonPlan, 'theme', ['class' => 't-field-text__label--required']); ?>
-                                <?php echo $form->textField($lessonPlan, 'theme', [
-                                    'class' => 't-field-text__input',
-                                    'maxlength' => 255,
-                                    'placeholder' => 'Tema da aula',
-                                ]); ?>
-                                <?php echo $form->error($lessonPlan, 'theme'); ?>
-                            </div>
-                        </div>
-                        <div class="column">
-                        </div>
-                    </div>
-
                     <div class="row">
                         <div class="column">
                             <div class="t-field-tarea">

--- a/app/modules/macete/views/lessonsplan/create.php
+++ b/app/modules/macete/views/lessonsplan/create.php
@@ -14,5 +14,6 @@ echo $this->renderPartial('_form', [
     'materialValues' => $materialValues,
     'selectedAbilities' => $selectedAbilities,
     'schoolName' => $schoolName,
+    'territoryContext' => $territoryContext,
     'professorName' => $professorName,
 ], true);

--- a/app/modules/macete/views/lessonsplan/update.php
+++ b/app/modules/macete/views/lessonsplan/update.php
@@ -14,5 +14,6 @@ echo $this->renderPartial('_form', [
     'materialValues' => $materialValues,
     'selectedAbilities' => $selectedAbilities,
     'schoolName' => $schoolName,
+    'territoryContext' => $territoryContext,
     'professorName' => $professorName,
 ], true);

--- a/app/modules/macete/views/lessonsrecord/_form.php
+++ b/app/modules/macete/views/lessonsrecord/_form.php
@@ -4,6 +4,7 @@
 /* @var $plans MaceteLessonPlan[] */
 /* @var $classrooms Classroom[] */
 /* @var $selectedAbilities CourseClassAbilities[] */
+/* @var $territoryContext string */
 
 $baseScriptUrl = Yii::app()->controller->module->baseScriptUrl;
 $themeUrl = Yii::app()->theme->baseUrl;
@@ -62,7 +63,7 @@ $selectedPlan = $lessonRecord->lessonPlanFk;
     'classroom_fk',
     CHtml::listData($classrooms, 'id', 'name'),
     [
-        'class' => 'select-search-on t-field-select__input',
+        'class' => 'select-search-on t-field-select__input js-macete-record-classroom',
         'prompt' => 'Selecione a turma',
     ]
 ); ?>
@@ -130,10 +131,11 @@ $selectedPlan = $lessonRecord->lessonPlanFk;
             <div class="t-cards js-macete-plan-summary">
                 <div class="t-cards-content">
                     <h2 class="t-cards-title">Plano selecionado</h2>
+                        <p><b>Contextualização do território:</b> <?php echo nl2br(CHtml::encode($territoryContext)); ?></p>
                     <p><b>Tema:</b> <span data-summary-field="theme"><?php echo $selectedPlan !== null ? CHtml::encode($selectedPlan->theme) : ''; ?></span></p>
                     <p><b>Ano/Série:</b> <span data-summary-field="stage"><?php echo $selectedPlan !== null && $selectedPlan->stageFk !== null ? CHtml::encode($selectedPlan->stageFk->name) : ''; ?></span></p>
                     <p><b>Componentes:</b> <span data-summary-field="discipline"><?php echo $selectedPlan !== null ? CHtml::encode($selectedPlan->getDisciplineNames()) : ''; ?></span></p>
-                    <p><b>Turma:</b> <span data-summary-field="classroom"><?php echo $selectedPlan !== null && $selectedPlan->classroomFk !== null ? CHtml::encode($selectedPlan->classroomFk->name) : ''; ?></span></p>
+                    <p><b>Turma:</b> <span data-summary-field="classroom"><?php echo $lessonRecord->classroomFk !== null ? CHtml::encode($lessonRecord->classroomFk->name) : ''; ?></span></p>
                     <p><b>Habilidades:</b> <span data-summary-field="abilities"><?php echo $selectedPlan !== null ? CHtml::encode($selectedPlan->getAbilityCodes()) : ''; ?></span></p>
                 </div>
             </div>

--- a/app/modules/macete/views/lessonsrecord/_form.php
+++ b/app/modules/macete/views/lessonsrecord/_form.php
@@ -96,25 +96,10 @@ $selectedPlan = $lessonRecord->lessonPlanFk;
                 </div>
 
                 <div class="row">
-                    <div class="column t-field-tarea  is-three-fifths">
+                    <div class="column t-field-tarea is-full">
                         <?php echo $form->label($lessonRecord, 'executed_content', ['class' => 't-field-tarea__label--required']); ?>
-                        <?php echo $form->textArea($lessonRecord, 'executed_content', ['class' => 't-field-tarea__input large', 'rows' => 5, 'placeholder' => 'Registre o conteúdo efetivamente trabalhado.']); ?>
+                        <?php echo $form->textArea($lessonRecord, 'executed_content', ['class' => 't-field-tarea__input large', 'rows' => 8, 'placeholder' => 'Registre o conteúdo efetivamente trabalhado.']); ?>
                         <?php echo $form->error($lessonRecord, 'executed_content'); ?>
-                    </div>
-                    <div class="column t-field-tarea  is-three-fifths">
-                        <?php echo $form->labelEx($lessonRecord, 'methodology_notes', ['class' => 't-field-tarea__label']); ?>
-                        <?php echo $form->textArea($lessonRecord, 'methodology_notes', ['class' => 't-field-tarea__input large', 'rows' => 5]); ?>
-                    </div>
-                </div>
-
-                <div class="row">
-                    <div class="column t-field-tarea  is-three-fifths">
-                        <?php echo $form->labelEx($lessonRecord, 'evaluation_notes', ['class' => 't-field-tarea__label']); ?>
-                        <?php echo $form->textArea($lessonRecord, 'evaluation_notes', ['class' => 't-field-tarea__input large', 'rows' => 5]); ?>
-                    </div>
-                    <div class="column t-field-tarea  is-three-fifths">
-                        <?php echo $form->labelEx($lessonRecord, 'adaptation_notes', ['class' => 't-field-tarea__label']); ?>
-                        <?php echo $form->textArea($lessonRecord, 'adaptation_notes', ['class' => 't-field-tarea__input large', 'rows' => 5]); ?>
                     </div>
                 </div>
 
@@ -146,7 +131,7 @@ $selectedPlan = $lessonRecord->lessonPlanFk;
                 <div class="t-cards-content">
                     <h2 class="t-cards-title">Plano selecionado</h2>
                     <p><b>Tema:</b> <span data-summary-field="theme"><?php echo $selectedPlan !== null ? CHtml::encode($selectedPlan->theme) : ''; ?></span></p>
-                    <p><b>Etapa:</b> <span data-summary-field="stage"><?php echo $selectedPlan !== null && $selectedPlan->stageFk !== null ? CHtml::encode($selectedPlan->stageFk->name) : ''; ?></span></p>
+                    <p><b>Ano/Série:</b> <span data-summary-field="stage"><?php echo $selectedPlan !== null && $selectedPlan->stageFk !== null ? CHtml::encode($selectedPlan->stageFk->name) : ''; ?></span></p>
                     <p><b>Componentes:</b> <span data-summary-field="discipline"><?php echo $selectedPlan !== null ? CHtml::encode($selectedPlan->getDisciplineNames()) : ''; ?></span></p>
                     <p><b>Turma:</b> <span data-summary-field="classroom"><?php echo $selectedPlan !== null && $selectedPlan->classroomFk !== null ? CHtml::encode($selectedPlan->classroomFk->name) : ''; ?></span></p>
                     <p><b>Habilidades:</b> <span data-summary-field="abilities"><?php echo $selectedPlan !== null ? CHtml::encode($selectedPlan->getAbilityCodes()) : ''; ?></span></p>

--- a/app/modules/macete/views/lessonsrecord/create.php
+++ b/app/modules/macete/views/lessonsrecord/create.php
@@ -8,5 +8,6 @@ echo $this->renderPartial('_form', [
     'plans' => $plans,
     'classrooms' => $classrooms,
     'selectedAbilities' => $selectedAbilities,
+    'territoryContext' => $territoryContext,
 ], true);
 

--- a/app/modules/macete/views/lessonsrecord/update.php
+++ b/app/modules/macete/views/lessonsrecord/update.php
@@ -8,5 +8,6 @@ echo $this->renderPartial('_form', [
     'plans' => $plans,
     'classrooms' => $classrooms,
     'selectedAbilities' => $selectedAbilities,
+    'territoryContext' => $territoryContext,
 ], true);
 

--- a/app/modules/school/views/school/_form.php
+++ b/app/modules/school/views/school/_form.php
@@ -183,6 +183,33 @@ $form = $this->beginWidget('CActiveForm', [
                             </div>
                         </div>
                     </div>
+                    <?php if (Yii::app()->features->isEnable(TFeature::FEAT_DIARY_LESSON_PLAN) || Yii::app()->features->isEnable(TFeature::FEAT_DIARY_CLASSES)): ?>
+                        <div class="row">
+                            <div class="column is-two-fifths clearleft">
+                                <div class="t-field-tarea">
+                                    <?php echo $form->label(
+                                        $modelSchoolIdentification,
+                                        'territory_context',
+                                        ['class' => 't-field-tarea__label']
+                                    ); ?>
+                                    <?php echo $form->textArea(
+                                        $modelSchoolIdentification,
+                                        'territory_context',
+                                        [
+                                            'rows' => 3,
+                                            'placeholder' => 'Contextualize a escola, comunidade e território.',
+                                            'class' => 't-field-tarea__input',
+                                            'disabled' => $disabledFields
+                                        ]
+                                    ); ?>
+                                    <?php echo $form->error(
+                                        $modelSchoolIdentification,
+                                        'territory_context'
+                                    ); ?>
+                                </div>
+                            </div>
+                        </div>
+                    <?php endif; ?>
                     <div class="row">
                         <div class="column is-two-fifths clearleft">
                             <div class="t-field-select">

--- a/config.php
+++ b/config.php
@@ -8,7 +8,7 @@ defined('YII_DEBUG') or define('YII_DEBUG', $debug ?? false);
 // Sessão (1h por padrão)
 defined('SESSION_MAX_LIFETIME') or define('SESSION_MAX_LIFETIME', 3600);
 
-define("TAG_VERSION", '3.14.23');
+define("TAG_VERSION", '3.14.24');
 
 $buildConfig = require __DIR__ . '/app/config/build.php';
 defined('TAG_BUILD_COMMIT') or define('TAG_BUILD_COMMIT', isset($buildConfig['commit']) ? (string) $buildConfig['commit'] : '');

--- a/config.php
+++ b/config.php
@@ -8,7 +8,7 @@ defined('YII_DEBUG') or define('YII_DEBUG', $debug ?? false);
 // Sessão (1h por padrão)
 defined('SESSION_MAX_LIFETIME') or define('SESSION_MAX_LIFETIME', 3600);
 
-define("TAG_VERSION", '3.14.21');
+define("TAG_VERSION", '3.14.23');
 
 $buildConfig = require __DIR__ . '/app/config/build.php';
 defined('TAG_BUILD_COMMIT') or define('TAG_BUILD_COMMIT', isset($buildConfig['commit']) ? (string) $buildConfig['commit'] : '');


### PR DESCRIPTION
## 🚀 Motivação

Foram solicitados ajustes na forma como as informações de contextualização são apresentadas no MACETE. A contextualização por território estava cadastrada como um campo do Plano de Aula, repetido a cada novo plano, quando na prática é uma informação fixa da própria escola (uma espécie de "subtítulo" do nome dela) e deveria aparecer como referência, não como campo a ser preenchido em cada plano. Também foi pedido renomear o quadrante "Jogo Pedagógico" para "Material pedagógico", simplificar o Registro de Aula (que tinha campos demais para uma anotação simples do que foi trabalhado em sala) e eliminar a duplicidade do campo "Tema da aula", que aparecia duas vezes no formulário do plano.

## 🔧 Alterações Realizadas

- A Contextualização do território deixou de ser um campo do Plano de Aula e passou a ser um campo opcional (territory_context) vinculado à própria escola (school_identification), exibido no formulário de Escola apenas quando o MACETE (Plano de Aula ou Aulas Ministradas) está habilitado para o município
- Essa contextualização agora aparece como referência fixa no card "Resumo do plano" do Plano de Aula e no card "Plano selecionado" do Registro de Aula
- A Contextualização por etapa foi mantida como estava, já que faz parte da metodologia do MACETE
- O quadrante "Jogo Pedagógico" do item 3 (Complementar) passou a se chamar "Material pedagógico"
- Removido o campo "Tema da aula" duplicado que aparecia na aba Metodologia; existe agora um único campo (na aba Identificação), que preenche automaticamente o campo interno theme usado por listagens e relatórios já existentes
- Na tela "Registrar Aula MACETE", os campos "Aplicação da metodologia", "Evidências/observações" e "Adaptações realizadas" foram removidos, restando um único campo de registro, renomeado de "Conteúdo executado" para "Anotações de Aula"
- Corrigido o campo "Turma" do resumo do Registro de Aula, que não refletia a turma escolhida no próprio formulário (lia a turma do plano selecionado, que pode nem ter turma vinculada)
- Ao selecionar um Plano MACETE no Registro de Aula, as habilidades BNCC já definidas nesse plano agora são pré-carregadas na lista de habilidades do registro, evitando que o professor tenha que buscá-las de novo manualmente
- Migration adiciona a coluna territory_context (nullable) em school_identification, sem afetar dados existentes

## 📌 Requisitos
```app/migrations/3.14.23/add_school_territory_context.sql```

## 🛠️ Fluxo de Teste

🧪 Fluxo de Teste 1 (FT1):
```
1. ...  
2. ...  
3. ...
```
✅ Sucesso: 
❌ Falha: 

## ✨ Migrations Utilizadas

## ✔️ Checklist - Padrões para PR
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?

### Documentação 
Houve alteração nos fluxo de uso? 
*(Lembrete: Em caso afirmativo, adicionar label Atualização de manual)*
- [ ] Sim   
- [ ] Não
