### PR TITLE
fix: notas redondas exibidas sem casa decimal (TCDA-1127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Versão 3.13.30]
+- Corrigidas médias redondas exibidas sem casa decimal (TCDA-1127): na Ata de Notas, na Ficha de Notas (média final e notas por bimestre/unidade, incluindo recuperações) e na tela de Notas, uma nota redonda (ex.: 7) passou a ser exibida como "7.0"; valores que já têm casas decimais (ex.: 8.67) continuam exibidos exatamente como calculados, sem arredondamento
+
 ## [Versão 3.13.28]
 - Corrigidas duas inconsistências do validador do Sagres Edu que o Validador SAGRES do TCE detectava e o TAG deixava passar (TCDA-1246): turma marcada como multiseriada com apenas uma etapa de ensino agora gera inconsistência; CPF de aluno com matrícula ativa duplicada em turmas de Educação Infantil ou EJA (modalidades que não eram verificadas pela checagem de duplicidade) também passou a ser sinalizado
 

--- a/app/repository/FormsRepository.php
+++ b/app/repository/FormsRepository.php
@@ -280,7 +280,7 @@ class FormsRepository
 
                     array_push($result, [
                         'discipline_id' => $gradeResult->disciplineFk->id,
-                        'final_media' => $gradeResult->final_media,
+                        'final_media' => $this->formatGradeKeepingDecimals($gradeResult->final_media),
                         'grade_result' => $gradeResult,
                         'partial_recoveries' => $partialRecoveries,
                         'total_number_of_classes' => $totalContentsPerDiscipline,
@@ -1170,6 +1170,8 @@ class FormsRepository
                         if ($r['grade_concept_1'] != null && $r['grade_concept_1'] != '') {
                             $finalconcept = GradeConcept::model()->findByPk($r['final_concept']);
                             $finalMedia = $finalconcept ? $finalconcept->name : $this->checkConceptGradeRange($finalMedia, $concepts);
+                        } else {
+                            $finalMedia = $this->formatGradeKeepingDecimals($finalMedia);
                         }
                         $r['situation'] = mb_strtoupper($r['situation']);
                         if ($s->getCurrentStatus() == 'DEIXOU DE FREQUENTAR') {
@@ -1229,6 +1231,25 @@ class FormsRepository
             return $matchedConcept;
         }
         return $finalMedia;
+    }
+
+    /**
+     * Garante a casa decimal em médias redondas (ex.: 8 -> "8.0") sem
+     * arredondar valores que já têm casas decimais (ex.: 8.67 continua
+     * "8.67", não vira "8.7").
+     *
+     * @param mixed $value
+     * @return mixed
+     */
+    private function formatGradeKeepingDecimals($value)
+    {
+        if (!is_numeric($value)) {
+            return $value;
+        }
+
+        $number = (float) $value;
+
+        return $number == (int) $number ? number_format($number, 1) : $value;
     }
 
     /**

--- a/config.php
+++ b/config.php
@@ -8,7 +8,7 @@ defined('YII_DEBUG') or define('YII_DEBUG', $debug ?? false);
 // Sessão (1h por padrão)
 defined('SESSION_MAX_LIFETIME') or define('SESSION_MAX_LIFETIME', 3600);
 
-define("TAG_VERSION", '3.13.29');
+define("TAG_VERSION", '3.13.30');
 
 $buildConfig = require __DIR__ . '/app/config/build.php';
 defined('TAG_BUILD_COMMIT') or define('TAG_BUILD_COMMIT', isset($buildConfig['commit']) ? (string) $buildConfig['commit'] : '');

--- a/js/grades/functions.js
+++ b/js/grades/functions.js
@@ -275,7 +275,7 @@ function GradeTableBuilder(data) {
 
                 if (unity.grades.length > 1) {
                     const unityMedia = template`
-                <td>${unity.unityMedia ?? ""}</td>
+                <td>${formatMediaKeepingDecimals(unity.unityMedia)}</td>
                 `;
 
                     unityRow.push(unityMedia);
@@ -335,6 +335,17 @@ function GradeTableBuilder(data) {
             return "";
         }
         return result;
+    }
+
+    // Só garante o ".0" em números redondos (ex.: 10 -> "10.0"), sem
+    // arredondar valores que já têm casas decimais (ex.: 9.166... segue
+    // exibindo "9.17", como o backend calculou, em vez de virar "9.2").
+    function formatMediaKeepingDecimals(val) {
+        const num = parseFloat(val);
+        if (isNaN(num)) {
+            return "";
+        }
+        return Number.isInteger(num) ? num.toFixed(1) : String(num);
     }
 
     function build() {

--- a/themes/default/views/forms/EnrollmentGradesReport.php
+++ b/themes/default/views/forms/EnrollmentGradesReport.php
@@ -27,6 +27,19 @@ function calculateFrequence($numClasses, $numFalts): int
     return round((($aulasdadas - $faltas) * 100) / $aulasdadas);
 }
 
+// Garante a casa decimal em notas redondas (ex.: 7 -> "7.0") sem
+// arredondar valores que já têm casas decimais (ex.: 6.67 continua "6.67").
+function formatGradeKeepingDecimals($value)
+{
+    if (!is_numeric($value)) {
+        return $value;
+    }
+
+    $number = (float) $value;
+
+    return $number == (int) $number ? number_format($number, 1) : $value;
+}
+
 ?>
 
 <div class="row-fluid hidden-print">
@@ -153,7 +166,7 @@ function calculateFrequence($numClasses, $numFalts): int
                                 <?php if ($discipline["requires_exam"] === 0) { ?>
                                     <td style="text-align: center;"><?= $discipline["report_text"] ?></td>
                                 <?php } elseif ($unities[$i - 1]->type == 'RF') { ?>
-                                    <td style="text-align: center;"><?= $gradeResult['rec_final'] ?></td>
+                                    <td style="text-align: center;"><?= formatGradeKeepingDecimals($gradeResult['rec_final']) ?></td>
                                 <?php } elseif ($unities[$i - 1]->type == 'FC') {
                                     $finalConcept = GradeConcept::model()->findByPk($gradeResult['final_concept']);
                                     ?>
@@ -168,9 +181,9 @@ function calculateFrequence($numClasses, $numFalts): int
                                     in_array('grade_' . $i, $result[$j]["partial_recoveries"]["rec_partial_" . $i])
                                 ) {
                                     ?>
-                                    <td style="text-align: center;"><?= $gradeResult['rec_partial_' . $i] ?></td>
+                                    <td style="text-align: center;"><?= formatGradeKeepingDecimals($gradeResult['rec_partial_' . $i]) ?></td>
                                 <?php } else { ?>
-                                    <td style="text-align: center;"><?= $gradeResult['grade_' . $i] ?></td>
+                                    <td style="text-align: center;"><?= formatGradeKeepingDecimals($gradeResult['grade_' . $i]) ?></td>
                                 <?php } ?>
                             <?php } ?>
                             <?php if ($unities[$i - 1]->type != 'RF') { ?>


### PR DESCRIPTION
Uma nota redonda (ex.: 7) aparecia como "7" em vez de "7.0" em várias telas, enquanto valores com casas decimais (ex.: 8.67) exibiam corretamente. Adiciona uma formatação que só garante a casa decimal em números redondos, sem arredondar o que já tem mais precisão:

- Ata de Notas (FormsRepository::getAtaSchoolPerformance)
- Ficha de Notas: média final (FormsRepository::getEnrollmentGrades)
- Ficha de Notas: nota por bimestre/unidade, recuperação parcial e final (EnrollmentGradesReport.php)
- Tela de Notas: coluna Média da Unidade (js/grades/functions.js)

## 🚀 Motivação
Foi relatado que, na Ata de Notas, médias terminadas em número redondo apareciam sem a casa decimal (ex.: uma média 7.0 aparecia só como "7"), enquanto médias com casas decimais (ex.: 8.67) eram exibidas normalmente. Ao investigar, encontramos o mesmo problema em outras telas de notas do sistema: Ficha de Notas (tanto na média final quanto na nota lançada por bimestre/unidade) e na tela de lançamento de Notas, na coluna Média da Unidade.

## 🔧 Alterações Realizadas

- Adicionada uma formatação que só acrescenta a casa decimal quando o valor é um número redondo (ex.: 7 vira "7.0"), sem arredondar valores que já têm casas decimais (ex.: 8.67 continua exatamente "8.67", não vira "8.7")
- Aplicada na Ata de Notas (FormsRepository::getAtaSchoolPerformance)
- Aplicada na Ficha de Notas, na média final de cada disciplina (FormsRepository::getEnrollmentGrades)
- Aplicada na Ficha de Notas, nas notas por bimestre/unidade, recuperação parcial e recuperação final (EnrollmentGradesReport.php)
- Aplicada na tela de Notas, na coluna "Média da Unidade" (js/grades/functions.js)

## 📌 Requisitos
_Descreva alterações ou configurações que devem ser feitas antes de testar a funcionalidade._  

## 🛠️ Fluxo de Teste

🧪 Fluxo de Teste 1 (FT1):
```
1. ...  
2. ...  
3. ...
```
✅ Sucesso: 
❌ Falha: 

## ✨ Migrations Utilizadas

## ✔️ Checklist - Padrões para PR
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [ ] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?

### Documentação 
Houve alteração nos fluxo de uso? 
*(Lembrete: Em caso afirmativo, adicionar label Atualização de manual)*
- [ ] Sim   
- [ ] Não
